### PR TITLE
BSP-289: fixed unit test that was failing because of timezone

### DIFF
--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/OrderRefusalTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/OrderRefusalTest.java
@@ -46,8 +46,8 @@ public class OrderRefusalTest {
             dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
 
             return dateFormat.parse(stringDate);
-        } catch (ParseException exeption) {
-            throw new IllegalArgumentException("Invalid date or format of date!", exeption);
+        } catch (ParseException exception) {
+            throw new IllegalArgumentException("Invalid date or format of date!", exception);
         }
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/OrderRefusalTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/OrderRefusalTest.java
@@ -1,11 +1,15 @@
 package uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.joda.time.DateTimeZone;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
-import java.sql.Date;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
@@ -16,6 +20,7 @@ public class OrderRefusalTest {
 
     @Before
     public void setUp() throws Exception {
+        DateTimeZone.setDefault(DateTimeZone.UTC);
         ObjectMapper mapper = new ObjectMapper();
         order = mapper.readValue(new File(getClass()
                 .getResource("/fixtures/model/order-refusal.json").toURI()), OrderRefusal.class);
@@ -25,7 +30,7 @@ public class OrderRefusalTest {
     public void shouldCreateOrderRefusalFromJson() {
         assertThat(order.getOrderRefusalAfterText(), is("afterText"));
         assertThat(order.getOrderRefusal(), hasItems("Other"));
-        assertThat(order.getOrderRefusalDate(), is(Date.valueOf("2003-02-01")));
+        assertThat(order.getOrderRefusalDate(), is(parseDate("2003-02-01")));
         assertThat(order.getOrderRefusalDocs().getDocumentUrl(), is("http://doc1"));
         assertThat(order.getOrderRefusalDocs().getDocumentFilename(), is("doc1"));
         assertThat(order.getOrderRefusalDocs().getDocumentBinaryUrl(), is("http://doc1.binary"));
@@ -33,5 +38,16 @@ public class OrderRefusalTest {
         assertThat(order.getOrderRefusalOther(), is("test1"));
         assertThat(order.getOrderRefusalJudgeName(), is("test3"));
         assertThat(order.getOrderRefusalAddComments(), is("comment1"));
+    }
+
+    private static Date parseDate(String stringDate) {
+        try {
+            SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+            dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+            return dateFormat.parse(stringDate);
+        } catch (ParseException exeption) {
+            throw new IllegalArgumentException("Invalid date or format of date!", exeption);
+        }
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BSP-289


### Change description ###
Just fix unit test that was failing because of timezones.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
