### PR TITLE
Removed comma from applicantRepresentedPaper value

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/bulkscan/helper/BulkScanHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/bulkscan/helper/BulkScanHelper.java
@@ -64,7 +64,7 @@ public class BulkScanHelper {
                     .put("I am not represented by a solicitor in these proceedings", FR_APPLICANT_REPRESENTED_1)
                     .put("I am not represented by a solicitor in these proceedings but am receiving advice from a solicitor",
                             FR_APPLICANT_REPRESENTED_2)
-                    .put("I am represented by a solicitor in these proceedings, who has signed Section 5, and all "
+                    .put("I am represented by a solicitor in these proceedings, who has signed Section 5 and all "
                                     + "documents for my attention should be sent to my solicitor whose details are as follows",
                             FR_APPLICANT_REPRESENTED_3)
                     .build();

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/bulk/scan/transformation/FormAToCaseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/bulk/scan/transformation/FormAToCaseTransformerTest.java
@@ -416,7 +416,7 @@ public class FormAToCaseTransformerTest {
 
         Map<String, Object> transformedCaseDataOptionThree = formAToCaseTransformer.transformIntoCaseData(
                 createExceptionRecord(singletonList(new OcrDataField(OcrFieldName.APPLICANT_REPRESENTED,
-                        "I am represented by a solicitor in these proceedings, who has signed Section 5, and all "
+                        "I am represented by a solicitor in these proceedings, who has signed Section 5 and all "
                                 + "documents for my attention should be sent to my solicitor whose details are as follows"))));
         assertThat(transformedCaseDataOptionThree.get(APPLICANT_REPRESENTED_PAPER), is("FR_applicant_represented_3"));
         assertThat(transformedCaseDataOptionThree.get(APPLICANT_REPRESENTED), is(YES_VALUE));


### PR DESCRIPTION
There was a bug with a redundant comma that caused a difference between the validation and transformation logics for BSP.
'I am represented by a solicitor in these proceedings, who has signed Section 5, and all documents for my attention should be sent to my solicitor whose details are as follows'
so it is now:
''I am represented by a solicitor in these proceedings, who has signed Section 5 and all documents for my attention should be sent to my solicitor whose details are as follows''

