### PR TITLE
BSP-265: Removed ignore on JSON property and updated test

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/ApprovedOrder.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/ApprovedOrder.java
@@ -25,10 +25,6 @@ public class ApprovedOrder {
     private CaseDocument consentOrder;
     @JsonProperty("pensionDocuments")
     private List<PensionCollectionData> pensionDocuments;
-
-    @JsonIgnore
-    @Getter(AccessLevel.NONE)
-    @Setter(AccessLevel.NONE)
     @JsonProperty("consentOrderApprovedNotificationLetter")
     private CaseDocument consentOrderApprovedNotificationLetter;
 }

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/ConsentOrderApprovedControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/ConsentOrderApprovedControllerTest.java
@@ -135,8 +135,7 @@ public class ConsentOrderApprovedControllerTest extends BaseControllerTest {
         verify(service, times(1)).generateApprovedConsentOrderNotificationLetter(any(), any());
 
         result.andExpect(status().isOk());
-        // TODO: Reintroduce this and fix failing test
-        //assertConsentOrderNotificationLetter(result);
+        assertConsentOrderNotificationLetter(result);
     }
 
     @Test


### PR DESCRIPTION
To fix changes for BSP-265.

Now that the code is behind feature toggle on COS & CCD, we should be able to reintroduce this JSON property and test accordingly