### PR TITLE
BSP-375 & BSP-376: Added additional transformation for 'solicitorEmail' & 'rSolicitorName'

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/CCDConfigConstant.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/CCDConfigConstant.java
@@ -14,9 +14,8 @@ public class CCDConfigConstant {
     public static final String APP_RESPONDENT_FIRST_MIDDLE_NAME = "appRespondentFMName";
     public static final String APP_RESPONDENT_LAST_NAME = "appRespondentLName";
     public static final String RESPONDENT_ADDRESS = "respondentAddress";
-    public static final String RESP_SOLICITOR_ADDRESS = "rSolicitorAddress";
 
-    //Solicitor related
+    //Applicant Solicitor related
     public static final String SOLICITOR_REFERENCE = "solicitorReference";
     public static final String SOLICITOR_NAME = "solicitorName";
     public static final String SOLICITOR_EMAIL = "solicitorEmail";
@@ -27,6 +26,11 @@ public class CCDConfigConstant {
     public static final String APP_SOLICITOR_ADDRESS_CCD_FIELD = "solicitorAddress";
     public static final String SOLICITOR_AGREE_TO_RECEIVE_EMAILS = "solicitorAgreeToReceiveEmails";
     public static final String APPLICANT_REPRESENTED = "applicantRepresented";
+
+    //Respondent Solicitor Related
+    public static final String RESPONDENT_REPRESENTED = "appRespondentRep";
+    public static final String RESP_SOLICITOR_NAME = "rSolicitorName";
+    public static final String RESP_SOLICITOR_ADDRESS = "rSolicitorAddress";
 
     //Application Type related
     public static final String D81_QUESTION = "d81Question";

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/bulkscan/OcrFieldName.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/bulkscan/OcrFieldName.java
@@ -36,6 +36,8 @@ public class OcrFieldName {
     public static final String RESPONDENT_ADDRESS_COUNTY = "RespondentAddressCounty";
     public static final String RESPONDENT_ADDRESS_POSTCODE = "RespondentAddressPostcode";
     public static final String RESPONDENT_ADDRESS_COUNTRY = "RespondentAddressCountry";
+    public static final String RESPONDENT_SOLICITOR_NAME = "RespondentSolicitorName";
+    public static final String RESPONDENT_SOLICITOR_EMAIL = "RespondentSolicitorEmail";
     public static final String RESPONDENT_SOLICITOR_ADDRESS_LINE_1 = "RespondentSolicitorAddressLine1";
     public static final String RESPONDENT_SOLICITOR_ADDRESS_TOWN = "RespondentSolicitorAddressTown";
     public static final String RESPONDENT_SOLICITOR_ADDRESS_COUNTY = "RespondentSolicitorAddressCounty";

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/bulkscan/helper/BulkScanHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/bulkscan/helper/BulkScanHelper.java
@@ -1,9 +1,14 @@
 package uk.gov.hmcts.reform.finrem.caseorchestration.service.bulkscan.helper;
 
 import com.google.common.collect.ImmutableMap;
+import org.apache.commons.lang3.StringUtils;
+import uk.gov.hmcts.reform.bsp.common.model.shared.in.OcrDataField;
 
+import java.util.List;
 import java.util.Map;
 
+import static java.util.Arrays.asList;
+import static uk.gov.hmcts.reform.bsp.common.mapper.GenericMapper.getValueFromOcrDataFields;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.bulk.scan.domain.FormA.ApplicantRepresentPaper.FR_APPLICANT_REPRESENTED_1;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.bulk.scan.domain.FormA.ApplicantRepresentPaper.FR_APPLICANT_REPRESENTED_2;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.bulk.scan.domain.FormA.ApplicantRepresentPaper.FR_APPLICANT_REPRESENTED_3;
@@ -69,4 +74,18 @@ public class BulkScanHelper {
                             FR_APPLICANT_REPRESENTED_3)
                     .build();
 
+    public static void mapFullNameToFirstAndLast(String ocrFieldName, String ccdFirstNameFieldName, String ccdLastNameFieldName,
+                                                 List<OcrDataField> ocrDataFields, Map<String, Object> formSpecificMap) {
+
+        getValueFromOcrDataFields(ocrFieldName, ocrDataFields)
+                .ifPresent(fullName -> {
+                    List<String> nameElements = asList(fullName.split(" "));
+                    formSpecificMap.put(ccdFirstNameFieldName, String.join(" ", nameElements.subList(0, nameElements.size() - 1)));
+                    formSpecificMap.put(ccdLastNameFieldName, nameElements.get(nameElements.size() - 1));
+                });
+    }
+
+    public static String getValueOrEmptyString(int index, List<OcrDataField> ocrDataFields, String fieldPrefix) {
+        return getValueFromOcrDataFields(fieldPrefix + index, ocrDataFields).orElse(StringUtils.EMPTY);
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/bulkscan/helper/BulkScanHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/bulkscan/helper/BulkScanHelper.java
@@ -1,14 +1,9 @@
 package uk.gov.hmcts.reform.finrem.caseorchestration.service.bulkscan.helper;
 
 import com.google.common.collect.ImmutableMap;
-import org.apache.commons.lang3.StringUtils;
-import uk.gov.hmcts.reform.bsp.common.model.shared.in.OcrDataField;
 
-import java.util.List;
 import java.util.Map;
 
-import static java.util.Arrays.asList;
-import static uk.gov.hmcts.reform.bsp.common.mapper.GenericMapper.getValueFromOcrDataFields;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.bulk.scan.domain.FormA.ApplicantRepresentPaper.FR_APPLICANT_REPRESENTED_1;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.bulk.scan.domain.FormA.ApplicantRepresentPaper.FR_APPLICANT_REPRESENTED_2;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.bulk.scan.domain.FormA.ApplicantRepresentPaper.FR_APPLICANT_REPRESENTED_3;
@@ -74,18 +69,4 @@ public class BulkScanHelper {
                             FR_APPLICANT_REPRESENTED_3)
                     .build();
 
-    public static void mapFullNameToFirstAndLast(String ocrFieldName, String ccdFirstNameFieldName, String ccdLastNameFieldName,
-                                                 List<OcrDataField> ocrDataFields, Map<String, Object> formSpecificMap) {
-
-        getValueFromOcrDataFields(ocrFieldName, ocrDataFields)
-                .ifPresent(fullName -> {
-                    List<String> nameElements = asList(fullName.split(" "));
-                    formSpecificMap.put(ccdFirstNameFieldName, String.join(" ", nameElements.subList(0, nameElements.size() - 1)));
-                    formSpecificMap.put(ccdLastNameFieldName, nameElements.get(nameElements.size() - 1));
-                });
-    }
-
-    public static String getValueOrEmptyString(int index, List<OcrDataField> ocrDataFields, String fieldPrefix) {
-        return getValueFromOcrDataFields(fieldPrefix + index, ocrDataFields).orElse(StringUtils.EMPTY);
-    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/bulkscan/transformation/FormAToCaseTransformer.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/bulkscan/transformation/FormAToCaseTransformer.java
@@ -2,10 +2,8 @@ package uk.gov.hmcts.reform.finrem.caseorchestration.service.bulkscan.transforma
 
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
-import uk.gov.hmcts.reform.bsp.common.mapper.AddressMapper;
 import uk.gov.hmcts.reform.bsp.common.model.shared.in.OcrDataField;
 import uk.gov.hmcts.reform.bsp.common.service.transformation.BulkScanFormTransformer;
-import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.ChildInfo;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.ChildrenInfo;
 import uk.gov.hmcts.reform.finrem.caseorchestration.service.bulkscan.OcrFieldName;
@@ -17,7 +15,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static java.util.Arrays.asList;
 import static uk.gov.hmcts.reform.bsp.common.mapper.AddressMapper.applyMappings;
 import static uk.gov.hmcts.reform.bsp.common.mapper.GenericMapper.getValueFromOcrDataFields;
 import static uk.gov.hmcts.reform.bsp.common.utils.BulkScanCommonHelper.getCommaSeparatedValuesFromOcrDataField;
@@ -25,8 +22,13 @@ import static uk.gov.hmcts.reform.bsp.common.utils.BulkScanCommonHelper.transfor
 import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.NO_VALUE;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.PAPER_APPLICATION;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.YES_VALUE;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.DIVORCE_CASE_NUMBER;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_AGREE_TO_RECEIVE_EMAILS;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_EMAIL;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.service.bulkscan.helper.BulkScanHelper.applicantRepresentPaperToCcdFieldNames;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.service.bulkscan.helper.BulkScanHelper.dischargePeriodicalPaymentSubstituteChecklistToCcdFieldNames;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.service.bulkscan.helper.BulkScanHelper.getValueOrEmptyString;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.service.bulkscan.helper.BulkScanHelper.mapFullNameToFirstAndLast;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.service.bulkscan.helper.BulkScanHelper.natureOfApplicationChecklistToCcdFieldNames;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.service.bulkscan.helper.BulkScanHelper.orderForChildrenNoAgreementToCcdFieldNames;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.service.bulkscan.helper.BulkScanHelper.orderForChildrenToCcdFieldNames;
@@ -60,14 +62,14 @@ public class FormAToCaseTransformer extends BulkScanFormTransformer {
         commaSeparatedEntryTransformer(OcrFieldName.DISCHARGE_PERIODICAL_PAYMENT_SUBSTITUTE, "dischargePeriodicalPaymentSubstituteFor",
                 dischargePeriodicalPaymentSubstituteChecklistToCcdFieldNames, ocrDataFields, transformedCaseData);
 
-        AddressMapper.applyMappings("applicantSolicitor", "solicitorAddress", ocrDataFields, transformedCaseData);
+        applyMappings("applicantSolicitor", "solicitorAddress", ocrDataFields, transformedCaseData);
         applyMappingsForAddress("applicant", ocrDataFields, transformedCaseData);
         applyMappingsForAddress("respondent", ocrDataFields, transformedCaseData);
-        AddressMapper.applyMappings("respondentSolicitor", "rSolicitorAddress", ocrDataFields, transformedCaseData);
+        applyMappings("respondentSolicitor", "rSolicitorAddress", ocrDataFields, transformedCaseData);
 
         addMappingsToChildren(ocrDataFields, transformedCaseData);
 
-        mapAuthorisationSignedToYesOrNo(OcrFieldName.AUTHORISATION_SIGNED, "authorisationSigned", ocrDataFields, transformedCaseData);
+        mapAuthorisationSignedToYesOrNo("authorisationSigned", ocrDataFields, transformedCaseData);
 
         mapFormDateToCcdDate(OcrFieldName.AUTHORISATION_DATE, "authorisation3", ocrDataFields, transformedCaseData);
 
@@ -103,6 +105,11 @@ public class FormAToCaseTransformer extends BulkScanFormTransformer {
             modifiedCaseData.put("orderForChildrenQuestion1", YES_VALUE);
         }
 
+        // If SolicitorEmail is populated then set SOLICITOR_AGREE_TO_RECEIVE_EMAILS to Yes
+        if (StringUtils.isNotEmpty((String) modifiedCaseData.get(SOLICITOR_EMAIL))) {
+            modifiedCaseData.put(SOLICITOR_AGREE_TO_RECEIVE_EMAILS, YES_VALUE);
+        }
+
         return modifiedCaseData;
     }
 
@@ -114,26 +121,15 @@ public class FormAToCaseTransformer extends BulkScanFormTransformer {
         });
     }
 
-    private void mapAuthorisationSignedToYesOrNo(String ocrFieldName, String ccdFieldName,
+    private void mapAuthorisationSignedToYesOrNo(String ccdFieldName,
                                                  List<OcrDataField> ocrDataFields, Map<String, Object> formSpecificMap) {
         ocrDataFields.stream()
-                .filter(ocrDataField -> ocrDataField.getName().equals(ocrFieldName))
+                .filter(ocrDataField -> ocrDataField.getName().equals(OcrFieldName.AUTHORISATION_SIGNED))
                 .map(OcrDataField::getValue)
                 .findFirst()
                 .ifPresent(ocrValue -> {
                     String ccdValue = ocrValue.trim().isEmpty() ? NO_VALUE : YES_VALUE;
                     formSpecificMap.put(ccdFieldName, ccdValue);
-                });
-    }
-
-    private void mapFullNameToFirstAndLast(String ocrFieldName, String ccdFirstNameFieldName, String ccdLastNameFieldName,
-                                           List<OcrDataField> ocrDataFields, Map<String, Object> formSpecificMap) {
-
-        getValueFromOcrDataFields(ocrFieldName, ocrDataFields)
-                .ifPresent(fullName -> {
-                    List<String> nameElements = asList(fullName.split(" "));
-                    formSpecificMap.put(ccdFirstNameFieldName, String.join(" ", nameElements.subList(0, nameElements.size() - 1)));
-                    formSpecificMap.put(ccdLastNameFieldName, nameElements.get(nameElements.size() - 1));
                 });
     }
 
@@ -163,7 +159,7 @@ public class FormAToCaseTransformer extends BulkScanFormTransformer {
         Map<String, String> exceptionRecordToCcdFieldsMap = new HashMap<>();
 
         // Section 0 - nature of application
-        exceptionRecordToCcdFieldsMap.put(OcrFieldName.DIVORCE_CASE_NUMBER, CCDConfigConstant.DIVORCE_CASE_NUMBER);
+        exceptionRecordToCcdFieldsMap.put(OcrFieldName.DIVORCE_CASE_NUMBER, DIVORCE_CASE_NUMBER);
         exceptionRecordToCcdFieldsMap.put(OcrFieldName.HWF_NUMBER, "HWFNumber");
         exceptionRecordToCcdFieldsMap.put(OcrFieldName.APPLICANT_INTENDS_TO, "applicantIntendsTo");
         exceptionRecordToCcdFieldsMap.put(OcrFieldName.APPLYING_FOR_CONSENT_ORDER, "applyingForConsentOrder");
@@ -230,9 +226,5 @@ public class FormAToCaseTransformer extends BulkScanFormTransformer {
                 .build();
 
         return child;
-    }
-
-    private String getValueOrEmptyString(int index, List<OcrDataField> ocrDataFields, String fieldPrefix) {
-        return getValueFromOcrDataFields(fieldPrefix + index, ocrDataFields).orElse(StringUtils.EMPTY);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/bulkscan/transformation/FormAToCaseTransformer.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/bulkscan/transformation/FormAToCaseTransformer.java
@@ -25,6 +25,8 @@ import static uk.gov.hmcts.reform.bsp.common.utils.BulkScanCommonHelper.transfor
 import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.NO_VALUE;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.PAPER_APPLICATION;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.YES_VALUE;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.RESPONDENT_REPRESENTED;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.RESP_SOLICITOR_NAME;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_AGREE_TO_RECEIVE_EMAILS;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_EMAIL;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.service.bulkscan.helper.BulkScanHelper.applicantRepresentPaperToCcdFieldNames;
@@ -105,9 +107,12 @@ public class FormAToCaseTransformer extends BulkScanFormTransformer {
             modifiedCaseData.put("orderForChildrenQuestion1", YES_VALUE);
         }
 
-        // If SolicitorEmail is populated then set SOLICITOR_AGREE_TO_RECEIVE_EMAILS to Yes
         if (StringUtils.isNotEmpty((String) modifiedCaseData.get(SOLICITOR_EMAIL))) {
             modifiedCaseData.put(SOLICITOR_AGREE_TO_RECEIVE_EMAILS, YES_VALUE);
+        }
+
+        if (StringUtils.isNotEmpty((String) modifiedCaseData.get(RESP_SOLICITOR_NAME))) {
+            modifiedCaseData.put(RESPONDENT_REPRESENTED, YES_VALUE);
         }
 
         return modifiedCaseData;
@@ -197,6 +202,8 @@ public class FormAToCaseTransformer extends BulkScanFormTransformer {
         exceptionRecordToCcdFieldsMap.put(OcrFieldName.AUTHORISATION_SOLICITOR_ADDRESS, "authorisationSolicitorAddress");
         exceptionRecordToCcdFieldsMap.put(OcrFieldName.AUTHORISATION_SIGNED_BY, "authorisationSignedBy");
         exceptionRecordToCcdFieldsMap.put(OcrFieldName.AUTHORISATION_SOLICITOR_POSITION, "authorisation2b");
+
+        exceptionRecordToCcdFieldsMap.put(OcrFieldName.RESPONDENT_SOLICITOR_NAME, "rSolicitorName");
 
         return exceptionRecordToCcdFieldsMap;
     }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/bulkscan/transformation/FormAToCaseTransformer.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/bulkscan/transformation/FormAToCaseTransformer.java
@@ -109,10 +109,14 @@ public class FormAToCaseTransformer extends BulkScanFormTransformer {
 
         if (StringUtils.isNotEmpty((String) modifiedCaseData.get(SOLICITOR_EMAIL))) {
             modifiedCaseData.put(SOLICITOR_AGREE_TO_RECEIVE_EMAILS, YES_VALUE);
+        } else {
+            modifiedCaseData.put(SOLICITOR_AGREE_TO_RECEIVE_EMAILS, NO_VALUE);
         }
 
         if (StringUtils.isNotEmpty((String) modifiedCaseData.get(RESP_SOLICITOR_NAME))) {
             modifiedCaseData.put(RESPONDENT_REPRESENTED, YES_VALUE);
+        } else {
+            modifiedCaseData.put(RESPONDENT_REPRESENTED, NO_VALUE);
         }
 
         return modifiedCaseData;

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/bulk/scan/transformation/FormAToCaseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/bulk/scan/transformation/FormAToCaseTransformerTest.java
@@ -278,7 +278,7 @@ public class FormAToCaseTransformerTest {
                 hasEntry(BULK_SCAN_CASE_REFERENCE, TEST_CASE_ID),
                 hasEntry(PAPER_APPLICATION, YES_VALUE),
                 hasEntry("natureOfApplication5b", "FR_nature_of_application_2"),
-                hasEntry("orderForChildrenQuestion1", "Yes")
+                hasEntry("orderForChildrenQuestion1", YES_VALUE)
         ));
 
         Map<String, Object> optionThreeTransformedData = formAToCaseTransformer.transformIntoCaseData(createExceptionRecord(
@@ -288,7 +288,7 @@ public class FormAToCaseTransformerTest {
                 hasEntry(BULK_SCAN_CASE_REFERENCE, TEST_CASE_ID),
                 hasEntry(PAPER_APPLICATION, YES_VALUE),
                 hasEntry("natureOfApplication5b", "FR_nature_of_application_3"),
-                hasEntry("orderForChildrenQuestion1", "Yes")
+                hasEntry("orderForChildrenQuestion1", YES_VALUE)
         ));
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/bulk/scan/transformation/FormAToCaseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/bulk/scan/transformation/FormAToCaseTransformerTest.java
@@ -32,6 +32,7 @@ import static uk.gov.hmcts.reform.finrem.caseorchestration.TestConstants.TEST_CA
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.DIVORCE_CASE_NUMBER;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.PBA_NUMBER;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.RESP_SOLICITOR_ADDRESS;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_AGREE_TO_RECEIVE_EMAILS;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_EMAIL;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_FIRM;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_NAME;
@@ -118,6 +119,7 @@ public class FormAToCaseTransformerTest {
                 hasEntry(SOLICITOR_REFERENCE, "SOL-RED"),
                 hasEntry(PBA_NUMBER, "PBA123456"),
                 hasEntry(SOLICITOR_EMAIL, "test@example.com"),
+                hasEntry(SOLICITOR_AGREE_TO_RECEIVE_EMAILS, "Yes"),
                 hasEntry("applicantPhone", "0712345654"),
                 hasEntry("applicantEmail", "applicant@divorcity.com"),
 

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/bulk/scan/transformation/FormAToCaseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/bulk/scan/transformation/FormAToCaseTransformerTest.java
@@ -159,7 +159,6 @@ public class FormAToCaseTransformerTest {
         Map<String, Object> transformedCaseData = formAToCaseTransformer.transformIntoCaseData(incomingExceptionRecord);
 
         assertThat(transformedCaseData, allOf(
-                aMapWithSize(2),
                 hasEntry(BULK_SCAN_CASE_REFERENCE, TEST_CASE_ID),
                 hasEntry(PAPER_APPLICATION, YES_VALUE)
         ));
@@ -175,7 +174,6 @@ public class FormAToCaseTransformerTest {
         Map<String, Object> transformedCaseData = formAToCaseTransformer.transformIntoCaseData(incomingExceptionRecord);
 
         assertThat(transformedCaseData, allOf(
-                aMapWithSize(2),
                 hasEntry(BULK_SCAN_CASE_REFERENCE, TEST_CASE_ID),
                 hasEntry(PAPER_APPLICATION, YES_VALUE)
         ));
@@ -212,7 +210,6 @@ public class FormAToCaseTransformerTest {
         Map<String, Object> transformedCaseData = formAToCaseTransformer.transformIntoCaseData(incomingExceptionRecord);
 
         assertThat(transformedCaseData, allOf(
-                aMapWithSize(6),    // 5 = BULK_SCAN_CASE_REFERENCE, paperApplication + 4 address fields
                 hasEntry(BULK_SCAN_CASE_REFERENCE, TEST_CASE_ID)
         ));
 
@@ -267,7 +264,6 @@ public class FormAToCaseTransformerTest {
                 singletonList(new OcrDataField("OrderForChildren",
                         "there is a written agreement made before 5 April 1993 about maintenance for the benefit of children"))));
         assertThat(optionOneTransformedData, allOf(
-                aMapWithSize(4),
                 hasEntry(BULK_SCAN_CASE_REFERENCE, TEST_CASE_ID),
                 hasEntry(PAPER_APPLICATION, YES_VALUE),
                 hasEntry("natureOfApplication5b", "FR_nature_of_application_1"),
@@ -278,7 +274,6 @@ public class FormAToCaseTransformerTest {
                 singletonList(new OcrDataField("OrderForChildren",
                         "there is a written agreement made on or after 5 April 1993 about maintenance for the benefit of children"))));
         assertThat(optionTwoTransformedData, allOf(
-                aMapWithSize(4),
                 hasEntry(BULK_SCAN_CASE_REFERENCE, TEST_CASE_ID),
                 hasEntry(PAPER_APPLICATION, YES_VALUE),
                 hasEntry("natureOfApplication5b", "FR_nature_of_application_2"),
@@ -288,7 +283,6 @@ public class FormAToCaseTransformerTest {
         Map<String, Object> optionThreeTransformedData = formAToCaseTransformer.transformIntoCaseData(createExceptionRecord(
                 singletonList(new OcrDataField("OrderForChildren", "there is no agreement, but the applicant is applying for payments"))));
         assertThat(optionThreeTransformedData, allOf(
-                aMapWithSize(4),
                 hasEntry(BULK_SCAN_CASE_REFERENCE, TEST_CASE_ID),
                 hasEntry(PAPER_APPLICATION, YES_VALUE),
                 hasEntry("natureOfApplication5b", "FR_nature_of_application_3"),
@@ -305,7 +299,6 @@ public class FormAToCaseTransformerTest {
         Map<String, Object> transformedCaseData = formAToCaseTransformer.transformIntoCaseData(incomingExceptionRecord);
 
         assertThat(transformedCaseData, allOf(
-                aMapWithSize(3),
                 hasEntry(BULK_SCAN_CASE_REFERENCE, TEST_CASE_ID),
                 hasEntry(PAPER_APPLICATION, YES_VALUE),
                 hasEntry("natureOfApplication5b", ""),
@@ -314,12 +307,11 @@ public class FormAToCaseTransformerTest {
     }
 
     @Test
-    public void shouldSetSolicitorAgreeToReceiveEmailsIfSolicitorEmailIsPopulated() {
+    public void shouldSetSolicitorAgreeToReceiveEmailsToYesIfSolicitorEmailIsPopulated() {
         Map<String, Object> convertedCcdData = formAToCaseTransformer.transformIntoCaseData(createExceptionRecord(
                 singletonList(new OcrDataField("ApplicantSolicitorEmail", TEST_SOLICITOR_EMAIL))));
 
         assertThat(convertedCcdData, allOf(
-                aMapWithSize(4),
                 hasEntry(BULK_SCAN_CASE_REFERENCE, TEST_CASE_ID),
                 hasEntry(PAPER_APPLICATION, YES_VALUE),
                 hasEntry(SOLICITOR_EMAIL, TEST_SOLICITOR_EMAIL),
@@ -328,7 +320,7 @@ public class FormAToCaseTransformerTest {
     }
 
     @Test
-    public void shouldNotSetSolicitorAgreeToReceiveEmailsIfSolicitorEmailIsNotPopulated() {
+    public void shouldSetSolicitorAgreeToReceiveEmailsToNoIfSolicitorEmailIsNotPopulated() {
         ExceptionRecord incomingExceptionRecord = createExceptionRecord(singletonList(
                 new OcrDataField("ApplicantSolicitorEmail", "")
         ));
@@ -336,21 +328,19 @@ public class FormAToCaseTransformerTest {
         Map<String, Object> transformedCaseData = formAToCaseTransformer.transformIntoCaseData(incomingExceptionRecord);
 
         assertThat(transformedCaseData, allOf(
-                aMapWithSize(3),
                 hasEntry(BULK_SCAN_CASE_REFERENCE, TEST_CASE_ID),
                 hasEntry(PAPER_APPLICATION, YES_VALUE),
                 hasEntry(SOLICITOR_EMAIL, ""),
-                not(hasKey(SOLICITOR_AGREE_TO_RECEIVE_EMAILS))
+                hasEntry(SOLICITOR_AGREE_TO_RECEIVE_EMAILS, NO_VALUE)
         ));
     }
 
     @Test
-    public void shouldSetRespondentRepresentedIfRespSolicitorNameIsPopulated() {
+    public void shouldSetRespondentRepresentedToYesIfRespSolicitorNameIsPopulated() {
         Map<String, Object> convertedCcdData = formAToCaseTransformer.transformIntoCaseData(createExceptionRecord(
                 singletonList(new OcrDataField("RespondentSolicitorName", TEST_SOLICITOR_NAME))));
 
         assertThat(convertedCcdData, allOf(
-                aMapWithSize(4),
                 hasEntry(BULK_SCAN_CASE_REFERENCE, TEST_CASE_ID),
                 hasEntry(PAPER_APPLICATION, YES_VALUE),
                 hasEntry(RESP_SOLICITOR_NAME, TEST_SOLICITOR_NAME),
@@ -359,7 +349,7 @@ public class FormAToCaseTransformerTest {
     }
 
     @Test
-    public void shouldNotSetRespondentRepresentedIfRespSolicitorNameIsNotPopulated() {
+    public void shouldSetRespondentRepresentedToNoIfRespSolicitorNameIsNotPopulated() {
         ExceptionRecord incomingExceptionRecord = createExceptionRecord(singletonList(
                 new OcrDataField("RespondentSolicitorName", "")
         ));
@@ -367,11 +357,10 @@ public class FormAToCaseTransformerTest {
         Map<String, Object> transformedCaseData = formAToCaseTransformer.transformIntoCaseData(incomingExceptionRecord);
 
         assertThat(transformedCaseData, allOf(
-                aMapWithSize(3),
                 hasEntry(BULK_SCAN_CASE_REFERENCE, TEST_CASE_ID),
                 hasEntry(PAPER_APPLICATION, YES_VALUE),
                 hasEntry(RESP_SOLICITOR_NAME, ""),
-                not(hasKey(RESPONDENT_REPRESENTED))
+                hasEntry(RESPONDENT_REPRESENTED, NO_VALUE)
         ));
     }
 
@@ -448,7 +437,6 @@ public class FormAToCaseTransformerTest {
                 createExceptionRecord(asList(new OcrDataField(ocrFieldName, ocrFieldValue))));
 
         assertThat(transformedCaseData, allOf(
-                aMapWithSize(3),
                 hasEntry(BULK_SCAN_CASE_REFERENCE, TEST_CASE_ID),
                 hasEntry(PAPER_APPLICATION, YES_VALUE),
                 hasEntry(ccdFieldName, ccdFieldValue)

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/bulk/scan/transformation/FormAToCaseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/bulk/scan/transformation/FormAToCaseTransformerTest.java
@@ -29,9 +29,13 @@ import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstant
 import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.PAPER_APPLICATION;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.YES_VALUE;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.TestConstants.TEST_CASE_ID;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.TestConstants.TEST_SOLICITOR_EMAIL;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.TestConstants.TEST_SOLICITOR_NAME;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.DIVORCE_CASE_NUMBER;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.PBA_NUMBER;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.RESPONDENT_REPRESENTED;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.RESP_SOLICITOR_ADDRESS;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.RESP_SOLICITOR_NAME;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_AGREE_TO_RECEIVE_EMAILS;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_EMAIL;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_FIRM;
@@ -306,6 +310,68 @@ public class FormAToCaseTransformerTest {
                 hasEntry(PAPER_APPLICATION, YES_VALUE),
                 hasEntry("natureOfApplication5b", ""),
                 not(hasKey("orderForChildrenQuestion1"))
+        ));
+    }
+
+    @Test
+    public void shouldSetSolicitorAgreeToReceiveEmailsIfSolicitorEmailIsPopulated() {
+        Map<String, Object> convertedCcdData = formAToCaseTransformer.transformIntoCaseData(createExceptionRecord(
+                singletonList(new OcrDataField("ApplicantSolicitorEmail", TEST_SOLICITOR_EMAIL))));
+
+        assertThat(convertedCcdData, allOf(
+                aMapWithSize(4),
+                hasEntry(BULK_SCAN_CASE_REFERENCE, TEST_CASE_ID),
+                hasEntry(PAPER_APPLICATION, YES_VALUE),
+                hasEntry(SOLICITOR_EMAIL, TEST_SOLICITOR_EMAIL),
+                hasEntry(SOLICITOR_AGREE_TO_RECEIVE_EMAILS, YES_VALUE)
+        ));
+    }
+
+    @Test
+    public void shouldNotSetSolicitorAgreeToReceiveEmailsIfSolicitorEmailIsNotPopulated() {
+        ExceptionRecord incomingExceptionRecord = createExceptionRecord(singletonList(
+                new OcrDataField("ApplicantSolicitorEmail", "")
+        ));
+
+        Map<String, Object> transformedCaseData = formAToCaseTransformer.transformIntoCaseData(incomingExceptionRecord);
+
+        assertThat(transformedCaseData, allOf(
+                aMapWithSize(3),
+                hasEntry(BULK_SCAN_CASE_REFERENCE, TEST_CASE_ID),
+                hasEntry(PAPER_APPLICATION, YES_VALUE),
+                hasEntry(SOLICITOR_EMAIL, ""),
+                not(hasKey(SOLICITOR_AGREE_TO_RECEIVE_EMAILS))
+        ));
+    }
+
+    @Test
+    public void shouldSetRespondentRepresentedIfRespSolicitorNameIsPopulated() {
+        Map<String, Object> convertedCcdData = formAToCaseTransformer.transformIntoCaseData(createExceptionRecord(
+                singletonList(new OcrDataField("RespondentSolicitorName", TEST_SOLICITOR_NAME))));
+
+        assertThat(convertedCcdData, allOf(
+                aMapWithSize(4),
+                hasEntry(BULK_SCAN_CASE_REFERENCE, TEST_CASE_ID),
+                hasEntry(PAPER_APPLICATION, YES_VALUE),
+                hasEntry(RESP_SOLICITOR_NAME, TEST_SOLICITOR_NAME),
+                hasEntry(RESPONDENT_REPRESENTED, YES_VALUE)
+        ));
+    }
+
+    @Test
+    public void shouldNotSetRespondentRepresentedIfRespSolicitorNameIsNotPopulated() {
+        ExceptionRecord incomingExceptionRecord = createExceptionRecord(singletonList(
+                new OcrDataField("RespondentSolicitorName", "")
+        ));
+
+        Map<String, Object> transformedCaseData = formAToCaseTransformer.transformIntoCaseData(incomingExceptionRecord);
+
+        assertThat(transformedCaseData, allOf(
+                aMapWithSize(3),
+                hasEntry(BULK_SCAN_CASE_REFERENCE, TEST_CASE_ID),
+                hasEntry(PAPER_APPLICATION, YES_VALUE),
+                hasEntry(RESP_SOLICITOR_NAME, ""),
+                not(hasKey(RESPONDENT_REPRESENTED))
         ));
     }
 


### PR DESCRIPTION
- BSP-375: Added additional transformation for 'solicitorEmail' (If 'solicitorEmail' field is populated, then add the value 'Yes' to the field 'solicitorAgreeToReceiveEmails'.)
- BSP-376: Additional transformation for 'rSolicitorName' to 'appRespondentRep' (If 'rSolicitorName' is empty, then make ''appRespondentRep' is set to 'No', If 'rSolicitorName' is not empty, then make ''appRespondentRep' is set to 'Yes')


