### PR TITLE
FR-820_remove_unused_auth_headers

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/NotificationsController.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/NotificationsController.java
@@ -36,13 +36,12 @@ public class NotificationsController implements BaseController {
         @ApiResponse(code = 200, message = "HWFSuccessful e-mail sent successfully",
             response = AboutToStartOrSubmitCallbackResponse.class)})
     public ResponseEntity<AboutToStartOrSubmitCallbackResponse> sendHwfSuccessfulConfirmationEmail(
-        @RequestBody CallbackRequest callbackRequest,
-        @RequestHeader(value = "Authorization") String userToken) {
+        @RequestBody CallbackRequest callbackRequest) {
         log.info(LOG_MESSAGE, callbackRequest.getCaseDetails().getId());
         validateCaseData(callbackRequest);
         Map<String, Object> caseData = callbackRequest.getCaseDetails().getData();
         if (isSolicitorAgreedToReceiveEmails(caseData)) {
-            notificationService.sendHWFSuccessfulConfirmationEmail(callbackRequest, userToken);
+            notificationService.sendHWFSuccessfulConfirmationEmail(callbackRequest);
         }
         return ResponseEntity.ok(AboutToStartOrSubmitCallbackResponse.builder().data(caseData).build());
     }
@@ -53,13 +52,12 @@ public class NotificationsController implements BaseController {
         @ApiResponse(code = 204, message = "Case assigned to Judge e-mail sent successfully",
             response = AboutToStartOrSubmitCallbackResponse.class)})
     public ResponseEntity<AboutToStartOrSubmitCallbackResponse> sendAssignToJudgeConfirmationEmail(
-        @RequestBody CallbackRequest callbackRequest,
-        @RequestHeader(value = "Authorization") String userToken) {
+        @RequestBody CallbackRequest callbackRequest) {
         log.info(LOG_MESSAGE, callbackRequest.getCaseDetails().getId());
         validateCaseData(callbackRequest);
         Map<String, Object> caseData = callbackRequest.getCaseDetails().getData();
         if (isSolicitorAgreedToReceiveEmails(caseData)) {
-            notificationService.sendAssignToJudgeConfirmationEmail(callbackRequest, userToken);
+            notificationService.sendAssignToJudgeConfirmationEmail(callbackRequest);
         }
         return ResponseEntity.ok(AboutToStartOrSubmitCallbackResponse.builder().data(caseData).build());
     }
@@ -70,13 +68,12 @@ public class NotificationsController implements BaseController {
         @ApiResponse(code = 204, message = "Consent order made e-mail sent successfully",
             response = AboutToStartOrSubmitCallbackResponse.class)})
     public ResponseEntity<AboutToStartOrSubmitCallbackResponse> sendConsentOrderMadeConfirmationEmail(
-        @RequestBody CallbackRequest callbackRequest,
-        @RequestHeader(value = "Authorization") String userToken) {
+        @RequestBody CallbackRequest callbackRequest) {
         log.info(LOG_MESSAGE, callbackRequest.getCaseDetails().getId());
         validateCaseData(callbackRequest);
         Map<String, Object> caseData = callbackRequest.getCaseDetails().getData();
         if (isSolicitorAgreedToReceiveEmails(caseData)) {
-            notificationService.sendConsentOrderMadeConfirmationEmail(callbackRequest, userToken);
+            notificationService.sendConsentOrderMadeConfirmationEmail(callbackRequest);
         }
         return ResponseEntity.ok(AboutToStartOrSubmitCallbackResponse.builder().data(caseData).build());
     }
@@ -87,13 +84,12 @@ public class NotificationsController implements BaseController {
         @ApiResponse(code = 204, message = "Consent order not approved e-mail sent successfully",
             response = AboutToStartOrSubmitCallbackResponse.class)})
     public ResponseEntity<AboutToStartOrSubmitCallbackResponse> sendConsentOrderNotApprovedEmail(
-        @RequestBody CallbackRequest callbackRequest,
-        @RequestHeader(value = "Authorization") String userToken) {
+        @RequestBody CallbackRequest callbackRequest) {
         log.info(LOG_MESSAGE, callbackRequest.getCaseDetails().getId());
         validateCaseData(callbackRequest);
         Map<String, Object> caseData = callbackRequest.getCaseDetails().getData();
         if (isSolicitorAgreedToReceiveEmails(caseData)) {
-            notificationService.sendConsentOrderNotApprovedEmail(callbackRequest, userToken);
+            notificationService.sendConsentOrderNotApprovedEmail(callbackRequest);
         }
         return ResponseEntity.ok(AboutToStartOrSubmitCallbackResponse.builder().data(caseData).build());
     }
@@ -104,13 +100,12 @@ public class NotificationsController implements BaseController {
         @ApiResponse(code = 204, message = "Consent order available e-mail sent successfully",
             response = AboutToStartOrSubmitCallbackResponse.class)})
     public ResponseEntity<AboutToStartOrSubmitCallbackResponse> sendConsentOrderAvailableEmail(
-        @RequestBody CallbackRequest callbackRequest,
-        @RequestHeader(value = "Authorization") String userToken) {
+        @RequestBody CallbackRequest callbackRequest) {
         log.info(LOG_MESSAGE, callbackRequest.getCaseDetails().getId());
         validateCaseData(callbackRequest);
         Map<String, Object> caseData = callbackRequest.getCaseDetails().getData();
         if (isSolicitorAgreedToReceiveEmails(caseData)) {
-            notificationService.sendConsentOrderAvailableEmail(callbackRequest, userToken);
+            notificationService.sendConsentOrderAvailableEmail(callbackRequest);
         }
         return ResponseEntity.ok(AboutToStartOrSubmitCallbackResponse.builder().data(caseData).build());
     }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/NotificationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/NotificationService.java
@@ -32,34 +32,34 @@ public class NotificationService {
     private final NotificationServiceConfiguration notificationServiceConfiguration;
     private final RestTemplate restTemplate;
 
-    public void sendHWFSuccessfulConfirmationEmail(CallbackRequest callbackRequest , String authToken) {
+    public void sendHWFSuccessfulConfirmationEmail(CallbackRequest callbackRequest) {
         URI uri = buildUri(notificationServiceConfiguration.getHwfSuccessful());
-        sendNotificationEmail(callbackRequest, authToken, uri);
+        sendNotificationEmail(callbackRequest, uri);
     }
 
-    public void sendAssignToJudgeConfirmationEmail(CallbackRequest callbackRequest, String authToken) {
+    public void sendAssignToJudgeConfirmationEmail(CallbackRequest callbackRequest) {
         URI uri = buildUri(notificationServiceConfiguration.getAssignToJudge());
-        sendNotificationEmail(callbackRequest, authToken, uri);
+        sendNotificationEmail(callbackRequest, uri);
     }
 
-    public void sendConsentOrderMadeConfirmationEmail(CallbackRequest callbackRequest, String authToken) {
+    public void sendConsentOrderMadeConfirmationEmail(CallbackRequest callbackRequest) {
         URI uri = buildUri(notificationServiceConfiguration.getConsentOrderMade());
-        sendNotificationEmail(callbackRequest, authToken, uri);
+        sendNotificationEmail(callbackRequest, uri);
     }
 
-    public void sendConsentOrderNotApprovedEmail(CallbackRequest callbackRequest, String authToken) {
+    public void sendConsentOrderNotApprovedEmail(CallbackRequest callbackRequest) {
         URI uri = buildUri(notificationServiceConfiguration.getConsentOrderNotApproved());
-        sendNotificationEmail(callbackRequest, authToken, uri);
+        sendNotificationEmail(callbackRequest, uri);
     }
 
-    public void sendConsentOrderAvailableEmail(CallbackRequest callbackRequest, String authToken) {
+    public void sendConsentOrderAvailableEmail(CallbackRequest callbackRequest) {
         URI uri = buildUri(notificationServiceConfiguration.getConsentOrderAvailable());
-        sendNotificationEmail(callbackRequest, authToken, uri);
+        sendNotificationEmail(callbackRequest, uri);
     }
 
-    private void sendNotificationEmail(CallbackRequest callbackRequest, String authToken, URI uri) {
+    private void sendNotificationEmail(CallbackRequest callbackRequest, URI uri) {
         NotificationRequest notificationRequest = buildNotificationRequest(callbackRequest);
-        HttpEntity<NotificationRequest> request = new HttpEntity<>(notificationRequest, buildHeaders(authToken));
+        HttpEntity<NotificationRequest> request = new HttpEntity<>(notificationRequest, buildHeaders());
         log.info(NOTIFICATION_SERVICE_URL, uri.toString());
         try {
             restTemplate.exchange(uri, HttpMethod.POST, request, String.class);
@@ -89,9 +89,8 @@ public class NotificationService {
                 .toUri();
     }
 
-    private HttpHeaders buildHeaders(String authToken) {
+    private HttpHeaders buildHeaders() {
         HttpHeaders headers = new HttpHeaders();
-        headers.add("Authorization", authToken);
         headers.add("Content-Type", "application/json");
         return headers;
     }

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/NotificationsControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/NotificationsControllerTest.java
@@ -27,7 +27,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.SetUpUtils.AUTH_TOKEN;
 
 @RunWith(SpringRunner.class)
 @WebMvcTest(NotificationsController.class)
@@ -59,12 +58,11 @@ public class NotificationsControllerTest {
         buildCcdRequest();
         mockMvc.perform(post(HWF_SUCCESSFUL_EMAIL_URL)
                 .content(requestContent.toString())
-                .header("Authorization", AUTH_TOKEN)
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
 
         verify(notificationService, times(1))
-                .sendHWFSuccessfulConfirmationEmail(any(CallbackRequest.class), any());
+                .sendHWFSuccessfulConfirmationEmail(any(CallbackRequest.class));
 
     }
 
@@ -73,7 +71,6 @@ public class NotificationsControllerTest {
         buildRequest();
         mockMvc.perform(post(HWF_SUCCESSFUL_EMAIL_URL)
                 .content(requestContent.toString())
-                .header("Authorization", AUTH_TOKEN)
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
 
@@ -86,12 +83,11 @@ public class NotificationsControllerTest {
         buildCcdRequest();
         mockMvc.perform(post(ASSIGN_TO_JUDGE_URL)
                 .content(requestContent.toString())
-                .header("Authorization", AUTH_TOKEN)
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
 
         verify(notificationService, times(1))
-                .sendAssignToJudgeConfirmationEmail(any(CallbackRequest.class), any());
+                .sendAssignToJudgeConfirmationEmail(any(CallbackRequest.class));
 
     }
 
@@ -100,7 +96,6 @@ public class NotificationsControllerTest {
         buildRequest();
         mockMvc.perform(post(ASSIGN_TO_JUDGE_URL)
                 .content(requestContent.toString())
-                .header("Authorization", AUTH_TOKEN)
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
 
@@ -113,12 +108,11 @@ public class NotificationsControllerTest {
         buildCcdRequest();
         mockMvc.perform(post(CONSENT_ORDER_MADE_URL)
                 .content(requestContent.toString())
-                .header("Authorization", AUTH_TOKEN)
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
 
         verify(notificationService, times(1))
-                .sendConsentOrderMadeConfirmationEmail(any(CallbackRequest.class), any());
+                .sendConsentOrderMadeConfirmationEmail(any(CallbackRequest.class));
 
     }
 
@@ -127,7 +121,6 @@ public class NotificationsControllerTest {
         buildRequest();
         mockMvc.perform(post(CONSENT_ORDER_MADE_URL)
                 .content(requestContent.toString())
-                .header("Authorization", AUTH_TOKEN)
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
 
@@ -139,12 +132,11 @@ public class NotificationsControllerTest {
         buildCcdRequest();
         mockMvc.perform(post(CONSENT_ORDER_NOT_APPROVED_URL)
                 .content(requestContent.toString())
-                .header("Authorization", AUTH_TOKEN)
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
 
         verify(notificationService, times(1))
-                .sendConsentOrderNotApprovedEmail(any(CallbackRequest.class), any());
+                .sendConsentOrderNotApprovedEmail(any(CallbackRequest.class));
 
     }
 
@@ -153,7 +145,6 @@ public class NotificationsControllerTest {
         buildRequest();
         mockMvc.perform(post(CONSENT_ORDER_NOT_APPROVED_URL)
                 .content(requestContent.toString())
-                .header("Authorization", AUTH_TOKEN)
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
 
@@ -166,12 +157,11 @@ public class NotificationsControllerTest {
         buildCcdRequest();
         mockMvc.perform(post(CONSENT_ORDER_AVAILABLE_URL)
                 .content(requestContent.toString())
-                .header("Authorization", AUTH_TOKEN)
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
 
         verify(notificationService, times(1))
-                .sendConsentOrderAvailableEmail(any(CallbackRequest.class), any());
+                .sendConsentOrderAvailableEmail(any(CallbackRequest.class));
 
     }
 
@@ -180,7 +170,6 @@ public class NotificationsControllerTest {
         buildRequest();
         mockMvc.perform(post(CONSENT_ORDER_AVAILABLE_URL)
                 .content(requestContent.toString())
-                .header("Authorization", AUTH_TOKEN)
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
 

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/integrationtest/NotificationsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/integrationtest/NotificationsTest.java
@@ -89,8 +89,7 @@ public class NotificationsTest {
         stubForNotification(NOTIFY_HWF_SUCCESSFUL_CONTEXT_PATH, HttpStatus.OK.value());
         webClient.perform(MockMvcRequestBuilders.post(HWF_SUCCESSFUL_URL)
                 .contentType(APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request))
-                .header(AUTHORIZATION, AUTH_TOKEN))
+                .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
                 .andDo(print())
                 .andExpect(content().json(expectedCaseData()));
@@ -103,8 +102,7 @@ public class NotificationsTest {
         stubForNotification(NOTIFY_CONSENT_ORDER_MADE_CONTEXT_PATH, HttpStatus.OK.value());
         webClient.perform(MockMvcRequestBuilders.post(CONSENT_ORDER_MADE_URL)
                 .contentType(APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request))
-                .header(AUTHORIZATION, AUTH_TOKEN))
+                .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
                 .andDo(print())
                 .andExpect(content().json(expectedCaseData()));
@@ -117,8 +115,7 @@ public class NotificationsTest {
         stubForNotification(NOTIFY_CONSENT_ORDER_AVAILABLE_CONTEXT_PATH, HttpStatus.OK.value());
         webClient.perform(MockMvcRequestBuilders.post(CONSENT_ORDER_AVAILABLE_URL)
                 .contentType(APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request))
-                .header(AUTHORIZATION, AUTH_TOKEN))
+                .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
                 .andDo(print())
                 .andExpect(content().json(expectedCaseData()));
@@ -131,8 +128,7 @@ public class NotificationsTest {
         stubForNotification(NOTIFY_CONSENT_ORDER_NOT_APPROVED_CONTEXT_PATH, HttpStatus.OK.value());
         webClient.perform(MockMvcRequestBuilders.post(CONSENT_ORDER_NOT_APPROVED_URL)
                 .contentType(APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request))
-                .header(AUTHORIZATION, AUTH_TOKEN))
+                .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
                 .andDo(print())
                 .andExpect(content().json(expectedCaseData()));
@@ -145,8 +141,7 @@ public class NotificationsTest {
         stubForNotification(NOTIFY_ASSIGN_TO_JUDGE_CONTEXT_PATH, HttpStatus.OK.value());
         webClient.perform(MockMvcRequestBuilders.post(ASSIGNED_TO_JUDGE_URL)
                 .contentType(APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request))
-                .header(AUTHORIZATION, AUTH_TOKEN))
+                .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
                 .andDo(print())
                 .andExpect(content().json(expectedCaseData()));

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/NotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/NotificationServiceTest.java
@@ -20,7 +20,6 @@ import java.util.Map;
 import static org.junit.Assert.assertThat;
 
 public class NotificationServiceTest extends BaseServiceTest {
-    private static final String AUTH_TOKEN = "Bearer eyJhbGciOiJIUzI1NiJ9";
     private static final String END_POINT_HWF_SUCCESSFUL = "http://localhost:8086/notify/hwf-successful";
     private static final String END_POINT_ASSIGNED_TO_JUDGE = "http://localhost:8086/notify/assign-to-judge";
     private static final String END_POINT_CONSENT_ORDER_MADE = "http://localhost:8086/notify/consent-order-made";
@@ -49,7 +48,7 @@ public class NotificationServiceTest extends BaseServiceTest {
         mockServer.expect(MockRestRequestMatchers.requestTo(END_POINT_HWF_SUCCESSFUL))
                 .andExpect(MockRestRequestMatchers.method(HttpMethod.POST))
                 .andRespond(MockRestResponseCreators.withNoContent());
-        notificationService.sendHWFSuccessfulConfirmationEmail(callbackRequest, AUTH_TOKEN);
+        notificationService.sendHWFSuccessfulConfirmationEmail(callbackRequest);
     }
 
     @Test
@@ -58,7 +57,7 @@ public class NotificationServiceTest extends BaseServiceTest {
                 .andExpect(MockRestRequestMatchers.method(HttpMethod.POST))
                 .andRespond(MockRestResponseCreators.withStatus(HttpStatus.INTERNAL_SERVER_ERROR));
         try {
-            notificationService.sendHWFSuccessfulConfirmationEmail(callbackRequest, AUTH_TOKEN);
+            notificationService.sendHWFSuccessfulConfirmationEmail(callbackRequest);
         } catch (Exception ex) {
             assertThat(ex.getMessage(), Is.is("500 Internal Server Error"));
         }
@@ -70,7 +69,7 @@ public class NotificationServiceTest extends BaseServiceTest {
         mockServer.expect(MockRestRequestMatchers.requestTo(END_POINT_ASSIGNED_TO_JUDGE))
                 .andExpect(MockRestRequestMatchers.method(HttpMethod.POST))
                 .andRespond(MockRestResponseCreators.withNoContent());
-        notificationService.sendAssignToJudgeConfirmationEmail(callbackRequest, AUTH_TOKEN);
+        notificationService.sendAssignToJudgeConfirmationEmail(callbackRequest);
     }
 
     @Test
@@ -81,7 +80,7 @@ public class NotificationServiceTest extends BaseServiceTest {
 
 
         try {
-            notificationService.sendAssignToJudgeConfirmationEmail(getCallbackRequest(), AUTH_TOKEN);
+            notificationService.sendAssignToJudgeConfirmationEmail(getCallbackRequest());
         } catch (Exception ex) {
             assertThat(ex.getMessage(), Is.is("500 Internal Server Error"));
         }
@@ -93,7 +92,7 @@ public class NotificationServiceTest extends BaseServiceTest {
         mockServer.expect(MockRestRequestMatchers.requestTo(END_POINT_CONSENT_ORDER_MADE))
                 .andExpect(MockRestRequestMatchers.method(HttpMethod.POST))
                 .andRespond(MockRestResponseCreators.withNoContent());
-        notificationService.sendConsentOrderMadeConfirmationEmail(callbackRequest, AUTH_TOKEN);
+        notificationService.sendConsentOrderMadeConfirmationEmail(callbackRequest);
     }
 
     @Test
@@ -102,7 +101,7 @@ public class NotificationServiceTest extends BaseServiceTest {
                 .andExpect(MockRestRequestMatchers.method(HttpMethod.POST))
                 .andRespond(MockRestResponseCreators.withStatus(HttpStatus.INTERNAL_SERVER_ERROR));
         try {
-            notificationService.sendConsentOrderMadeConfirmationEmail(callbackRequest, AUTH_TOKEN);
+            notificationService.sendConsentOrderMadeConfirmationEmail(callbackRequest);
         } catch (Exception ex) {
             assertThat(ex.getMessage(), Is.is("500 Internal Server Error"));
         }
@@ -114,7 +113,7 @@ public class NotificationServiceTest extends BaseServiceTest {
         mockServer.expect(MockRestRequestMatchers.requestTo(END_POINT_CONSENT_ORDER_NOT_APPROVED))
                 .andExpect(MockRestRequestMatchers.method(HttpMethod.POST))
                 .andRespond(MockRestResponseCreators.withNoContent());
-        notificationService.sendConsentOrderNotApprovedEmail(callbackRequest, AUTH_TOKEN);
+        notificationService.sendConsentOrderNotApprovedEmail(callbackRequest);
     }
 
     @Test
@@ -123,7 +122,7 @@ public class NotificationServiceTest extends BaseServiceTest {
                 .andExpect(MockRestRequestMatchers.method(HttpMethod.POST))
                 .andRespond(MockRestResponseCreators.withStatus(HttpStatus.INTERNAL_SERVER_ERROR));
         try {
-            notificationService.sendConsentOrderNotApprovedEmail(callbackRequest, AUTH_TOKEN);
+            notificationService.sendConsentOrderNotApprovedEmail(callbackRequest);
         } catch (Exception ex) {
             assertThat(ex.getMessage(), Is.is("500 Internal Server Error"));
         }
@@ -134,7 +133,7 @@ public class NotificationServiceTest extends BaseServiceTest {
         mockServer.expect(MockRestRequestMatchers.requestTo(END_POINT_CONSENT_ORDER_AVAILABLE))
                 .andExpect(MockRestRequestMatchers.method(HttpMethod.POST))
                 .andRespond(MockRestResponseCreators.withNoContent());
-        notificationService.sendConsentOrderAvailableEmail(callbackRequest, AUTH_TOKEN);
+        notificationService.sendConsentOrderAvailableEmail(callbackRequest);
     }
 
     @Test
@@ -143,7 +142,7 @@ public class NotificationServiceTest extends BaseServiceTest {
                 .andExpect(MockRestRequestMatchers.method(HttpMethod.POST))
                 .andRespond(MockRestResponseCreators.withStatus(HttpStatus.INTERNAL_SERVER_ERROR));
         try {
-            notificationService.sendConsentOrderAvailableEmail(callbackRequest, AUTH_TOKEN);
+            notificationService.sendConsentOrderAvailableEmail(callbackRequest);
         } catch (Exception ex) {
             assertThat(ex.getMessage(), Is.is("500 Internal Server Error"));
         }


### PR DESCRIPTION
- removed authToken as it is not required for notification api.
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FR-820

### Change description ###
removed authToken as it is not required for notification api.
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
