### PR TITLE
Minor code cleanup

### DIFF
--- a/src/functionalTests/java/uk/gov/hmcts/reform/finrem/functional/caseorchestration/AmendCaseDetailsTest.java
+++ b/src/functionalTests/java/uk/gov/hmcts/reform/finrem/functional/caseorchestration/AmendCaseDetailsTest.java
@@ -54,8 +54,7 @@ public class AmendCaseDetailsTest extends IntegrationTestBase {
                 "amend-divorce-details-decree-absolute1.json");
 
         if (jsonPathEvaluator.get("divorceDecreeNisiDate") != null) {
-            Assert.fail("The divorceDecreeNisiDate is still showing in the result even after"
-                    + " selecting decree Absolute.");
+            Assert.fail("The divorceDecreeNisiDate is still showing in the result even after selecting decree Absolute.");
         }
     }
 
@@ -149,9 +148,8 @@ public class AmendCaseDetailsTest extends IntegrationTestBase {
         if (jsonPathEvaluator.get("divorceUploadEvidence2") != null
                 || jsonPathEvaluator.get("divorceDecreeAbsoluteDate") != null) {
 
-            Assert.fail("The decree nissi file is still showing in the result.");
+            Assert.fail("The decree nisi file is still showing in the result.");
         }
-
     }
 
     @Test
@@ -164,7 +162,6 @@ public class AmendCaseDetailsTest extends IntegrationTestBase {
 
             Assert.fail("The decree Absolute file is still showing in the result.");
         }
-
     }
 
     @Test
@@ -180,7 +177,6 @@ public class AmendCaseDetailsTest extends IntegrationTestBase {
             Assert.fail("The property details are still showing in the result.");
         }
     }
-
 
     @Test
     public void verifyRemoveAdditionalPropertyDetailsForContested() {
@@ -206,7 +202,6 @@ public class AmendCaseDetailsTest extends IntegrationTestBase {
 
             Assert.fail("The periodic payment details are still showing in the result.");
         }
-
     }
 
     @Test
@@ -220,7 +215,6 @@ public class AmendCaseDetailsTest extends IntegrationTestBase {
             Assert.fail("The periodic payment details are still showing even after payment for children is unchecked for"
                 + " contested in the result.");
         }
-
     }
 
     @Test
@@ -247,7 +241,6 @@ public class AmendCaseDetailsTest extends IntegrationTestBase {
                 || jsonPathEvaluator.get("rSolicitorDXnumber") != null) {
             Assert.fail("The respondent solicitor details are still showing in the result.");
         }
-
     }
 
     @Test
@@ -332,7 +325,6 @@ public class AmendCaseDetailsTest extends IntegrationTestBase {
             Assert.fail("The Miam exception details when applicant attended Miam for contested are still showing "
                     + "in the result.");
         }
-
     }
 
     @Test
@@ -429,7 +421,6 @@ public class AmendCaseDetailsTest extends IntegrationTestBase {
         }
     }
 
-
     @Test
     public void verifyShouldNotRemoveMiamCheckListForContested() {
         jsonPathEvaluator = amendCaseDetails(amendContestedCaseDetailsUrl,contestedDir,
@@ -445,7 +436,7 @@ public class AmendCaseDetailsTest extends IntegrationTestBase {
     }
 
     @Test
-    public void verifyShouldUpdateCaseDataWithLatestConsentOrder() throws Exception {
+    public void verifyShouldUpdateCaseDataWithLatestConsentOrder() {
         jsonPathEvaluator = amendCaseDetails(amendCaseDetailsUrl,consentedDir,
                 "amend-consent-order-by-solicitor.json");
 
@@ -455,7 +446,7 @@ public class AmendCaseDetailsTest extends IntegrationTestBase {
     }
 
     @Test
-    public void verifyShouldSetLatestDraftConsentOrderWhenACaseIsCreated() throws Exception {
+    public void verifyShouldSetLatestDraftConsentOrderWhenACaseIsCreated() {
         jsonPathEvaluator = amendCaseDetails(amendCaseDetailsUrl,consentedDir,
                 "draft-consent-order.json");
         assertThat(jsonPathEvaluator.get("latestConsentOrder.document_binary_url"), is("http://file1.binary"));
@@ -464,7 +455,7 @@ public class AmendCaseDetailsTest extends IntegrationTestBase {
     }
 
     @Test
-    public void verifyshouldUpdateLatestDraftConsentOrderWhenACaseIsAmended() throws Exception {
+    public void verifyShouldUpdateLatestDraftConsentOrderWhenACaseIsAmended() {
 
         jsonPathEvaluator = amendCaseDetails(amendCaseDetailsUrl,consentedDir,
                 "amend-consent-order-by-solicitor.json");
@@ -475,7 +466,7 @@ public class AmendCaseDetailsTest extends IntegrationTestBase {
     }
 
     @Test
-    public void shouldReturnLatestAmendedConsentOrderWhenACaseIsAmendedByCaseWorker() throws Exception {
+    public void shouldReturnLatestAmendedConsentOrderWhenACaseIsAmendedByCaseWorker() {
         jsonPathEvaluator = amendCaseDetails(amendCaseDetailsUrl,consentedDir,
                 "amend-consent-order-by-caseworker.json");
         assertThat(jsonPathEvaluator.get("latestConsentOrder.document_binary_url"),
@@ -487,7 +478,7 @@ public class AmendCaseDetailsTest extends IntegrationTestBase {
     }
 
     @Test
-    public void shouldReturnLatestAmendedConsentOrderWhenACaseIsRespondedBySolictor() throws Exception {
+    public void shouldReturnLatestAmendedConsentOrderWhenACaseIsRespondedBySolictor() {
         jsonPathEvaluator = amendCaseDetails(amendCaseDetailsUrl,consentedDir,
                 "respond-to-order-solicitor.json");
         assertThat(jsonPathEvaluator.get("latestConsentOrder.document_binary_url"), is("http://doc1/binary"));

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/OrchestrationConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/OrchestrationConstants.java
@@ -13,6 +13,7 @@ public class OrchestrationConstants {
     // Bulk Scan & Printing
     public static final String BULK_SCAN_CASE_REFERENCE = "bulkScanCaseReference";
     public static final String CASE_TYPE_ID_CONSENTED = "FinancialRemedyMVP2";
+    public static final String PAPER_APPLICATION = "paperApplication";
 
     public static final String BINARY_URL_TYPE = "binary";
 

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/ccd/datamigration/controller/CcdDataMigrationController.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/ccd/datamigration/controller/CcdDataMigrationController.java
@@ -18,8 +18,8 @@ import java.util.Map;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.AUTHORIZATION_HEADER;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.YES_VALUE;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APPLICANT_REPRESENTED;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.YES;
 
 @RestController
 @RequiredArgsConstructor
@@ -43,7 +43,7 @@ public class CcdDataMigrationController {
         log.info("FR Migration: {} ,applicantRepresentedExist : {}", caseId, applicantRepresentedExist);
 
         if (!applicantRepresentedExist) {
-            caseData.put(APPLICANT_REPRESENTED, YES);
+            caseData.put(APPLICANT_REPRESENTED, YES_VALUE);
             log.info("FR Migration: {} setting applicantRepresented to Yes.", caseId);
             migrationRequired = true;
         }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/CaseDataController.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/CaseDataController.java
@@ -21,10 +21,10 @@ import java.util.List;
 import java.util.Map;
 
 import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.AUTHORIZATION_HEADER;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.NO_VALUE;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.YES_VALUE;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APPLICANT_REPRESENTED;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.IS_ADMIN;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.NO;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.YES;
 
 @RestController
 @RequiredArgsConstructor
@@ -86,11 +86,11 @@ public class CaseDataController implements BaseController {
     private void setData(final String authToken, final Map<String, Object> caseData) {
         if (idamService.isUserRoleAdmin(authToken)) {
             log.info("Admin users.");
-            caseData.put(IS_ADMIN, YES);
+            caseData.put(IS_ADMIN, YES_VALUE);
         } else {
             log.info("other users.");
-            caseData.put(IS_ADMIN, NO);
-            caseData.put(APPLICANT_REPRESENTED, YES);
+            caseData.put(IS_ADMIN, NO_VALUE);
+            caseData.put(APPLICANT_REPRESENTED, YES_VALUE);
         }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/ConsentOrderController.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/ConsentOrderController.java
@@ -21,9 +21,9 @@ import java.util.Map;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.AUTHORIZATION_HEADER;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.YES_VALUE;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APPLICANT_REPRESENTED;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.LATEST_CONSENT_ORDER;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.YES;
 
 @Slf4j
 @RestController
@@ -53,7 +53,7 @@ public class ConsentOrderController implements BaseController {
         caseData.put(LATEST_CONSENT_ORDER, caseDocument);
 
         if (!idamService.isUserRoleAdmin(authToken)) {
-            caseData.put(APPLICANT_REPRESENTED, YES);
+            caseData.put(APPLICANT_REPRESENTED, YES_VALUE);
         }
         return ResponseEntity.ok(AboutToStartOrSubmitCallbackResponse.builder().data(caseData).build());
     }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/DraftOnlineDocumentController.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/DraftOnlineDocumentController.java
@@ -24,9 +24,9 @@ import java.util.Map;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.AUTHORIZATION_HEADER;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.YES_VALUE;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APPLICANT_REPRESENTED;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.MINI_FORM_A;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.YES;
 
 @RestController
 @RequestMapping(value = "/case-orchestration")
@@ -58,7 +58,7 @@ public class DraftOnlineDocumentController {
         caseData.put(MINI_FORM_A, document);
         if (!idamService.isUserRoleAdmin(authorisationToken)) {
             log.info("other users.");
-            caseData.put(APPLICANT_REPRESENTED, YES);
+            caseData.put(APPLICANT_REPRESENTED, YES_VALUE);
         }
 
         return ResponseEntity.ok(AboutToStartOrSubmitCallbackResponse.builder().data(caseData).build());

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/NotificationsController.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/NotificationsController.java
@@ -19,6 +19,7 @@ import java.util.Objects;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.YES_VALUE;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.controllers.BaseController.isConsentedApplication;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_AGREE_TO_RECEIVE_EMAILS;
 
 @RestController
 @Slf4j
@@ -38,7 +39,7 @@ public class NotificationsController implements BaseController {
         validateCaseData(callbackRequest);
         Map<String, Object> caseData = callbackRequest.getCaseDetails().getData();
         if (isConsentedApplication(caseData)) {
-            if (isSolicitorAgreedToReceiveEmails(caseData, "solicitorAgreeToReceiveEmails")) {
+            if (isSolicitorAgreedToReceiveEmails(caseData, SOLICITOR_AGREE_TO_RECEIVE_EMAILS)) {
                 log.info("Sending Consented HWF Successful email notification to Solicitor");
                 notificationService.sendHWFSuccessfulConfirmationEmail(callbackRequest);
             }
@@ -60,7 +61,7 @@ public class NotificationsController implements BaseController {
         log.info("Received request to send email for Judge successfully assigned to case for Case ID: {}", callbackRequest.getCaseDetails().getId());
         validateCaseData(callbackRequest);
         Map<String, Object> caseData = callbackRequest.getCaseDetails().getData();
-        if (isSolicitorAgreedToReceiveEmails(caseData, "solicitorAgreeToReceiveEmails")) {
+        if (isSolicitorAgreedToReceiveEmails(caseData, SOLICITOR_AGREE_TO_RECEIVE_EMAILS)) {
             log.info("Sending email notification to Solicitor for Judge successfully assigned to case");
             notificationService.sendAssignToJudgeConfirmationEmail(callbackRequest);
         }
@@ -77,7 +78,7 @@ public class NotificationsController implements BaseController {
         log.info("Received request to send email for 'Consent Order Made' for Case ID: {}", callbackRequest.getCaseDetails().getId());
         validateCaseData(callbackRequest);
         Map<String, Object> caseData = callbackRequest.getCaseDetails().getData();
-        if (isSolicitorAgreedToReceiveEmails(caseData, "solicitorAgreeToReceiveEmails")) {
+        if (isSolicitorAgreedToReceiveEmails(caseData, SOLICITOR_AGREE_TO_RECEIVE_EMAILS)) {
             log.info("Sending email notification to Solicitor for 'Consent Order Made'");
             notificationService.sendConsentOrderMadeConfirmationEmail(callbackRequest);
         }
@@ -94,7 +95,7 @@ public class NotificationsController implements BaseController {
         log.info("Received request to send email for 'Consent Order Not Approved' for Case ID: {}", callbackRequest.getCaseDetails().getId());
         validateCaseData(callbackRequest);
         Map<String, Object> caseData = callbackRequest.getCaseDetails().getData();
-        if (isSolicitorAgreedToReceiveEmails(caseData, "solicitorAgreeToReceiveEmails")) {
+        if (isSolicitorAgreedToReceiveEmails(caseData, SOLICITOR_AGREE_TO_RECEIVE_EMAILS)) {
             log.info("Sending email notification to Solicitor for 'Consent Order Not Approved'");
             notificationService.sendConsentOrderNotApprovedEmail(callbackRequest);
         }
@@ -111,7 +112,7 @@ public class NotificationsController implements BaseController {
         log.info("Received request to send email for 'Consent Order Available' for Case ID: {}", callbackRequest.getCaseDetails().getId());
         validateCaseData(callbackRequest);
         Map<String, Object> caseData = callbackRequest.getCaseDetails().getData();
-        if (isSolicitorAgreedToReceiveEmails(caseData, "solicitorAgreeToReceiveEmails")) {
+        if (isSolicitorAgreedToReceiveEmails(caseData, SOLICITOR_AGREE_TO_RECEIVE_EMAILS)) {
             log.info("Sending email notification to Solicitor for 'Consent Order Available'");
             notificationService.sendConsentOrderAvailableEmail(callbackRequest);
         }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/UpdateConsentedCaseController.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/UpdateConsentedCaseController.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import static java.util.Objects.nonNull;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.AUTHORIZATION_HEADER;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_AGREE_TO_RECEIVE_EMAILS;
 
 @RestController
 @RequestMapping(value = "/case-orchestration")
@@ -158,7 +159,7 @@ public class UpdateConsentedCaseController implements BaseController {
         caseData.put("solicitorPhone", null);
         caseData.put("solicitorEmail", null);
         caseData.put("solicitorDXnumber", null);
-        caseData.put("solicitorAgreeToReceiveEmails", null);
+        caseData.put(SOLICITOR_AGREE_TO_RECEIVE_EMAILS, null);
     }
 
     private void removeApplicantAddress(Map<String, Object> caseData) {

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/CCDConfigConstant.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/CCDConfigConstant.java
@@ -25,7 +25,6 @@ public class CCDConfigConstant {
     public static final String CONTESTED_SOLICITOR_NAME = "applicantSolicitorName";
     public static final String SOLICITOR_FIRM = "solicitorFirm";
     public static final String APP_SOLICITOR_ADDRESS_CCD_FIELD = "solicitorAddress";
-    public static final String RESP_SOLICITOR_ADDRESS_CCD_FIELD = "rSolicitorAddress";
     public static final String SOLICITOR_AGREE_TO_RECEIVE_EMAILS = "solicitorAgreeToReceiveEmails";
     public static final String APPLICANT_REPRESENTED = "applicantRepresented";
 
@@ -62,8 +61,6 @@ public class CCDConfigConstant {
     public static final String MIAM_ATTENDANCE = "applicantAttendedMIAM";
     public static final String MIAM_EXEMPTION = "claimingExemptionMIAM";
     public static final String IS_ADMIN = "isAdmin";
-    public static final String YES = "Yes";
-    public static final String NO = "No";
     public static final String FR_COURT_ADMIN = "caseworker-divorce-financialremedy-courtadmin";
     public static final String ROLES = "roles";
     public static final String ALLOCATED_COURT_LIST = "allocatedCourtList";

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/bulkscan/transformation/FormAToCaseTransformer.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/bulkscan/transformation/FormAToCaseTransformer.java
@@ -23,6 +23,7 @@ import static uk.gov.hmcts.reform.bsp.common.mapper.GenericMapper.getValueFromOc
 import static uk.gov.hmcts.reform.bsp.common.utils.BulkScanCommonHelper.getCommaSeparatedValuesFromOcrDataField;
 import static uk.gov.hmcts.reform.bsp.common.utils.BulkScanCommonHelper.transformFormDateIntoCcdDate;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.NO_VALUE;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.PAPER_APPLICATION;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.YES_VALUE;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.service.bulkscan.helper.BulkScanHelper.applicantRepresentPaperToCcdFieldNames;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.service.bulkscan.helper.BulkScanHelper.dischargePeriodicalPaymentSubstituteChecklistToCcdFieldNames;
@@ -95,7 +96,7 @@ public class FormAToCaseTransformer extends BulkScanFormTransformer {
     protected Map<String, Object> runPostMappingModification(final Map<String, Object> transformedCaseData) {
         Map<String, Object> modifiedCaseData = new HashMap<>(transformedCaseData);
 
-        modifiedCaseData.put("paperApplication", YES_VALUE);
+        modifiedCaseData.put(PAPER_APPLICATION, YES_VALUE);
 
         // If OrderForChildren is populated then set orderForChildrenQuestion1 to Yes
         if (StringUtils.isNotEmpty((String) modifiedCaseData.get("natureOfApplication5b"))) {

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/CaseDataControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/CaseDataControllerTest.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.MediaType;
 import uk.gov.hmcts.reform.finrem.caseorchestration.service.IdamService;
 
 import java.io.File;
@@ -12,22 +11,22 @@ import java.io.File;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.AUTHORIZATION_HEADER;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.NO_VALUE;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.YES_VALUE;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.TestConstants.AUTH_TOKEN;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.NO;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.YES;
 
 @WebMvcTest(CaseDataController.class)
 public class CaseDataControllerTest extends BaseControllerTest {
 
     private static final String MOVE_VALUES_SAMPLE_JSON = "/fixtures/move-values-sample.json";
     private static final String CONTESTED_HWF_JSON = "/fixtures/contested/hwf.json";
-    private static final String CONTESTED_VALIDATE_HEARING_SUCCESSFULLY_JSON
-        = "/fixtures/contested/validate-hearing-successfully.json";
+    private static final String CONTESTED_VALIDATE_HEARING_SUCCESSFULLY_JSON = "/fixtures/contested/validate-hearing-successfully.json";
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     @MockBean
@@ -44,7 +43,7 @@ public class CaseDataControllerTest extends BaseControllerTest {
         mvc.perform(post("/case-orchestration/move-collection/uploadHearingOrder/to/uploadHearingOrderRO")
                             .content(requestContent.toString())
                             .header(AUTHORIZATION_HEADER, AUTH_TOKEN)
-                            .contentType(MediaType.APPLICATION_JSON_VALUE))
+                            .contentType(APPLICATION_JSON_VALUE))
                 .andExpect(status().isOk())
                 .andDo(print())
                 .andExpect(jsonPath("$.data.uploadHearingOrderRO[0]").exists())
@@ -64,7 +63,7 @@ public class CaseDataControllerTest extends BaseControllerTest {
         mvc.perform(post("/case-orchestration/move-collection/uploadHearingOrder/to/uploadHearingOrderNew")
                             .content(requestContent.toString())
                             .header(AUTHORIZATION_HEADER, AUTH_TOKEN)
-                            .contentType(MediaType.APPLICATION_JSON_VALUE))
+                            .contentType(APPLICATION_JSON_VALUE))
                 .andExpect(status().isOk())
                 .andDo(print())
                 .andExpect(jsonPath("$.data.uploadHearingOrderNew[0]").exists())
@@ -82,7 +81,7 @@ public class CaseDataControllerTest extends BaseControllerTest {
         mvc.perform(post("/case-orchestration/move-collection/someString/to/uploadHearingOrder")
                             .content(requestContent.toString())
                             .header(AUTHORIZATION_HEADER, AUTH_TOKEN)
-                            .contentType(MediaType.APPLICATION_JSON_VALUE))
+                            .contentType(APPLICATION_JSON_VALUE))
                 .andExpect(status().isOk())
                 .andDo(print())
                 .andExpect(jsonPath("$.data.uploadHearingOrder[0]").exists());
@@ -99,7 +98,7 @@ public class CaseDataControllerTest extends BaseControllerTest {
         mvc.perform(post("/case-orchestration/move-collection/uploadHearingOrder/to/someString")
                             .content(requestContent.toString())
                             .header(AUTHORIZATION_HEADER, AUTH_TOKEN)
-                            .contentType(MediaType.APPLICATION_JSON_VALUE))
+                            .contentType(APPLICATION_JSON_VALUE))
                 .andExpect(status().isOk())
                 .andDo(print())
                 .andExpect(jsonPath("$.data.uploadHearingOrder[0]").exists());
@@ -116,7 +115,7 @@ public class CaseDataControllerTest extends BaseControllerTest {
         mvc.perform(post("/case-orchestration/move-collection/empty/to/uploadHearingOrder")
                             .content(requestContent.toString())
                             .header(AUTHORIZATION_HEADER, AUTH_TOKEN)
-                            .contentType(MediaType.APPLICATION_JSON_VALUE))
+                            .contentType(APPLICATION_JSON_VALUE))
                 .andExpect(status().isOk())
                 .andDo(print())
                 .andExpect(jsonPath("$.data.uploadHearingOrder[0]").exists());
@@ -132,10 +131,10 @@ public class CaseDataControllerTest extends BaseControllerTest {
         mvc.perform(post("/case-orchestration/consented/set-defaults")
             .content(requestContent.toString())
             .header(AUTHORIZATION_HEADER, AUTH_TOKEN)
-            .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .contentType(APPLICATION_JSON_VALUE))
             .andExpect(status().isOk())
             .andDo(print())
-            .andExpect(jsonPath("$.data.isAdmin", is(YES)));
+            .andExpect(jsonPath("$.data.isAdmin", is(YES_VALUE)));
     }
 
     @Test
@@ -147,11 +146,11 @@ public class CaseDataControllerTest extends BaseControllerTest {
         mvc.perform(post("/case-orchestration/consented/set-defaults")
             .content(requestContent.toString())
             .header(AUTHORIZATION_HEADER, AUTH_TOKEN)
-            .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .contentType(APPLICATION_JSON_VALUE))
             .andExpect(status().isOk())
             .andDo(print())
-            .andExpect(jsonPath("$.data.isAdmin", is(NO)))
-            .andExpect(jsonPath("$.data.applicantRepresented", is(YES)));
+            .andExpect(jsonPath("$.data.isAdmin", is(NO_VALUE)))
+            .andExpect(jsonPath("$.data.applicantRepresented", is(YES_VALUE)));
     }
 
     @Test
@@ -163,10 +162,10 @@ public class CaseDataControllerTest extends BaseControllerTest {
         mvc.perform(post("/case-orchestration/contested/set-defaults")
             .content(requestContent.toString())
             .header(AUTHORIZATION_HEADER, AUTH_TOKEN)
-            .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .contentType(APPLICATION_JSON_VALUE))
             .andExpect(status().isOk())
             .andDo(print())
-            .andExpect(jsonPath("$.data.isAdmin", is(YES)));
+            .andExpect(jsonPath("$.data.isAdmin", is(YES_VALUE)));
     }
 
     @Test
@@ -178,10 +177,10 @@ public class CaseDataControllerTest extends BaseControllerTest {
         mvc.perform(post("/case-orchestration/contested/set-defaults")
             .content(requestContent.toString())
             .header(AUTHORIZATION_HEADER, AUTH_TOKEN)
-            .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .contentType(APPLICATION_JSON_VALUE))
             .andExpect(status().isOk())
             .andDo(print())
-            .andExpect(jsonPath("$.data.isAdmin", is(NO)))
-            .andExpect(jsonPath("$.data.applicantRepresented", is(YES)));
+            .andExpect(jsonPath("$.data.isAdmin", is(NO_VALUE)))
+            .andExpect(jsonPath("$.data.applicantRepresented", is(YES_VALUE)));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/RemoveApplicantDetailsControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/RemoveApplicantDetailsControllerTest.java
@@ -3,18 +3,18 @@ package uk.gov.hmcts.reform.finrem.caseorchestration.controllers;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.http.MediaType;
 
 import java.io.File;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.AUTHORIZATION_HEADER;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.NO_VALUE;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.YES_VALUE;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.TestConstants.AUTH_TOKEN;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.NO;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.YES;
 
 @WebMvcTest(RemoveApplicantDetailsController.class)
 public class RemoveApplicantDetailsControllerTest extends BaseControllerTest {
@@ -31,8 +31,8 @@ public class RemoveApplicantDetailsControllerTest extends BaseControllerTest {
         mvc.perform(post(REMOVE_DETAILS_URL)
                 .content(requestContent.toString())
                 .header(AUTHORIZATION_HEADER, AUTH_TOKEN)
-                .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(jsonPath("$.data.applicantRepresented", is(NO)))
+                .contentType(APPLICATION_JSON_VALUE))
+                .andExpect(jsonPath("$.data.applicantRepresented", is(NO_VALUE)))
                 .andExpect(jsonPath("$.data.applicantAddress", is(notNullValue())))
                 .andExpect(jsonPath("$.data.applicantPhone", is("89897876765")))
                 .andExpect(jsonPath("$.data.applicantEmail", is("email01@email.com")))
@@ -57,8 +57,8 @@ public class RemoveApplicantDetailsControllerTest extends BaseControllerTest {
         mvc.perform(post(REMOVE_DETAILS_URL)
                 .content(requestContent.toString())
                 .header(AUTHORIZATION_HEADER, AUTH_TOKEN)
-                .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(jsonPath("$.data.applicantRepresented", is(YES)))
+                .contentType(APPLICATION_JSON_VALUE))
+                .andExpect(jsonPath("$.data.applicantRepresented", is(YES_VALUE)))
                 .andExpect(jsonPath("$.data.applicantAddress").doesNotExist())
                 .andExpect(jsonPath("$.data.applicantPhone").doesNotExist())
                 .andExpect(jsonPath("$.data.applicantEmail").doesNotExist())

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/bulk/scan/transformation/FormAToCaseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/bulk/scan/transformation/FormAToCaseTransformerTest.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 import uk.gov.hmcts.reform.bsp.common.model.shared.in.ExceptionRecord;
 import uk.gov.hmcts.reform.bsp.common.model.shared.in.OcrDataField;
-import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.ChildInfo;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.ChildrenInfo;
 import uk.gov.hmcts.reform.finrem.caseorchestration.service.bulkscan.OcrFieldName;
@@ -27,14 +26,20 @@ import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.collection.IsMapWithSize.aMapWithSize;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.BULK_SCAN_CASE_REFERENCE;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.NO_VALUE;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.PAPER_APPLICATION;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.YES_VALUE;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.TestConstants.TEST_CASE_ID;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.DIVORCE_CASE_NUMBER;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.PBA_NUMBER;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.RESP_SOLICITOR_ADDRESS;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_EMAIL;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_FIRM;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_NAME;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_REFERENCE;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.service.bulkscan.OcrFieldName.APPLICANT_FULL_NAME;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.service.bulkscan.OcrFieldName.DISCHARGE_PERIODICAL_PAYMENT_SUBSTITUTE;
 
 public class FormAToCaseTransformerTest {
-
-    public static final String PAPER_APPLICATION = "paperApplication";
 
     private final FormAToCaseTransformer formAToCaseTransformer = new FormAToCaseTransformer();
 
@@ -95,7 +100,7 @@ public class FormAToCaseTransformerTest {
         assertThat(transformedCaseData, allOf(
                 hasEntry(BULK_SCAN_CASE_REFERENCE, TEST_CASE_ID),
                 hasEntry(PAPER_APPLICATION, YES_VALUE),
-                hasEntry(CCDConfigConstant.DIVORCE_CASE_NUMBER, "1234567890"),
+                hasEntry(DIVORCE_CASE_NUMBER, "1234567890"),
                 hasEntry("HWFNumber", "123456"),
                 hasEntry("applicantFMName", "Peter"),
                 hasEntry("applicantLName", "Griffin"),
@@ -106,13 +111,13 @@ public class FormAToCaseTransformerTest {
                 hasEntry("applyingForConsentOrder", "Yes"),
                 hasEntry("divorceStageReached", "Decree Nisi"),
                 hasEntry("applicantRepresentPaper", "FR_applicant_represented_1"),
-                hasEntry(CCDConfigConstant.SOLICITOR_NAME, "Saul Call"),
-                hasEntry(CCDConfigConstant.SOLICITOR_FIRM, "Better Divorce Ltd"),
+                hasEntry(SOLICITOR_NAME, "Saul Call"),
+                hasEntry(SOLICITOR_FIRM, "Better Divorce Ltd"),
                 hasEntry("solicitorPhone", "0712456543"),
                 hasEntry("solicitorDXnumber", "DX123"),
-                hasEntry("solicitorReference", "SOL-RED"),
-                hasEntry(CCDConfigConstant.PBA_NUMBER, "PBA123456"),
-                hasEntry(CCDConfigConstant.SOLICITOR_EMAIL, "test@example.com"),
+                hasEntry(SOLICITOR_REFERENCE, "SOL-RED"),
+                hasEntry(PBA_NUMBER, "PBA123456"),
+                hasEntry(SOLICITOR_EMAIL, "test@example.com"),
                 hasEntry("applicantPhone", "0712345654"),
                 hasEntry("applicantEmail", "applicant@divorcity.com"),
 
@@ -239,7 +244,7 @@ public class FormAToCaseTransformerTest {
         );
 
         assertAddressIsTransformed(
-                (Map) transformedCaseData.get("rSolicitorAddress"),
+                (Map) transformedCaseData.get(RESP_SOLICITOR_ADDRESS),
                 ImmutableMap.of(
                         "AddressLine1", "Drive",
                         "AddressTown", "Leeds",


### PR DESCRIPTION
- Added new constants for SOLICITOR_AGREE_TO_RECEIVE_EMAILS and PAPER_APPLICATION
- Removed duplicate YES & NO constants that were in both CCD config constants and orchestration constants
- Removed redundant empty lines
- Removed "throws Exception" from tests that don't throw exceptions