### PR TITLE
DO NOT MERGE : FR-748-amend case data

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/CaseMaintenanceController.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/CaseMaintenanceController.java
@@ -44,6 +44,7 @@ public class CaseMaintenanceController implements BaseController {
         updatePropertyDetails(caseData);
         updateRespondentSolicitorAddress(caseData);
         updateD81Details(caseData);
+        updatePensionDocuments(caseData);
         return ResponseEntity.ok(CCDCallbackResponse.builder().data(caseData).build());
     }
 
@@ -121,6 +122,25 @@ public class CaseMaintenanceController implements BaseController {
     private boolean hasNotSelected(List<String> natureOfApplication2, String option) {
         return nonNull(natureOfApplication2)
                 && !natureOfApplication2.contains(option);
+    }
+
+    private void updatePensionDocuments(CaseData caseData) {
+        List<String> natureOfApplication2 = caseData.getNatureOfApplication2();
+        if (isPensionOptionsRemoved(natureOfApplication2)) {
+            removePensionDocuments(caseData);
+        }
+
+    }
+
+    private boolean isPensionOptionsRemoved(List<String> natureOfApplication2) {
+        return hasNotSelected(natureOfApplication2, "Pension Sharing Order")
+                && hasNotSelected(natureOfApplication2, "Pension Attachment Order")
+                && hasNotSelected(natureOfApplication2, "Pension Compensation Sharing Order")
+                && hasNotSelected(natureOfApplication2, "Pension Compensation Attachment Order");
+    }
+
+    private void removePensionDocuments(CaseData caseData) {
+        caseData.setPensionCollection(null);
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/CaseMaintenanceControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/CaseMaintenanceControllerTest.java
@@ -171,4 +171,30 @@ public class CaseMaintenanceControllerTest extends BaseControllerTest {
                 .andExpect(jsonPath("$.data.rSolicitorEmail").doesNotExist())
                 .andExpect(jsonPath("$.data.rSolicitorPhone").doesNotExist());
     }
+
+    @Test
+    public void shouldDeletePensionDocumentsWhenPensionRelatedOptionsAreRemoved() throws Exception {
+        requestContent = objectMapper.readTree(new File(getClass()
+                .getResource("/fixtures/updatecase/remove-pension-documents.json").toURI()));
+        mvc.perform(post("/case-orchestration/update-case")
+                .content(requestContent.toString())
+                .header("Authorization", BEARER_TOKEN)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andExpect(jsonPath("$.data.pensionCollection").doesNotExist());
+    }
+
+    @Test
+    public void shouldNotDeletePensionDocumentsWhenPensionRelatedOptionsExists() throws Exception {
+        requestContent = objectMapper.readTree(new File(getClass()
+                .getResource("/fixtures/updatecase/do-not-remove-pension-documents.json").toURI()));
+        mvc.perform(post("/case-orchestration/update-case")
+                .content(requestContent.toString())
+                .header("Authorization", BEARER_TOKEN)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andExpect(jsonPath("$.data.pensionCollection").exists());
+    }
 }

--- a/src/test/resources/fixtures/updatecase/do-not-remove-pension-documents.json
+++ b/src/test/resources/fixtures/updatecase/do-not-remove-pension-documents.json
@@ -1,0 +1,283 @@
+{
+  "token": "test_token",
+  "event_id": "event1",
+  "case_details": {
+    "id" : "12345678",
+    "jurisdiction": "divorce",
+    "state": "created",
+    "case_data": {
+      "PBANumber": "PBA123456",
+      "d81Question": "No",
+      "PBAreference": "ABCD",
+      "consentOrder": {
+        "document_url": "http://file1",
+        "document_filename": "file1",
+        "document_binary_url": "http://file1.binary"
+      },
+      "d81Joint": {
+        "document_url": "http://file1",
+        "document_filename": "file1",
+        "document_binary_url": "http://file1.binary"
+      },
+      "d81Applicant": {
+        "document_url": "http://file1",
+        "document_filename": "file1",
+        "document_binary_url": "http://file1.binary"
+      },
+      "d81Respondent": {
+        "document_url": "http://file1",
+        "document_filename": "file1",
+        "document_binary_url": "http://file1.binary"
+      },
+      "solicitorFirm": "FirmA",
+      "solicitorName": "Solictor",
+      "applicantLName": "Guy",
+      "authorisation3": "2010-01-01",
+      "solicitorEmail": "test@admin.com",
+      "solicitorPhone": "1234",
+      "applicantFMName": "Poor",
+      "authorisation2b": "test",
+      "otherCollection": [
+        {
+          "id": "1",
+          "value": {
+            "typeOfDocument": "pdf",
+            "uploadedDocument": {
+              "document_url": "http://file1",
+              "document_filename": "file1",
+              "document_binary_url": "http://file1.binary"
+            }
+          }
+        }
+      ],
+      "respondentEmail": "test@test.com",
+      "respondentPhone": "9963472494",
+      "appRespondentRep": "No",
+      "consentOrderText": {
+        "document_url": "http://file1",
+        "document_filename": "file1",
+        "document_binary_url": "http://file1.binary"
+      },
+      "solicitorAddress": {
+        "County": "essex",
+        "Country": "UK",
+        "PostCode": "b1 1ab",
+        "PostTown": "london",
+        "AddressLine1": "line1",
+        "AddressLine2": "line2",
+        "AddressLine3": "line3"
+      },
+      "authorisationFirm": "test",
+      "authorisationName": "test",
+      "divorceCaseNumber": "DD12D12345",
+      "pensionCollection": [
+        {
+          "id": "1",
+          "value": {
+            "typeOfDocument": "pdf",
+            "uploadedDocument": {
+              "document_url": "http://file1",
+              "document_filename": "file1",
+              "document_binary_url": "http://file1.binary"
+            }
+          }
+        }
+      ],
+      "respondentAddress": {
+        "County": "essex",
+        "Country": "UK",
+        "PostCode": "b1 1ab",
+        "PostTown": "london",
+        "AddressLine1": "line1",
+        "AddressLine2": "line2",
+        "AddressLine3": "line3"
+      },
+      "solicitorDXnumber": "dx1",
+      "appRespondentLName": "smith",
+      "solicitorReference": "LL01",
+      "appRespondentFMName": "john",
+      "divorceStageReached": "Decree Nisi",
+      "helpWithFeesQuestion": "No",
+      "natureOfApplication2": [
+        "Pension Sharing Order",
+        "item2"
+      ],
+      "natureOfApplication5": "No",
+      "natureOfApplication6": [
+        "item1",
+        "item2"
+      ],
+      "natureOfApplication7": "test",
+      "natureOfApplication3a": "test",
+      "natureOfApplication3b": "test",
+      "divorceUploadEvidence1": {
+        "document_url": "http://file1",
+        "document_filename": "file1",
+        "document_binary_url": "http://file1.binary"
+      },
+      "divorceDecreeNisiDate": "2010-01-01",
+      "divorceUploadEvidence2": {
+        "document_url": "http://file2",
+        "document_filename": "file2",
+        "document_binary_url": "http://file2.binary"
+      },
+      "divorceDecreeAbsoluteDate": "2010-01-01",
+      "orderForChildrenQuestion1": "No",
+      "solicitorAgreeToReceiveEmails": "Yes",
+      "orderDirection": "test",
+      "orderDirectionOpt1": {
+        "document_url": "http://file1",
+        "document_filename": "file1",
+        "document_binary_url": "http://file1.binary"
+      },
+      "orderDirectionAbsolute": "test",
+      "orderDirectionJudge": "test",
+      "orderDirectionJudgeName": "test",
+      "orderDirectionDate": "2010-01-01",
+      "dueDate": "2010-01-01",
+      "issueDate": "2010-01-01",
+      "orderDirectionAddComments": "test",
+      "orderDirectionOpt2": "test",
+      "assignedToJudgeReason": "test",
+      "assignedToJudge": "judge1",
+      "referToJudgeDate": "2010-01-01",
+      "referToJudgeText": "test",
+      "referToJudgeDateFromAwaitingResponse": "2010-01-01",
+      "referToJudgeTextFromAwaitingResponse": "test",
+      "referToJudgeDateFromOrderMade": "2010-01-01",
+      "referToJudgeTextFromOrderMade": "test",
+      "referToJudgeDateFromConsOrdApproved": "2010-01-01",
+      "referToJudgeTextFromConsOrdApproved": "test",
+      "referToJudgeDateFromConsOrdMade": "2010-01-01",
+      "referToJudgeTextFromConsOrdMade": "test",
+      "referToJudgeDateFromClose": "2010-01-01",
+      "referToJudgeTextFromClose": "test",
+      "referToJudgeDateFromRespondToOrder": "2010-01-01",
+      "referToJudgeTextFromRespondToOrder": "test",
+      "orderRefusalCollection": [
+        {
+          "id": "1",
+          "value": {
+            "orderRefusal": [
+              "Other"
+            ],
+            "orderRefusalDate": "2003-02-01",
+            "orderRefusalDocs": {
+              "document_url": "http://doc1",
+              "document_filename": "doc1",
+              "document_binary_url": "http://doc1.binary"
+            },
+            "orderRefusalJudge": "District Judge",
+            "orderRefusalOther": "test1",
+            "otherHearingDetails": "test2",
+            "orderRefusalJudgeName": "test3",
+            "orderRefusalNotEnough": [
+              "reason1"
+            ],
+            "estimateLengthOfHearing": "10",
+            "orderRefusalAddComments": "comment1",
+            "orderRefusalNotEnoughOther": "test",
+            "whenShouldHearingTakePlace": "today",
+            "whereShouldHearingTakePlace": "EZ801"
+          }
+        }
+      ],
+      "uploadConsentOrderDocuments": [
+        {
+          "id": "1",
+          "value": {
+            "DocumentType": "pdf",
+            "DocumentLink": {
+              "document_url": "http://doc1",
+              "document_filename": "doc1",
+              "document_binary_url": "http://doc1.binary"
+            },
+            "DocumentEmailContent": "email-content",
+            "DocumentDateAdded": "2010-01-02",
+            "DocumentComment": "doc-comment",
+            "DocumentFileName": "file1"
+          }
+        }
+      ],
+      "uploadOrder": [
+        {
+          "id": "1",
+          "value": {
+            "DocumentType": "pdf",
+            "DocumentLink": {
+              "document_url": "http://doc1",
+              "document_filename": "doc1",
+              "document_binary_url": "http://doc1.binary"
+            },
+            "DocumentEmailContent": "email-content",
+            "DocumentDateAdded": "2010-01-02",
+            "DocumentComment": "doc-comment",
+            "DocumentFileName": "file1"
+          }
+        }
+      ],
+      "uploadDocuments": [
+        {
+          "id": "1",
+          "value": {
+            "DocumentType": "pdf",
+            "DocumentLink": {
+              "document_url": "http://doc1",
+              "document_filename": "doc1",
+              "document_binary_url": "http://doc1.binary"
+            },
+            "DocumentEmailContent": "email-content",
+            "DocumentDateAdded": "2010-01-02",
+            "DocumentComment": "doc-comment",
+            "DocumentFileName": "file1"
+          }
+        }
+      ],
+      "generalOrderCollection": [
+        {
+          "id": "1",
+          "value": {
+            "generalOrder_order": "order1",
+            "generalOrder_documentUpload": {
+              "document_url": "http://doc1",
+              "document_filename": "doc1",
+              "document_binary_url": "http://doc1.binary"
+            },
+            "generalOrder_judgeList": "district judge",
+            "generalOrder_judgeName": "judge1",
+            "generalOrder_dateOfOrder": "2010-01-02",
+            "generalOrder_comments": "comment1"
+          }
+        }
+      ],
+      "respondToOrderDocuments": [
+        {
+          "id": "1",
+          "value": {
+            "DocumentType": "pdf",
+            "DocumentLink": {
+              "document_url": "http://doc1",
+              "document_filename": "doc1",
+              "document_binary_url": "http://doc1.binary"
+            },
+            "DocumentDateAdded": "2010-01-02",
+            "DocumentFileName": "file1"
+          }
+        }
+      ],
+      "amendedConsentOrderCollection": [
+        {
+          "id": "1",
+          "value": {
+            "amendedConsentOrder": {
+              "document_url": "http://doc1",
+              "document_filename": "doc1",
+              "document_binary_url": "http://doc1.binary"
+            },
+            "amendedConsentOrderDate": "2010-01-02"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/test/resources/fixtures/updatecase/remove-pension-documents.json
+++ b/src/test/resources/fixtures/updatecase/remove-pension-documents.json
@@ -1,0 +1,283 @@
+{
+  "token": "test_token",
+  "event_id": "event1",
+  "case_details": {
+    "id" : "12345678",
+    "jurisdiction": "divorce",
+    "state": "created",
+    "case_data": {
+      "PBANumber": "PBA123456",
+      "d81Question": "No",
+      "PBAreference": "ABCD",
+      "consentOrder": {
+        "document_url": "http://file1",
+        "document_filename": "file1",
+        "document_binary_url": "http://file1.binary"
+      },
+      "d81Joint": {
+        "document_url": "http://file1",
+        "document_filename": "file1",
+        "document_binary_url": "http://file1.binary"
+      },
+      "d81Applicant": {
+        "document_url": "http://file1",
+        "document_filename": "file1",
+        "document_binary_url": "http://file1.binary"
+      },
+      "d81Respondent": {
+        "document_url": "http://file1",
+        "document_filename": "file1",
+        "document_binary_url": "http://file1.binary"
+      },
+      "solicitorFirm": "FirmA",
+      "solicitorName": "Solictor",
+      "applicantLName": "Guy",
+      "authorisation3": "2010-01-01",
+      "solicitorEmail": "test@admin.com",
+      "solicitorPhone": "1234",
+      "applicantFMName": "Poor",
+      "authorisation2b": "test",
+      "otherCollection": [
+        {
+          "id": "1",
+          "value": {
+            "typeOfDocument": "pdf",
+            "uploadedDocument": {
+              "document_url": "http://file1",
+              "document_filename": "file1",
+              "document_binary_url": "http://file1.binary"
+            }
+          }
+        }
+      ],
+      "respondentEmail": "test@test.com",
+      "respondentPhone": "9963472494",
+      "appRespondentRep": "No",
+      "consentOrderText": {
+        "document_url": "http://file1",
+        "document_filename": "file1",
+        "document_binary_url": "http://file1.binary"
+      },
+      "solicitorAddress": {
+        "County": "essex",
+        "Country": "UK",
+        "PostCode": "b1 1ab",
+        "PostTown": "london",
+        "AddressLine1": "line1",
+        "AddressLine2": "line2",
+        "AddressLine3": "line3"
+      },
+      "authorisationFirm": "test",
+      "authorisationName": "test",
+      "divorceCaseNumber": "DD12D12345",
+      "pensionCollection": [
+        {
+          "id": "1",
+          "value": {
+            "typeOfDocument": "pdf",
+            "uploadedDocument": {
+              "document_url": "http://file1",
+              "document_filename": "file1",
+              "document_binary_url": "http://file1.binary"
+            }
+          }
+        }
+      ],
+      "respondentAddress": {
+        "County": "essex",
+        "Country": "UK",
+        "PostCode": "b1 1ab",
+        "PostTown": "london",
+        "AddressLine1": "line1",
+        "AddressLine2": "line2",
+        "AddressLine3": "line3"
+      },
+      "solicitorDXnumber": "dx1",
+      "appRespondentLName": "smith",
+      "solicitorReference": "LL01",
+      "appRespondentFMName": "john",
+      "divorceStageReached": "Decree Nisi",
+      "helpWithFeesQuestion": "No",
+      "natureOfApplication2": [
+        "item1",
+        "item2"
+      ],
+      "natureOfApplication5": "No",
+      "natureOfApplication6": [
+        "item1",
+        "item2"
+      ],
+      "natureOfApplication7": "test",
+      "natureOfApplication3a": "test",
+      "natureOfApplication3b": "test",
+      "divorceUploadEvidence1": {
+        "document_url": "http://file1",
+        "document_filename": "file1",
+        "document_binary_url": "http://file1.binary"
+      },
+      "divorceDecreeNisiDate": "2010-01-01",
+      "divorceUploadEvidence2": {
+        "document_url": "http://file2",
+        "document_filename": "file2",
+        "document_binary_url": "http://file2.binary"
+      },
+      "divorceDecreeAbsoluteDate": "2010-01-01",
+      "orderForChildrenQuestion1": "No",
+      "solicitorAgreeToReceiveEmails": "Yes",
+      "orderDirection": "test",
+      "orderDirectionOpt1": {
+        "document_url": "http://file1",
+        "document_filename": "file1",
+        "document_binary_url": "http://file1.binary"
+      },
+      "orderDirectionAbsolute": "test",
+      "orderDirectionJudge": "test",
+      "orderDirectionJudgeName": "test",
+      "orderDirectionDate": "2010-01-01",
+      "dueDate": "2010-01-01",
+      "issueDate": "2010-01-01",
+      "orderDirectionAddComments": "test",
+      "orderDirectionOpt2": "test",
+      "assignedToJudgeReason": "test",
+      "assignedToJudge": "judge1",
+      "referToJudgeDate": "2010-01-01",
+      "referToJudgeText": "test",
+      "referToJudgeDateFromAwaitingResponse": "2010-01-01",
+      "referToJudgeTextFromAwaitingResponse": "test",
+      "referToJudgeDateFromOrderMade": "2010-01-01",
+      "referToJudgeTextFromOrderMade": "test",
+      "referToJudgeDateFromConsOrdApproved": "2010-01-01",
+      "referToJudgeTextFromConsOrdApproved": "test",
+      "referToJudgeDateFromConsOrdMade": "2010-01-01",
+      "referToJudgeTextFromConsOrdMade": "test",
+      "referToJudgeDateFromClose": "2010-01-01",
+      "referToJudgeTextFromClose": "test",
+      "referToJudgeDateFromRespondToOrder": "2010-01-01",
+      "referToJudgeTextFromRespondToOrder": "test",
+      "orderRefusalCollection": [
+        {
+          "id": "1",
+          "value": {
+            "orderRefusal": [
+              "Other"
+            ],
+            "orderRefusalDate": "2003-02-01",
+            "orderRefusalDocs": {
+              "document_url": "http://doc1",
+              "document_filename": "doc1",
+              "document_binary_url": "http://doc1.binary"
+            },
+            "orderRefusalJudge": "District Judge",
+            "orderRefusalOther": "test1",
+            "otherHearingDetails": "test2",
+            "orderRefusalJudgeName": "test3",
+            "orderRefusalNotEnough": [
+              "reason1"
+            ],
+            "estimateLengthOfHearing": "10",
+            "orderRefusalAddComments": "comment1",
+            "orderRefusalNotEnoughOther": "test",
+            "whenShouldHearingTakePlace": "today",
+            "whereShouldHearingTakePlace": "EZ801"
+          }
+        }
+      ],
+      "uploadConsentOrderDocuments": [
+        {
+          "id": "1",
+          "value": {
+            "DocumentType": "pdf",
+            "DocumentLink": {
+              "document_url": "http://doc1",
+              "document_filename": "doc1",
+              "document_binary_url": "http://doc1.binary"
+            },
+            "DocumentEmailContent": "email-content",
+            "DocumentDateAdded": "2010-01-02",
+            "DocumentComment": "doc-comment",
+            "DocumentFileName": "file1"
+          }
+        }
+      ],
+      "uploadOrder": [
+        {
+          "id": "1",
+          "value": {
+            "DocumentType": "pdf",
+            "DocumentLink": {
+              "document_url": "http://doc1",
+              "document_filename": "doc1",
+              "document_binary_url": "http://doc1.binary"
+            },
+            "DocumentEmailContent": "email-content",
+            "DocumentDateAdded": "2010-01-02",
+            "DocumentComment": "doc-comment",
+            "DocumentFileName": "file1"
+          }
+        }
+      ],
+      "uploadDocuments": [
+        {
+          "id": "1",
+          "value": {
+            "DocumentType": "pdf",
+            "DocumentLink": {
+              "document_url": "http://doc1",
+              "document_filename": "doc1",
+              "document_binary_url": "http://doc1.binary"
+            },
+            "DocumentEmailContent": "email-content",
+            "DocumentDateAdded": "2010-01-02",
+            "DocumentComment": "doc-comment",
+            "DocumentFileName": "file1"
+          }
+        }
+      ],
+      "generalOrderCollection": [
+        {
+          "id": "1",
+          "value": {
+            "generalOrder_order": "order1",
+            "generalOrder_documentUpload": {
+              "document_url": "http://doc1",
+              "document_filename": "doc1",
+              "document_binary_url": "http://doc1.binary"
+            },
+            "generalOrder_judgeList": "district judge",
+            "generalOrder_judgeName": "judge1",
+            "generalOrder_dateOfOrder": "2010-01-02",
+            "generalOrder_comments": "comment1"
+          }
+        }
+      ],
+      "respondToOrderDocuments": [
+        {
+          "id": "1",
+          "value": {
+            "DocumentType": "pdf",
+            "DocumentLink": {
+              "document_url": "http://doc1",
+              "document_filename": "doc1",
+              "document_binary_url": "http://doc1.binary"
+            },
+            "DocumentDateAdded": "2010-01-02",
+            "DocumentFileName": "file1"
+          }
+        }
+      ],
+      "amendedConsentOrderCollection": [
+        {
+          "id": "1",
+          "value": {
+            "amendedConsentOrder": {
+              "document_url": "http://doc1",
+              "document_filename": "doc1",
+              "document_binary_url": "http://doc1.binary"
+            },
+            "amendedConsentOrderDate": "2010-01-02"
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
- added feature to remove pension documents when pension orders are removed.
- added unit tests
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FR-748

### Change description ###
when pension options are deselected then pension related documents are removed from case data.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
