### PR TITLE
FR-974-divorce_petition_issued_date_for_amend_application

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/CaseMaintenanceController.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/CaseMaintenanceController.java
@@ -32,7 +32,6 @@ public class CaseMaintenanceController implements BaseController {
     private static final String DIVORCE_STAGE_REACHED = "divorceStageReached";
     private static final String DIVORCE_UPLOAD_EVIDENCE_2 = "divorceUploadEvidence2";
     private static final String DIVORCE_DECREE_ABSOLUTE_DATE = "divorceDecreeAbsoluteDate";
-    private static final String DIVORCE_PETITION_ISSUED_DATE = "divorcePetitionIssuedDate";
     private static final String DIVORCE_UPLOAD_PETITION = "divorceUploadPetition";
     private static final String DIVORCE_UPLOAD_EVIDENCE_1 = "divorceUploadEvidence1";
     private static final String DIVORCE_DECREE_NISI_DATE = "divorceDecreeNisiDate";
@@ -280,15 +279,11 @@ public class CaseMaintenanceController implements BaseController {
             // remove Decree Absolute details
             caseData.put(DIVORCE_UPLOAD_EVIDENCE_2, null);
             caseData.put(DIVORCE_DECREE_ABSOLUTE_DATE, null);
-            // remove petition issue date data
-            caseData.put(DIVORCE_PETITION_ISSUED_DATE, null);
             caseData.put(DIVORCE_UPLOAD_PETITION, null);
         } else if (equalsTo((String) caseData.get(DIVORCE_STAGE_REACHED), "Decree Absolute")) {
             // remove Decree Nisi details
             caseData.put(DIVORCE_UPLOAD_EVIDENCE_1, null);
             caseData.put(DIVORCE_DECREE_NISI_DATE, null);
-            // remove petition issue date data
-            caseData.put(DIVORCE_PETITION_ISSUED_DATE, null);
             caseData.put(DIVORCE_UPLOAD_PETITION, null);
         } else {
             // remove Decree Nisi details

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/CaseMaintenanceControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/CaseMaintenanceControllerTest.java
@@ -222,7 +222,7 @@ public class CaseMaintenanceControllerTest extends BaseControllerTest {
                 .andDo(print())
                 .andExpect(jsonPath(DATA_DIVORCE_UPLOAD_EVIDENCE_2).doesNotExist())
                 .andExpect(jsonPath(DATA_DIVORCE_DECREE_ABSOLUTE_DATE).doesNotExist())
-                .andExpect(jsonPath(DIVORCE_PETITION_ISSUED_DATE).doesNotExist())
+                .andExpect(jsonPath(DIVORCE_PETITION_ISSUED_DATE).exists())
                 .andExpect(jsonPath(DATA_DIVORCE_UPLOAD_PETITION).doesNotExist())
                 .andExpect(jsonPath(DATA_DIVORCE_UPLOAD_EVIDENCE_1).exists())
                 .andExpect(jsonPath(DATA_DIVORCE_DECREE_NISI_DATE).exists())
@@ -241,7 +241,7 @@ public class CaseMaintenanceControllerTest extends BaseControllerTest {
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andDo(print())
-                .andExpect(jsonPath(DIVORCE_PETITION_ISSUED_DATE).doesNotExist())
+                .andExpect(jsonPath(DIVORCE_PETITION_ISSUED_DATE).exists())
                 .andExpect(jsonPath(DATA_DIVORCE_UPLOAD_PETITION).doesNotExist())
                 .andExpect(jsonPath(DATA_DIVORCE_UPLOAD_EVIDENCE_1).doesNotExist())
                 .andExpect(jsonPath(DATA_DIVORCE_DECREE_NISI_DATE).doesNotExist());

--- a/src/test/resources/fixtures/contested/amend-divorce-details-decree-absolute.json
+++ b/src/test/resources/fixtures/contested/amend-divorce-details-decree-absolute.json
@@ -20,6 +20,7 @@
       "respondentPhone": "7411201631",
       "respondentFMName": "respondant0012",
       "divorceCaseNumber": "EZ17D80124",
+      "divorcePetitionIssuedDate" : "2012-01-11",
       "fastTrackDecision": "No",
       "rSolicitorAddress": {
         "County": "Please select",

--- a/src/test/resources/fixtures/contested/amend-divorce-details-decree-nisi.json
+++ b/src/test/resources/fixtures/contested/amend-divorce-details-decree-nisi.json
@@ -40,7 +40,7 @@
         "AddressLine3": ""
       },
       "allocatedCourtList": "cfc",
-      "petitionIssuedDate": "2015-01-11",
+      "divorcePetitionIssuedDate" : "2012-01-11",
       "rSolicitorDXnumber": "aaaa001",
       "solicitorReference": "KKKK0012",
       "divorceStageReached": "Decree Nisi",


### PR DESCRIPTION
- feedback change for divorce petition issued date
- Divorce petition issued Date is mandatory field.
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FR-974

### Change description ###
Petition Date should be captured - regardless of whether the petition is issued or not

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
