### PR TITLE
BSP-145: Added update case endpoint for future use by BSP

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/bulkscan/UpdateController.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/bulkscan/UpdateController.java
@@ -1,0 +1,66 @@
+package uk.gov.hmcts.reform.finrem.caseorchestration.controllers.bulkscan;
+
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.bulkscan.transformation.output.CaseCreationDetails;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.bulkscan.update.in.transformation.in.BulkScanCaseUpdateRequest;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.bulkscan.update.in.transformation.output.SuccessfulUpdateResponse;
+import uk.gov.hmcts.reform.finrem.caseorchestration.service.bulkscan.transformer.FrFormToCaseTransformer;
+
+import javax.validation.Valid;
+import java.util.Collections;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@Slf4j
+@RestController
+public class UpdateController {
+
+    private static final String CASE_TYPE_ID = "FINANCIAL_REMEDY";
+    private static final String UPDATE_EVENT_ID = "bulkScanCaseUpdate";
+
+    private FrFormToCaseTransformer frFormToCaseTransformer = new FrFormToCaseTransformer();
+
+    @PostMapping(
+            path = "/update-case",
+            consumes = APPLICATION_JSON,
+            produces = APPLICATION_JSON
+        )
+    @ApiOperation(value = "API to update Financial Remedy case data by bulk scan")
+    @ApiResponses({
+            @ApiResponse(code = 200, response = SuccessfulUpdateResponse.class,
+                message = "Update of case data has been successful"
+            ),
+            @ApiResponse(code = 400, message = "Request failed due to malformed syntax (and only for that reason). "
+                + "This response results in a general error presented to the caseworker in CCD"),
+            @ApiResponse(code = 401, message = "Provided S2S token is missing or invalid"),
+            @ApiResponse(code = 403, message = "Calling service is not authorised to use the endpoint"),
+            @ApiResponse(code = 422, message = "Exception record is well-formed, but contains invalid data.")
+        })
+    public ResponseEntity<SuccessfulUpdateResponse> updateCase(
+            @RequestHeader(name = "ServiceAuthorization", required = false) String serviceAuthHeader,
+            @Valid @RequestBody BulkScanCaseUpdateRequest request
+    ) {
+        log.info("Updates existing case based on exception record");
+
+        SuccessfulUpdateResponse callbackResponse = SuccessfulUpdateResponse.builder()
+            .caseUpdateDetails(
+                CaseCreationDetails
+                    .builder()
+                    .caseData(request.getCaseData())
+                    .caseTypeId(CASE_TYPE_ID)
+                    .eventId(UPDATE_EVENT_ID)
+                    .build()
+            ).warnings(Collections.emptyList())
+            .build();
+
+        return ResponseEntity.ok(callbackResponse);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/bulkscan/transformation/output/CaseCreationDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/bulkscan/transformation/output/CaseCreationDetails.java
@@ -1,9 +1,13 @@
 package uk.gov.hmcts.reform.finrem.caseorchestration.model.bulkscan.transformation.output;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
 
 import java.util.Map;
 
+@Builder
+@Getter
 public class CaseCreationDetails {
 
     @JsonProperty("case_type_id")

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/bulkscan/update/in/transformation/in/BulkScanCaseUpdateRequest.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/bulkscan/update/in/transformation/in/BulkScanCaseUpdateRequest.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.reform.finrem.caseorchestration.model.bulkscan.update.in.transformation.in;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.bulkscan.transformation.in.ExceptionRecord;
+
+import java.util.Map;
+
+@Getter
+public class BulkScanCaseUpdateRequest {
+
+    private final ExceptionRecord exceptionRecord;
+    private final Map<String, Object> caseData;
+
+    public BulkScanCaseUpdateRequest(
+        @JsonProperty("exception_record") ExceptionRecord exceptionRecord,
+        @JsonProperty("case_details") Map<String, Object> caseData
+    ) {
+        this.exceptionRecord = exceptionRecord;
+        this.caseData = caseData;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/bulkscan/update/in/transformation/output/SuccessfulUpdateResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/bulkscan/update/in/transformation/output/SuccessfulUpdateResponse.java
@@ -1,0 +1,26 @@
+package uk.gov.hmcts.reform.finrem.caseorchestration.model.bulkscan.update.in.transformation.output;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.bulkscan.transformation.output.CaseCreationDetails;
+
+import java.util.List;
+
+@Data
+@Builder
+public class SuccessfulUpdateResponse {
+
+    @JsonProperty("case_update_details")
+    public final CaseCreationDetails caseUpdateDetails;
+
+    @JsonProperty("warnings")
+    public final List<String> warnings;
+
+    public SuccessfulUpdateResponse(
+        CaseCreationDetails caseUpdateDetails,
+        List<String> warnings) {
+        this.caseUpdateDetails = caseUpdateDetails;
+        this.warnings = warnings;
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/bulkscan/UpdateControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/bulkscan/UpdateControllerTest.java
@@ -1,0 +1,49 @@
+package uk.gov.hmcts.reform.finrem.caseorchestration.controllers.bulkscan;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import uk.gov.hmcts.reform.finrem.caseorchestration.controllers.BaseControllerTest;
+
+import java.io.File;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.isJson;
+import static java.util.Collections.emptyList;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UpdateController.class)
+public class UpdateControllerTest extends BaseControllerTest {
+
+    private static final String EXCEPTION_RECORD_JSON_PATH = "/fixtures/model/exception-record.json";
+    private static final String API_URL = "/update-case";
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    public void shouldReturnSuccessResponseForUpdateEndpoint() throws Exception {
+        JsonNode formToValidate = objectMapper.readTree(new File(getClass()
+            .getResource(EXCEPTION_RECORD_JSON_PATH).toURI()));
+        mvc.perform(post(API_URL)
+            .contentType(APPLICATION_JSON)
+            .content(formToValidate.toString()))
+            .andExpect(status().isOk())
+            .andExpect(content().string(
+                allOf(
+                    isJson(),
+                    hasJsonPath("$.warnings", equalTo(emptyList())),
+                    hasJsonPath("$.case_update_details.*", hasSize(3)),
+                    hasJsonPath("$.case_update_details", allOf(
+                        hasJsonPath("case_type_id", is("FINANCIAL_REMEDY")),
+                        hasJsonPath("event_id", is("bulkScanCaseUpdate"))
+                    ))
+                )));
+    }
+}


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/BSP-145

Created a new "Update case" endpoint for Bulk Scanning. At the moment this endpoint will not be used however it will be called in the future by the RBS team to trigger an update to an existing case in CCD. Currently no logic is introduced, the endpoint just returns a 200 response code.