### PR TITLE
BSP-155: POST /update-case is not implemented in FR cos

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -149,9 +149,9 @@ dependencyManagement {
         // CVE-2018-10237
         dependency group: 'com.google.guava', name: 'guava', version: '28.1-jre'
         // CVE-2019-17563
-        dependency group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.30'
-        dependency group: 'org.apache.tomcat.embed', name: 'tomcat-embed-el', version: '9.0.30'
-        dependency group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.30'
+        dependency group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.31'
+        dependency group: 'org.apache.tomcat.embed', name: 'tomcat-embed-el', version: '9.0.31'
+        dependency group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.31'
     }
 }
 

--- a/src/functionalTests/java/uk/gov/hmcts/reform/finrem/functional/bulkscan/BulkScanIntegrationTest.java
+++ b/src/functionalTests/java/uk/gov/hmcts/reform/finrem/functional/bulkscan/BulkScanIntegrationTest.java
@@ -80,25 +80,14 @@ public class BulkScanIntegrationTest extends IntegrationTestBase {
     }
 
     @Test
-    public void shouldGetSuccessfulResponsesWhenUsingWhitelistedServiceForUpdateEndPoint()  throws Exception {
-        String token = utils.getS2SToken(bulkScanTransformationAndUpdateMicroService);
-        body = loadValidBody();
-
-        Response forUpdateEndpoint = responseForEndpoint(token, UPDATE_END_POINT);
-
-        assert forUpdateEndpoint.getStatusCode() == 200 : "Service is not authorised to transform OCR data to case"
-            + forUpdateEndpoint.getStatusCode();
-    }
-
-    @Test
-    public void shouldGetServiceDeniedWhenUsingNonWhitelistedServiceForUpdateEndPoint()  throws Exception {
-        String token = utils.getS2SToken(bulkScanValidationMicroService);
-        body = loadValidBody();
-
-        Response forUpdateEndpoint = responseForEndpoint(token, UPDATE_END_POINT);
-
-        assert forUpdateEndpoint.getStatusCode() == 403 : "Not matching with expected error Code "
-           + forUpdateEndpoint.getStatusCode();
+    public void shouldBeNotImplemented() {
+        assert SerenityRest.given()
+            .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+            .header(SERVICE_AUTHORISATION_HEADER, "it doesn't matter")
+            .relaxedHTTPSValidation()
+            .body(body)
+            .post(cosBaseUrl + UPDATE_END_POINT)
+            .getStatusCode() == 501 : "POST /update-case should return not implemented!";
     }
 
     private Response responseForEndpoint(String token, String endpointName) {

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/BulkScanController.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/BulkScanController.java
@@ -6,6 +6,7 @@ import io.swagger.annotations.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -17,9 +18,7 @@ import uk.gov.hmcts.reform.bsp.common.config.BulkScanEndpoints;
 import uk.gov.hmcts.reform.bsp.common.error.UnsupportedFormTypeException;
 import uk.gov.hmcts.reform.bsp.common.model.transformation.in.ExceptionRecord;
 import uk.gov.hmcts.reform.bsp.common.model.transformation.output.CaseCreationDetails;
-import uk.gov.hmcts.reform.bsp.common.model.transformation.output.CaseUpdateDetails;
 import uk.gov.hmcts.reform.bsp.common.model.transformation.output.SuccessfulTransformationResponse;
-import uk.gov.hmcts.reform.bsp.common.model.update.in.BulkScanCaseUpdateRequest;
 import uk.gov.hmcts.reform.bsp.common.model.update.output.SuccessfulUpdateResponse;
 import uk.gov.hmcts.reform.bsp.common.model.validation.in.OcrDataValidationRequest;
 import uk.gov.hmcts.reform.bsp.common.model.validation.out.OcrValidationResponse;
@@ -29,7 +28,6 @@ import uk.gov.hmcts.reform.finrem.caseorchestration.event.bulkscan.BulkScanEvent
 import uk.gov.hmcts.reform.finrem.caseorchestration.service.BulkScanService;
 
 import javax.validation.Valid;
-import java.util.Collections;
 import java.util.Map;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -134,7 +132,7 @@ public class BulkScanController {
         consumes = APPLICATION_JSON,
         produces = APPLICATION_JSON
     )
-    @ApiOperation(value = "API to update Financial Remedy case data by bulk scan")
+    @ApiOperation(value = "OUT OF SCOPE: API to update Financial Remedy case data by bulk scan")
     @ApiResponses({
         @ApiResponse(code = 200, response = SuccessfulUpdateResponse.class,
             message = "Update of case data has been successful"
@@ -147,21 +145,10 @@ public class BulkScanController {
     })
     public ResponseEntity<SuccessfulUpdateResponse> updateCase(
         @RequestHeader(name = SERVICE_AUTHORISATION_HEADER) String s2sAuthToken,
-        @Valid @RequestBody BulkScanCaseUpdateRequest request
+        @Valid @RequestBody Object request
     ) {
-        log.info("Updates existing case based on exception record");
+        log.warn("Bulk scan /POST update is not implemented for fin-rem cos");
 
-        authService.assertIsServiceAllowedToUpdate(s2sAuthToken);
-
-        SuccessfulUpdateResponse callbackResponse = SuccessfulUpdateResponse.builder()
-            .caseUpdateDetails(
-                CaseUpdateDetails
-                    .builder()
-                    .caseTypeId(CASE_TYPE_ID_FR)
-                    .caseData(request.getCaseData())
-                    .build())
-            .warnings(Collections.emptyList())
-            .build();
-        return ResponseEntity.ok(callbackResponse);
+        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/BulkScanController.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/BulkScanController.java
@@ -152,3 +152,5 @@ public class BulkScanController {
         return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build();
     }
 }
+
+// just to kick off build

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/BulkScanController.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/BulkScanController.java
@@ -152,5 +152,3 @@ public class BulkScanController {
         return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build();
     }
 }
-
-// just to kick off build

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/BulkScanControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/BulkScanControllerTest.java
@@ -10,9 +10,7 @@ import org.springframework.http.ResponseEntity;
 import uk.gov.hmcts.reform.bsp.common.error.UnsupportedFormTypeException;
 import uk.gov.hmcts.reform.bsp.common.model.transformation.in.ExceptionRecord;
 import uk.gov.hmcts.reform.bsp.common.model.transformation.output.CaseCreationDetails;
-import uk.gov.hmcts.reform.bsp.common.model.transformation.output.CaseUpdateDetails;
 import uk.gov.hmcts.reform.bsp.common.model.transformation.output.SuccessfulTransformationResponse;
-import uk.gov.hmcts.reform.bsp.common.model.update.in.BulkScanCaseUpdateRequest;
 import uk.gov.hmcts.reform.bsp.common.model.update.output.SuccessfulUpdateResponse;
 import uk.gov.hmcts.reform.bsp.common.model.validation.in.OcrDataField;
 import uk.gov.hmcts.reform.bsp.common.model.validation.in.OcrDataValidationRequest;
@@ -22,7 +20,6 @@ import uk.gov.hmcts.reform.bsp.common.service.AuthService;
 import uk.gov.hmcts.reform.finrem.caseorchestration.service.BulkScanService;
 
 import java.util.List;
-import java.util.Map;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -35,6 +32,7 @@ import static org.hamcrest.Matchers.hasEntry;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpStatus.NOT_IMPLEMENTED;
 import static org.springframework.http.HttpStatus.OK;
 import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
 import static uk.gov.hmcts.reform.bsp.common.model.validation.out.ValidationStatus.ERRORS;
@@ -119,22 +117,10 @@ public class BulkScanControllerTest {
 
     @Test
     public void shouldReturnUpdateServiceResults() {
-        ExceptionRecord exceptionRecord = ExceptionRecord.builder().build();
-        Map<String, Object> caseData = singletonMap(TEST_KEY, TEST_VALUE);
-
-        BulkScanCaseUpdateRequest bulkScanCaseUpdateRequest = new BulkScanCaseUpdateRequest(exceptionRecord, singletonMap(TEST_KEY, TEST_VALUE));
-
         ResponseEntity<SuccessfulUpdateResponse> response =
-            bulkScanController.updateCase(TEST_SERVICE_TOKEN, bulkScanCaseUpdateRequest);
+                bulkScanController.updateCase(TEST_SERVICE_TOKEN, new Object());
 
-        assertThat(response.getStatusCode(), is(OK));
-        SuccessfulUpdateResponse updateResponse = response.getBody();
-        assertThat(updateResponse.getWarnings(), is(emptyList()));
-        CaseUpdateDetails caseUpdateDetails = updateResponse.getCaseUpdateDetails();
-        assertThat(caseUpdateDetails.getCaseTypeId(), is(CASE_TYPE_ID_FR));
-        assertThat(caseUpdateDetails.getCaseData(), hasEntry(TEST_KEY, TEST_VALUE));
-
-        verify(authService).assertIsServiceAllowedToUpdate(TEST_SERVICE_TOKEN);
+        assertThat(response.getStatusCode(), is(NOT_IMPLEMENTED));
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BSP-155

### Change description ###
endpoint `POST /update-case` is not needed for now in FR COS. It will always return NOT_IMPLEMENTED status code

**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes
[ ] No
```
