### PR TITLE
BSP-287: 'application assigned to judge' notification letter

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/OrchestrationConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/OrchestrationConstants.java
@@ -19,4 +19,16 @@ public class OrchestrationConstants {
 
     public static final String YES_VALUE = "Yes";
     public static final String NO_VALUE = "No";
+
+    // CTSC Contact Details
+    public static final String CTSC_SERVICE_CENTRE = "Courts and Tribunals Service Centre";
+    public static final String CTSC_CARE_OF = "c/o HMCTS Digital Financial Remedy";
+    public static final String CTSC_PO_BOX = "12746";
+    public static final String CTSC_TOWN = "HARLOW";
+    public static final String CTSC_POSTCODE = "CM20 9QZ";
+    public static final String CTSC_EMAIL_ADDRESS = "HMCTSFinancialRemedy@justice.gov.uk";
+    public static final String CTSC_PHONE_NUMBER = "0300 303 0642";
+    public static final String CTSC_OPENING_HOURS = "from 8.30am to 5pm";
+
+
 }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/config/DocumentConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/config/DocumentConfiguration.java
@@ -32,4 +32,6 @@ public class DocumentConfiguration {
     private String approvedConsentOrderFileName;
     private String approvedConsentOrderNotificationTemplate;
     private String approvedConsentOrderNotificationFileName;
+    private String applicationAssignedToJudgeTemplate;
+    private String applicationAssignedToJudgeFileName;
 }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/NotificationsController.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/NotificationsController.java
@@ -26,7 +26,6 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.AUTHORIZATION_HEADER;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.YES_VALUE;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.controllers.BaseController.isConsentedApplication;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.ASSIGNED_TO_JUDGE_NOTIFICATION_LETTER;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_AGREE_TO_RECEIVE_EMAILS;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.isPaperApplication;
 
@@ -91,6 +90,9 @@ public class NotificationsController implements BaseController {
 
                 // Send notification letter to Bulk Print
                 bulkPrintService.sendNotificationLetterForBulkPrint(assignedToJudgeNotificationLetter, caseDetails);
+
+                // will possibly remove once verified passing in reference works
+                cleanupCaseDataBeforeSubmittingToCcd(caseDetails);
             }
         }
 
@@ -151,5 +153,15 @@ public class NotificationsController implements BaseController {
     private boolean isSolicitorAgreedToReceiveEmails(Map<String, Object> mapOfCaseData, String solicitorAgreeToReceiveEmails) {
         return YES_VALUE.equalsIgnoreCase(Objects.toString(mapOfCaseData
                 .get(solicitorAgreeToReceiveEmails)));
+    }
+
+    private void cleanupCaseDataBeforeSubmittingToCcd(CaseDetails caseDetails) {
+        // Must remove any added case data as CCD will return an error
+        caseDetails.getData().remove("caseNumber");
+        caseDetails.getData().remove("reference");
+        caseDetails.getData().remove("addressee");
+        caseDetails.getData().remove("letterDate");
+        caseDetails.getData().remove("applicantName");
+        caseDetails.getData().remove("respondentName");
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/NotificationsController.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/NotificationsController.java
@@ -3,30 +3,42 @@ package uk.gov.hmcts.reform.finrem.caseorchestration.controllers;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.reform.ccd.client.model.AboutToStartOrSubmitCallbackResponse;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CaseDocument;
+import uk.gov.hmcts.reform.finrem.caseorchestration.service.AssignedToJudgeDocumentService;
+import uk.gov.hmcts.reform.finrem.caseorchestration.service.BulkPrintService;
+import uk.gov.hmcts.reform.finrem.caseorchestration.service.FeatureToggleService;
 import uk.gov.hmcts.reform.finrem.caseorchestration.service.NotificationService;
 
 import java.util.Map;
 import java.util.Objects;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.AUTHORIZATION_HEADER;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.YES_VALUE;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.controllers.BaseController.isConsentedApplication;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.ASSIGNED_TO_JUDGE_NOTIFICATION_LETTER;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_AGREE_TO_RECEIVE_EMAILS;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.isPaperApplication;
 
 @RestController
 @Slf4j
+@RequiredArgsConstructor
 public class NotificationsController implements BaseController {
 
-    @Autowired
-    private NotificationService notificationService;
+    private final NotificationService notificationService;
+    private final BulkPrintService bulkPrintService;
+    private final FeatureToggleService featureToggleService;
+    private final AssignedToJudgeDocumentService assignedToJudgeDocumentService;
 
     @PostMapping(value = "/case-orchestration/notify/hwf-successful", consumes = APPLICATION_JSON_VALUE)
     @ApiOperation(value = "send e-mail for HWF Successful.")
@@ -52,19 +64,36 @@ public class NotificationsController implements BaseController {
     }
 
     @PostMapping(value = "/case-orchestration/notify/assign-to-judge", consumes = APPLICATION_JSON_VALUE)
-    @ApiOperation(value = "send e-mail for case assigned to Judge Successful.")
+    @ApiOperation(value = "Notify solicitor when Judge assigned to case via email or letter")
     @ApiResponses(value = {
-            @ApiResponse(code = 204, message = "Case assigned to Judge e-mail sent successfully",
+            @ApiResponse(code = 204, message = "Case assigned to Judge notification sent successfully",
                     response = AboutToStartOrSubmitCallbackResponse.class)})
     public ResponseEntity<AboutToStartOrSubmitCallbackResponse> sendAssignToJudgeConfirmationEmail(
-            @RequestBody CallbackRequest callbackRequest) {
-        log.info("Received request to send email for Judge successfully assigned to case for Case ID: {}", callbackRequest.getCaseDetails().getId());
+        @RequestHeader(value = AUTHORIZATION_HEADER) String authToken,
+        @RequestBody CallbackRequest callbackRequest) {
+        log.info("Received request to notify solicitor for Judge successfully assigned to case for Case ID: {}",
+            callbackRequest.getCaseDetails().getId());
         validateCaseData(callbackRequest);
         Map<String, Object> caseData = callbackRequest.getCaseDetails().getData();
         if (isSolicitorAgreedToReceiveEmails(caseData, SOLICITOR_AGREE_TO_RECEIVE_EMAILS)) {
             log.info("Sending email notification to Solicitor for Judge successfully assigned to case");
             notificationService.sendAssignToJudgeConfirmationEmail(callbackRequest);
+        } else if (isConsentedApplication(caseData) && isPaperApplication(caseData)) {
+            if (featureToggleService.isAssignedToJudgeNotificationLetterEnabled()) {
+                log.info("isAssignedToJudgeNotificationLetterEnabled is toggled on");
+                log.info("Sending AssignedToJudge notification letter for bulk print");
+
+                CaseDetails caseDetails = callbackRequest.getCaseDetails();
+
+                // Generate PDF notification letter
+                CaseDocument assignedToJudgeNotificationLetter =
+                    assignedToJudgeDocumentService.generateAssignedToJudgeNotificationLetter(caseDetails, authToken);
+
+                // Send notification letter to Bulk Print
+                bulkPrintService.sendNotificationLetterForBulkPrint(assignedToJudgeNotificationLetter, caseDetails);
+            }
         }
+
         return ResponseEntity.ok(AboutToStartOrSubmitCallbackResponse.builder().data(caseData).build());
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/NotificationsController.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/NotificationsController.java
@@ -163,5 +163,6 @@ public class NotificationsController implements BaseController {
         caseDetails.getData().remove("letterDate");
         caseDetails.getData().remove("applicantName");
         caseDetails.getData().remove("respondentName");
+        caseDetails.getData().remove("ctscContactDetails");
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/CCDConfigConstant.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/CCDConfigConstant.java
@@ -57,7 +57,6 @@ public class CCDConfigConstant {
     public static final String AMENDED_CONSENT_ORDER_COLLECTION = "amendedConsentOrderCollection";
     public static final String ORDER_REFUSAL_COLLECTION = "orderRefusalCollection";
     public static final String ORDER_REFUSAL_PREVIEW_COLLECTION = "orderRefusalPreviewDocument";
-    public static final String ASSIGNED_TO_JUDGE_NOTIFICATION_LETTER = "assignedToJudgeNotificationLetter";
 
     public static final String FR_RESPOND_TO_ORDER = "FR_respondToOrder";
     public static final String FR_AMENDED_CONSENT_ORDER = "FR_amendedConsentOrder";

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/CCDConfigConstant.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/CCDConfigConstant.java
@@ -57,6 +57,7 @@ public class CCDConfigConstant {
     public static final String AMENDED_CONSENT_ORDER_COLLECTION = "amendedConsentOrderCollection";
     public static final String ORDER_REFUSAL_COLLECTION = "orderRefusalCollection";
     public static final String ORDER_REFUSAL_PREVIEW_COLLECTION = "orderRefusalPreviewDocument";
+    public static final String ASSIGNED_TO_JUDGE_NOTIFICATION_LETTER = "assignedToJudgeNotificationLetter";
 
     public static final String FR_RESPOND_TO_ORDER = "FR_respondToOrder";
     public static final String FR_AMENDED_CONSENT_ORDER = "FR_amendedConsentOrder";

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/document/CtscContactDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/document/CtscContactDetails.java
@@ -1,0 +1,38 @@
+package uk.gov.hmcts.reform.finrem.caseorchestration.model.document;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Builder
+@EqualsAndHashCode
+public class CtscContactDetails {
+
+    @JsonProperty("serviceCentre")
+    private String serviceCentre;
+
+    @JsonProperty("careOf")
+    private String careOf;
+
+    @JsonProperty("poBox")
+    private String poBox;
+
+    @JsonProperty("town")
+    private String town;
+
+    @JsonProperty("postcode")
+    private String postcode;
+
+    @JsonProperty("emailAddress")
+    private String emailAddress;
+
+    @JsonProperty("phoneNumber")
+    private String phoneNumber;
+
+    @JsonProperty("openingHours")
+    private String openingHours;
+}

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/AbstractDocumentService.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/AbstractDocumentService.java
@@ -34,7 +34,7 @@ public abstract class AbstractDocumentService {
 
         Map<String, Object> caseDetailsMap = Collections.singletonMap(DOCUMENT_CASE_DETAILS_JSON_KEY, caseDetails);
 
-        Document miniFormA =
+        Document generatedPdf =
                 documentClient.generatePdf(
                         DocumentGenerationRequest.builder()
                                 .template(template)
@@ -43,7 +43,7 @@ public abstract class AbstractDocumentService {
                                 .build(),
                         authorisationToken);
 
-        return caseDocument(miniFormA);
+        return caseDocument(generatedPdf);
     }
 
     UUID bulkPrint(BulkPrintRequest bulkPrintRequest) {

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/AbstractDocumentService.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/AbstractDocumentService.java
@@ -92,7 +92,6 @@ public abstract class AbstractDocumentService {
 
     CtscContactDetails buildCtscContactDetails() {
 
-        // move this values to application.properties
         return CtscContactDetails.builder()
             .serviceCentre("Courts and Tribunals Service Centre")
             .careOf("c/o HMCTS Digital Financial Remedy")

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/AbstractDocumentService.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/AbstractDocumentService.java
@@ -1,26 +1,45 @@
 package uk.gov.hmcts.reform.finrem.caseorchestration.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.finrem.caseorchestration.client.DocumentClient;
 import uk.gov.hmcts.reform.finrem.caseorchestration.config.DocumentConfiguration;
+import uk.gov.hmcts.reform.finrem.caseorchestration.helper.LetterAddressHelper;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CaseDocument;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.document.Addressee;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.document.BulkPrintRequest;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.document.CtscContactDetails;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.document.Document;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.document.DocumentGenerationRequest;
 
 import java.io.IOException;
+import java.time.LocalDate;
 import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
 
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APPLICANT_ADDRESS;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APPLICANT_FIRST_MIDDLE_NAME;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APPLICANT_LAST_NAME;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APP_RESPONDENT_FIRST_MIDDLE_NAME;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APP_RESPONDENT_LAST_NAME;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APP_SOLICITOR_ADDRESS_CCD_FIELD;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_NAME;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_REFERENCE;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.addressLineOneAndPostCodeAreBothNotEmpty;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.isApplicantRepresentedByASolicitor;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.nullToEmpty;
+
+@Slf4j
 public abstract class AbstractDocumentService {
     private static final String DOCUMENT_CASE_DETAILS_JSON_KEY = "caseDetails";
 
     protected final DocumentConfiguration config;
     private final DocumentClient documentClient;
     protected final ObjectMapper objectMapper;
+
+    private LetterAddressHelper letterAddressHelper = new LetterAddressHelper();
 
     public AbstractDocumentService(DocumentClient documentClient,
                                    DocumentConfiguration config,
@@ -88,6 +107,51 @@ public abstract class AbstractDocumentService {
         } catch (IOException e) {
             throw new IllegalStateException();
         }
+    }
+
+    CaseDetails prepareNotificationLetter(CaseDetails caseDetails) {
+        Map<String, Object> caseData = caseDetails.getData();
+        Map addressToSendTo;
+
+        String ccdNumber = nullToEmpty((caseDetails.getId()));
+        String reference = "";
+        String addresseeName;
+        String applicantName = nullToEmpty((caseData.get(APPLICANT_FIRST_MIDDLE_NAME)))
+            + " " + nullToEmpty((caseData.get(APPLICANT_LAST_NAME)));
+        String respondentName = nullToEmpty((caseData.get(APP_RESPONDENT_FIRST_MIDDLE_NAME)))
+            + " " + nullToEmpty((caseData.get(APP_RESPONDENT_LAST_NAME)));
+
+        if (isApplicantRepresentedByASolicitor(caseData)) {
+            log.info("Applicant is represented by a solicitor");
+            reference = nullToEmpty((caseData.get(SOLICITOR_REFERENCE)));
+            addresseeName = nullToEmpty((caseData.get(SOLICITOR_NAME)));
+            addressToSendTo = (Map) caseData.get(APP_SOLICITOR_ADDRESS_CCD_FIELD);
+        } else {
+            log.info("Applicant is not represented by a solicitor");
+            addresseeName = applicantName;
+            addressToSendTo = (Map) caseData.get(APPLICANT_ADDRESS);
+        }
+
+        if (addressLineOneAndPostCodeAreBothNotEmpty(addressToSendTo)) {
+            Addressee addressee = Addressee.builder()
+                .name(addresseeName)
+                .formattedAddress(letterAddressHelper.formatAddressForLetterPrinting(addressToSendTo))
+                .build();
+
+            caseData.put("caseNumber", ccdNumber);
+            caseData.put("reference", reference);
+            caseData.put("addressee",  addressee);
+            caseData.put("letterDate", String.valueOf(LocalDate.now()));
+            caseData.put("applicantName", applicantName);
+            caseData.put("respondentName", respondentName);
+            caseData.put("ctscContactDetails", buildCtscContactDetails());
+
+        } else {
+            log.info("Failed to generate Notification Letter as not all required address details were present");
+            throw new IllegalArgumentException(
+                "Mandatory data missing from address when trying to generate Assigned To Judge Notification Letter");
+        }
+        return caseDetails;
     }
 
     CtscContactDetails buildCtscContactDetails() {

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/AbstractDocumentService.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/AbstractDocumentService.java
@@ -19,6 +19,14 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
 
+import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.CTSC_CARE_OF;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.CTSC_EMAIL_ADDRESS;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.CTSC_OPENING_HOURS;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.CTSC_PHONE_NUMBER;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.CTSC_POSTCODE;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.CTSC_PO_BOX;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.CTSC_SERVICE_CENTRE;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.CTSC_TOWN;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APPLICANT_ADDRESS;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APPLICANT_FIRST_MIDDLE_NAME;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APPLICANT_LAST_NAME;
@@ -28,6 +36,7 @@ import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigCo
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_NAME;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_REFERENCE;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.addressLineOneAndPostCodeAreBothNotEmpty;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.buildFullName;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.isApplicantRepresentedByASolicitor;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.nullToEmpty;
 
@@ -116,10 +125,8 @@ public abstract class AbstractDocumentService {
         String ccdNumber = nullToEmpty((caseDetails.getId()));
         String reference = "";
         String addresseeName;
-        String applicantName = nullToEmpty((caseData.get(APPLICANT_FIRST_MIDDLE_NAME)))
-            + " " + nullToEmpty((caseData.get(APPLICANT_LAST_NAME)));
-        String respondentName = nullToEmpty((caseData.get(APP_RESPONDENT_FIRST_MIDDLE_NAME)))
-            + " " + nullToEmpty((caseData.get(APP_RESPONDENT_LAST_NAME)));
+        String applicantName = buildFullName(caseData, APPLICANT_FIRST_MIDDLE_NAME, APPLICANT_LAST_NAME);
+        String respondentName =  buildFullName(caseData, APP_RESPONDENT_FIRST_MIDDLE_NAME, APP_RESPONDENT_LAST_NAME);
 
         if (isApplicantRepresentedByASolicitor(caseData)) {
             log.info("Applicant is represented by a solicitor");
@@ -157,14 +164,14 @@ public abstract class AbstractDocumentService {
     CtscContactDetails buildCtscContactDetails() {
 
         return CtscContactDetails.builder()
-            .serviceCentre("Courts and Tribunals Service Centre")
-            .careOf("c/o HMCTS Digital Financial Remedy")
-            .poBox("12746")
-            .town("HARLOW")
-            .postcode("CM20 9QZ")
-            .emailAddress("HMCTSFinancialRemedy@justice.gov.uk")
-            .phoneNumber("0300 303 0642")
-            .openingHours("from 8.30am to 5pm")
+            .serviceCentre(CTSC_SERVICE_CENTRE)
+            .careOf(CTSC_CARE_OF)
+            .poBox(CTSC_PO_BOX)
+            .town(CTSC_TOWN)
+            .postcode(CTSC_POSTCODE)
+            .emailAddress(CTSC_EMAIL_ADDRESS)
+            .phoneNumber(CTSC_PHONE_NUMBER)
+            .openingHours(CTSC_OPENING_HOURS)
             .build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/AbstractDocumentService.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/AbstractDocumentService.java
@@ -6,6 +6,7 @@ import uk.gov.hmcts.reform.finrem.caseorchestration.client.DocumentClient;
 import uk.gov.hmcts.reform.finrem.caseorchestration.config.DocumentConfiguration;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CaseDocument;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.document.BulkPrintRequest;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.document.CtscContactDetails;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.document.Document;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.document.DocumentGenerationRequest;
 
@@ -87,5 +88,20 @@ public abstract class AbstractDocumentService {
         } catch (IOException e) {
             throw new IllegalStateException();
         }
+    }
+
+    CtscContactDetails buildCtscContactDetails() {
+
+        // move this values to application.properties
+        return CtscContactDetails.builder()
+            .serviceCentre("Courts and Tribunals Service Centre")
+            .careOf("c/o HMCTS Digital Financial Remedy")
+            .poBox("12746")
+            .town("HARLOW")
+            .postcode("CM20 9QZ")
+            .emailAddress("HMCTSFinancialRemedy@justice.gov.uk")
+            .phoneNumber("0300 303 0642")
+            .openingHours("from 8.30am to 5pm")
+            .build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/AssignedToJudgeDocumentService.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/AssignedToJudgeDocumentService.java
@@ -1,0 +1,115 @@
+package uk.gov.hmcts.reform.finrem.caseorchestration.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.finrem.caseorchestration.client.DocumentClient;
+import uk.gov.hmcts.reform.finrem.caseorchestration.config.DocumentConfiguration;
+import uk.gov.hmcts.reform.finrem.caseorchestration.helper.LetterAddressHelper;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CaseDocument;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.PensionCollectionData;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.document.Addressee;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.stream.Collectors.toList;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APPLICANT_ADDRESS;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APPLICANT_FIRST_MIDDLE_NAME;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APPLICANT_LAST_NAME;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APP_RESPONDENT_FIRST_MIDDLE_NAME;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APP_RESPONDENT_LAST_NAME;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APP_SOLICITOR_ADDRESS_CCD_FIELD;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_NAME;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_REFERENCE;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.addressLineOneAndPostCodeAreBothNotEmpty;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.isApplicantRepresentedByASolicitor;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.nullToEmpty;
+
+@Service
+@Slf4j
+public class AssignedToJudgeDocumentService extends AbstractDocumentService {
+
+    private LetterAddressHelper letterAddressHelper;
+
+    @Autowired
+    public AssignedToJudgeDocumentService(DocumentClient documentClient, DocumentConfiguration config,
+                                          ObjectMapper objectMapper, LetterAddressHelper letterAddressHelper) {
+        super(documentClient, config, objectMapper);
+        this.letterAddressHelper = letterAddressHelper;
+    }
+
+    public CaseDocument generateAssignedToJudgeNotificationLetter(CaseDetails caseDetails, String authToken) {
+        log.info("Generating Assigned To Judge Notification Letter {} from {} for bulk print",
+                config.getApplicationAssignedToJudgeFileName(),
+                config.getApplicationAssignedToJudgeTemplate());
+
+        prepareAssignedToJudgeNotificationLetter(caseDetails);
+
+        CaseDocument generatedAssignedToJudgeNotificationLetter =
+            generateDocument(authToken, caseDetails,
+                config.getApplicationAssignedToJudgeTemplate(),
+                config.getApplicationAssignedToJudgeFileName());
+
+        cleanupCaseDataBeforeSubmittingToCcd(caseDetails);
+
+        return generatedAssignedToJudgeNotificationLetter;
+    }
+
+    private void prepareAssignedToJudgeNotificationLetter(CaseDetails caseDetails) {
+        Map<String, Object> caseData = caseDetails.getData();
+        Map addressToSendTo;
+
+        String ccdNumber = nullToEmpty((caseDetails.getId()));
+        String reference = "";
+        String addresseeName;
+        String applicantName = nullToEmpty((caseData.get(APPLICANT_FIRST_MIDDLE_NAME)))
+                + " " + nullToEmpty((caseData.get(APPLICANT_LAST_NAME)));
+        String respondentName = nullToEmpty((caseData.get(APP_RESPONDENT_FIRST_MIDDLE_NAME)))
+                + " " + nullToEmpty((caseData.get(APP_RESPONDENT_LAST_NAME)));
+
+        if (isApplicantRepresentedByASolicitor(caseData)) {
+            log.info("Applicant is represented by a solicitor");
+            reference = nullToEmpty((caseData.get(SOLICITOR_REFERENCE)));
+            addresseeName = nullToEmpty((caseData.get(SOLICITOR_NAME)));
+            addressToSendTo = (Map) caseData.get(APP_SOLICITOR_ADDRESS_CCD_FIELD);
+        } else {
+            log.info("Applicant is not represented by a solicitor");
+            addresseeName = applicantName;
+            addressToSendTo = (Map) caseData.get(APPLICANT_ADDRESS);
+        }
+
+        if (addressLineOneAndPostCodeAreBothNotEmpty(addressToSendTo)) {
+            Addressee addressee = Addressee.builder()
+                    .name(addresseeName)
+                    .formattedAddress(letterAddressHelper.formatAddressForLetterPrinting(addressToSendTo))
+                    .build();
+
+            caseData.put("caseNumber", ccdNumber);
+            caseData.put("reference", reference);
+            caseData.put("addressee",  addressee);
+            caseData.put("letterDate", String.valueOf(LocalDate.now()));
+            caseData.put("applicantName", applicantName);
+            caseData.put("respondentName", respondentName);
+
+        } else {
+            log.info("Failed to generate Assigned To Judge Notification Letter as not all required address details were present");
+            throw new IllegalArgumentException(
+                    "Mandatory data missing from address when trying to generate Assigned To Judge Notification Letter");
+        }
+    }
+
+    private void cleanupCaseDataBeforeSubmittingToCcd(CaseDetails caseDetails) {
+        // Must remove any added case data as CCD will return an error
+        caseDetails.getData().remove("caseNumber");
+        caseDetails.getData().remove("reference");
+        caseDetails.getData().remove("addressee");
+        caseDetails.getData().remove("letterDate");
+        caseDetails.getData().remove("applicantName");
+        caseDetails.getData().remove("respondentName");
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/AssignedToJudgeDocumentService.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/AssignedToJudgeDocumentService.java
@@ -7,36 +7,16 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.finrem.caseorchestration.client.DocumentClient;
 import uk.gov.hmcts.reform.finrem.caseorchestration.config.DocumentConfiguration;
-import uk.gov.hmcts.reform.finrem.caseorchestration.helper.LetterAddressHelper;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CaseDocument;
-import uk.gov.hmcts.reform.finrem.caseorchestration.model.document.Addressee;
-
-import java.time.LocalDate;
-import java.util.Map;
-
-import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APPLICANT_ADDRESS;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APPLICANT_FIRST_MIDDLE_NAME;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APPLICANT_LAST_NAME;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APP_RESPONDENT_FIRST_MIDDLE_NAME;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APP_RESPONDENT_LAST_NAME;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APP_SOLICITOR_ADDRESS_CCD_FIELD;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_NAME;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_REFERENCE;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.addressLineOneAndPostCodeAreBothNotEmpty;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.isApplicantRepresentedByASolicitor;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.nullToEmpty;
 
 @Service
 @Slf4j
 public class AssignedToJudgeDocumentService extends AbstractDocumentService {
 
-    private LetterAddressHelper letterAddressHelper;
-
     @Autowired
     public AssignedToJudgeDocumentService(DocumentClient documentClient, DocumentConfiguration config,
-                                          ObjectMapper objectMapper, LetterAddressHelper letterAddressHelper) {
+                                          ObjectMapper objectMapper) {
         super(documentClient, config, objectMapper);
-        this.letterAddressHelper = letterAddressHelper;
     }
 
     public CaseDocument generateAssignedToJudgeNotificationLetter(CaseDetails caseDetails, String authToken) {
@@ -44,61 +24,15 @@ public class AssignedToJudgeDocumentService extends AbstractDocumentService {
                 config.getApplicationAssignedToJudgeFileName(),
                 config.getApplicationAssignedToJudgeTemplate());
 
-        CaseDetails caseDetailsForBulkPrint = prepareAssignedToJudgeNotificationLetter(caseDetails);
-
-        // Will remove once verified
-        log.info("Generating Assigned To Judge Notification Letter with case data: {}", caseDetails.getData());
+        CaseDetails caseDetailsForBulkPrint = prepareNotificationLetter(caseDetails);
 
         CaseDocument generatedAssignedToJudgeNotificationLetter =
             generateDocument(authToken, caseDetailsForBulkPrint,
                 config.getApplicationAssignedToJudgeTemplate(),
                 config.getApplicationAssignedToJudgeFileName());
 
+        log.info("Generated Assigned To Judge Notification Letter: {}", generatedAssignedToJudgeNotificationLetter);
+
         return generatedAssignedToJudgeNotificationLetter;
-    }
-
-    private CaseDetails prepareAssignedToJudgeNotificationLetter(CaseDetails caseDetails) {
-        Map<String, Object> caseData = caseDetails.getData();
-        Map addressToSendTo;
-
-        String ccdNumber = nullToEmpty((caseDetails.getId()));
-        String reference = "";
-        String addresseeName;
-        String applicantName = nullToEmpty((caseData.get(APPLICANT_FIRST_MIDDLE_NAME)))
-                + " " + nullToEmpty((caseData.get(APPLICANT_LAST_NAME)));
-        String respondentName = nullToEmpty((caseData.get(APP_RESPONDENT_FIRST_MIDDLE_NAME)))
-                + " " + nullToEmpty((caseData.get(APP_RESPONDENT_LAST_NAME)));
-
-        if (isApplicantRepresentedByASolicitor(caseData)) {
-            log.info("Applicant is represented by a solicitor");
-            reference = nullToEmpty((caseData.get(SOLICITOR_REFERENCE)));
-            addresseeName = nullToEmpty((caseData.get(SOLICITOR_NAME)));
-            addressToSendTo = (Map) caseData.get(APP_SOLICITOR_ADDRESS_CCD_FIELD);
-        } else {
-            log.info("Applicant is not represented by a solicitor");
-            addresseeName = applicantName;
-            addressToSendTo = (Map) caseData.get(APPLICANT_ADDRESS);
-        }
-
-        if (addressLineOneAndPostCodeAreBothNotEmpty(addressToSendTo)) {
-            Addressee addressee = Addressee.builder()
-                    .name(addresseeName)
-                    .formattedAddress(letterAddressHelper.formatAddressForLetterPrinting(addressToSendTo))
-                    .build();
-
-            caseData.put("caseNumber", ccdNumber);
-            caseData.put("reference", reference);
-            caseData.put("addressee",  addressee);
-            caseData.put("letterDate", String.valueOf(LocalDate.now()));
-            caseData.put("applicantName", applicantName);
-            caseData.put("respondentName", respondentName);
-            caseData.put("ctscContactDetails", buildCtscContactDetails());
-
-        } else {
-            log.info("Failed to generate Assigned To Judge Notification Letter as not all required address details were present");
-            throw new IllegalArgumentException(
-                    "Mandatory data missing from address when trying to generate Assigned To Judge Notification Letter");
-        }
-        return caseDetails;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/BulkPrintService.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/BulkPrintService.java
@@ -42,6 +42,24 @@ public class BulkPrintService extends AbstractDocumentService {
         this.featureToggleService = featureToggleService;
     }
 
+    public void sendNotificationLetterForBulkPrint(final CaseDocument notificationLetter, final CaseDetails caseDetails) {
+        List<BulkPrintDocument> bulkPrintDocuments = new ArrayList<>();
+        log.info("Sending Notification Letter for Bulk Print.");
+
+        bulkPrintDocuments.add(
+            BulkPrintDocument.builder().binaryFileUrl(notificationLetter.getDocumentBinaryUrl()).build());
+
+        log.info("Notification letter sent to Bulk Print: {}", bulkPrintDocuments);
+
+        bulkPrint(
+            BulkPrintRequest.builder()
+                .caseId(caseDetails.getId().toString())
+                .letterType("FINANCIAL_REMEDY_PACK")
+                .bulkPrintDocuments(bulkPrintDocuments)
+                .build());
+    }
+
+
     public UUID sendOrdersForBulkPrint(final CaseDocument coverSheet, final CaseDetails caseDetails) {
         List<BulkPrintDocument> bulkPrintDocuments = new ArrayList<>();
         log.info("Sending Orders for Bulk Print.");

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/BulkPrintService.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/BulkPrintService.java
@@ -42,20 +42,20 @@ public class BulkPrintService extends AbstractDocumentService {
         this.featureToggleService = featureToggleService;
     }
 
-    public void sendNotificationLetterForBulkPrint(final CaseDocument notificationLetter, final CaseDetails caseDetails) {
-        List<BulkPrintDocument> bulkPrintDocuments = new ArrayList<>();
+    public UUID sendNotificationLetterForBulkPrint(final CaseDocument notificationLetter, final CaseDetails caseDetails) {
+        List<BulkPrintDocument> notificationLetterList = new ArrayList<>();
         log.info("Sending Notification Letter for Bulk Print.");
 
-        bulkPrintDocuments.add(
+        notificationLetterList.add(
             BulkPrintDocument.builder().binaryFileUrl(notificationLetter.getDocumentBinaryUrl()).build());
 
-        log.info("Notification letter sent to Bulk Print: {}", bulkPrintDocuments);
+        log.info("Notification letter sent to Bulk Print: {}", notificationLetterList);
 
-        bulkPrint(
+        return bulkPrint(
             BulkPrintRequest.builder()
                 .caseId(caseDetails.getId().toString())
                 .letterType("FINANCIAL_REMEDY_PACK")
-                .bulkPrintDocuments(bulkPrintDocuments)
+                .bulkPrintDocuments(notificationLetterList)
                 .build());
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/CommonFunction.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/CommonFunction.java
@@ -41,11 +41,11 @@ public class CommonFunction {
             && StringUtils.isNotBlank((String) address.get(POSTCODE));
     }
 
-    public static String buildFullName(Map<String, Object> caseData, String applicantFirstMiddleName, String applicantLastName) {
+    public static String buildFullName(Map<String, Object> caseData, String firstMiddleName, String lastName) {
         return (
-            nullToEmpty((caseData.get(applicantFirstMiddleName))).trim()
+            nullToEmpty((caseData.get(firstMiddleName))).trim()
                 + " "
-                + nullToEmpty((caseData.get(applicantLastName))).trim()
+                + nullToEmpty((caseData.get(lastName))).trim()
         ).trim();
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/ConsentOrderApprovedDocumentService.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/ConsentOrderApprovedDocumentService.java
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.finrem.caseorchestration.client.DocumentClient;
 import uk.gov.hmcts.reform.finrem.caseorchestration.config.DocumentConfiguration;
-import uk.gov.hmcts.reform.finrem.caseorchestration.helper.LetterAddressHelper;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CaseDocument;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.PensionCollectionData;
 
@@ -20,13 +19,10 @@ import static java.util.stream.Collectors.toList;
 @Slf4j
 public class ConsentOrderApprovedDocumentService extends AbstractDocumentService {
 
-    private LetterAddressHelper letterAddressHelper;
-
     @Autowired
     public ConsentOrderApprovedDocumentService(DocumentClient documentClient, DocumentConfiguration config,
-                                               ObjectMapper objectMapper, LetterAddressHelper letterAddressHelper) {
+                                               ObjectMapper objectMapper) {
         super(documentClient, config, objectMapper);
-        this.letterAddressHelper = letterAddressHelper;
     }
 
     public CaseDocument generateApprovedConsentOrderLetter(CaseDetails caseDetails, String authToken) {

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/ConsentOrderApprovedDocumentService.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/ConsentOrderApprovedDocumentService.java
@@ -10,25 +10,11 @@ import uk.gov.hmcts.reform.finrem.caseorchestration.config.DocumentConfiguration
 import uk.gov.hmcts.reform.finrem.caseorchestration.helper.LetterAddressHelper;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CaseDocument;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.PensionCollectionData;
-import uk.gov.hmcts.reform.finrem.caseorchestration.model.document.Addressee;
 
 import java.io.IOException;
-import java.time.LocalDate;
 import java.util.List;
-import java.util.Map;
 
 import static java.util.stream.Collectors.toList;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APPLICANT_ADDRESS;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APPLICANT_FIRST_MIDDLE_NAME;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APPLICANT_LAST_NAME;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APP_RESPONDENT_FIRST_MIDDLE_NAME;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APP_RESPONDENT_LAST_NAME;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APP_SOLICITOR_ADDRESS_CCD_FIELD;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_NAME;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_REFERENCE;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.addressLineOneAndPostCodeAreBothNotEmpty;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.isApplicantRepresentedByASolicitor;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.nullToEmpty;
 
 @Service
 @Slf4j
@@ -58,56 +44,16 @@ public class ConsentOrderApprovedDocumentService extends AbstractDocumentService
                 config.getApprovedConsentOrderFileName(),
                 config.getApprovedConsentOrderTemplate());
 
-        prepareApprovedConsentOrderNotificationLetter(caseDetails);
+        CaseDetails caseDetailsForBulkPrint = prepareNotificationLetter(caseDetails);
 
-        return generateDocument(authToken, caseDetails,
+        CaseDocument generatedApprovedConsentOrderNotificationletter = generateDocument(authToken, caseDetailsForBulkPrint,
                 config.getApprovedConsentOrderNotificationTemplate(),
                 config.getApprovedConsentOrderNotificationFileName());
+
+        log.info("Generated Approved Consent Order Notification Letter: {}", generatedApprovedConsentOrderNotificationletter);
+
+        return generatedApprovedConsentOrderNotificationletter;
     }
-
-    private void prepareApprovedConsentOrderNotificationLetter(CaseDetails caseDetails) {
-        Map<String, Object> caseData = caseDetails.getData();
-        Map addressToSendTo;
-
-        String ccdNumber = nullToEmpty((caseDetails.getId()));
-        String reference = "";
-        String addresseeName;
-        String applicantName = nullToEmpty((caseData.get(APPLICANT_FIRST_MIDDLE_NAME)))
-                + " " + nullToEmpty((caseData.get(APPLICANT_LAST_NAME)));
-        String respondentName = nullToEmpty((caseData.get(APP_RESPONDENT_FIRST_MIDDLE_NAME)))
-                + " " + nullToEmpty((caseData.get(APP_RESPONDENT_LAST_NAME)));
-
-        if (isApplicantRepresentedByASolicitor(caseData)) {
-            log.info("Applicant is represented by a solicitor");
-            reference = nullToEmpty((caseData.get(SOLICITOR_REFERENCE)));
-            addresseeName = nullToEmpty((caseData.get(SOLICITOR_NAME)));
-            addressToSendTo = (Map) caseData.get(APP_SOLICITOR_ADDRESS_CCD_FIELD);
-        } else {
-            log.info("Applicant is not represented by a solicitor");
-            addresseeName = applicantName;
-            addressToSendTo = (Map) caseData.get(APPLICANT_ADDRESS);
-        }
-
-        if (addressLineOneAndPostCodeAreBothNotEmpty(addressToSendTo)) {
-            Addressee addressee = Addressee.builder()
-                    .name(addresseeName)
-                    .formattedAddress(letterAddressHelper.formatAddressForLetterPrinting(addressToSendTo))
-                    .build();
-
-            caseData.put("caseNumber", ccdNumber);
-            caseData.put("reference", reference);
-            caseData.put("addressee",  addressee);
-            caseData.put("letterDate", String.valueOf(LocalDate.now()));
-            caseData.put("applicantName", applicantName);
-            caseData.put("respondentName", respondentName);
-
-        } else {
-            log.info("Failed to generate Approved Consent Order Notification Letter as not all required address details were present");
-            throw new IllegalArgumentException(
-                    "Mandatory data missing from address when trying to generate Approved Consent Order Notification Letter");
-        }
-    }
-
 
     public CaseDocument annexStampDocument(CaseDocument document, String authToken) {
         return super.annexStampDocument(document, authToken);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -94,6 +94,9 @@ document.approvedConsentOrderFileName=ApprovedConsentOrderLetter.pdf
 document.approvedConsentOrderNotificationTemplate=FL-FRM-LET-ENG-00095.docx
 document.approvedConsentOrderNotificationFileName=ApprovedConsentOrderNotificationLetter.pdf
 
+document.assignedToJudgeNotificationTemplate=FL-FRM-LET-ENG-00318.docx
+document.assignedToJudgeNotificationFileName=AssignedToJudgeNotificationLetter.pdf
+
 document.bulkPrintTemplate=FL-FRM-LET-ENG-00070.docx
 document.bulkPrintFileName=BulkPrintCoverSheet.pdf
 

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/BaseServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/BaseServiceTest.java
@@ -2,10 +2,35 @@ package uk.gov.hmcts.reform.finrem.caseorchestration;
 
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.document.CtscContactDetails;
+
+import static org.junit.Assert.assertEquals;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.CTSC_CARE_OF;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.CTSC_EMAIL_ADDRESS;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.CTSC_OPENING_HOURS;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.CTSC_PHONE_NUMBER;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.CTSC_POSTCODE;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.CTSC_PO_BOX;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.CTSC_SERVICE_CENTRE;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.CTSC_TOWN;
 
 @TestPropertySource(locations = "/application.properties")
 @DirtiesContext
 public abstract class BaseServiceTest extends BaseTest {
 
+    protected void verifyCtscContactDetails(CaseDetails caseDetails) {
+        CtscContactDetails ctscContactDetails = CtscContactDetails.builder()
+            .serviceCentre(CTSC_SERVICE_CENTRE)
+            .careOf(CTSC_CARE_OF)
+            .poBox(CTSC_PO_BOX)
+            .town(CTSC_TOWN)
+            .postcode(CTSC_POSTCODE)
+            .emailAddress(CTSC_EMAIL_ADDRESS)
+            .phoneNumber(CTSC_PHONE_NUMBER)
+            .openingHours(CTSC_OPENING_HOURS)
+            .build();
 
+        assertEquals(ctscContactDetails, caseDetails.getData().get("ctscContactDetails"));
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/SetUpUtils.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/SetUpUtils.java
@@ -148,9 +148,9 @@ public class SetUpUtils {
         return document;
     }
 
-    public static void doCaseDocumentAssert(CaseDocument result) {
-        assertThat(result.getDocumentFilename(), is(FILE_NAME));
-        assertThat(result.getDocumentUrl(), is(DOC_URL));
-        assertThat(result.getDocumentBinaryUrl(), is(BINARY_URL));
+    public static void assertCaseDocument(CaseDocument caseDocument) {
+        assertThat(caseDocument.getDocumentFilename(), is(FILE_NAME));
+        assertThat(caseDocument.getDocumentUrl(), is(DOC_URL));
+        assertThat(caseDocument.getDocumentBinaryUrl(), is(BINARY_URL));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/NotificationsControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/NotificationsControllerTest.java
@@ -16,6 +16,7 @@ import org.springframework.web.context.WebApplicationContext;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.finrem.caseorchestration.service.AssignedToJudgeDocumentService;
+import uk.gov.hmcts.reform.finrem.caseorchestration.service.BulkPrintService;
 import uk.gov.hmcts.reform.finrem.caseorchestration.service.FeatureToggleService;
 import uk.gov.hmcts.reform.finrem.caseorchestration.service.NotificationService;
 
@@ -54,6 +55,9 @@ public class NotificationsControllerTest {
 
     @MockBean
     private FeatureToggleService featureToggleService;
+
+    @MockBean
+    private BulkPrintService bulkPrintService;
 
     @MockBean
     private AssignedToJudgeDocumentService assignedToJudgeDocumentService;
@@ -101,6 +105,7 @@ public class NotificationsControllerTest {
         verify(notificationService, times(1))
                 .sendAssignToJudgeConfirmationEmail(any(CallbackRequest.class));
         verifyNoInteractions(assignedToJudgeDocumentService);
+        verifyNoInteractions(bulkPrintService);
     }
 
     @Test
@@ -128,6 +133,8 @@ public class NotificationsControllerTest {
 
         verify(assignedToJudgeDocumentService, times(1))
             .generateAssignedToJudgeNotificationLetter(any(CaseDetails.class),any());
+        verify(bulkPrintService, times(1))
+            .sendNotificationLetterForBulkPrint(any(),any());
         verifyNoInteractions(notificationService);
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/NotificationsControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/NotificationsControllerTest.java
@@ -150,6 +150,7 @@ public class NotificationsControllerTest {
             .andExpect(status().isOk());
 
         verifyNoInteractions(assignedToJudgeDocumentService);
+        verifyNoInteractions(bulkPrintService);
         verifyNoInteractions(notificationService);
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/integrationtest/NotificationsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/integrationtest/NotificationsTest.java
@@ -14,6 +14,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -35,7 +36,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
-import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -86,13 +86,13 @@ public class NotificationsTest {
         stubForNotification(NOTIFY_HWF_SUCCESSFUL_CONTEXT_PATH, HttpStatus.OK.value());
         webClient.perform(MockMvcRequestBuilders.post(HWF_SUCCESSFUL_URL)
             .header(AUTHORIZATION_HEADER, AUTH_TOKEN)
-            .contentType(APPLICATION_JSON_VALUE)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
             .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().isOk())
             .andDo(print())
             .andExpect(content().json(expectedCaseData()));
         verify(postRequestedFor(urlEqualTo(NOTIFY_HWF_SUCCESSFUL_CONTEXT_PATH))
-            .withHeader(CONTENT_TYPE, equalTo(APPLICATION_JSON_VALUE)));
+            .withHeader(CONTENT_TYPE, equalTo(MediaType.APPLICATION_JSON_VALUE)));
     }
 
     @Test
@@ -100,13 +100,13 @@ public class NotificationsTest {
         stubForNotification(NOTIFY_CONSENT_ORDER_MADE_CONTEXT_PATH, HttpStatus.OK.value());
         webClient.perform(MockMvcRequestBuilders.post(CONSENT_ORDER_MADE_URL)
             .header(AUTHORIZATION_HEADER, AUTH_TOKEN)
-            .contentType(APPLICATION_JSON_VALUE)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
             .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().isOk())
             .andDo(print())
             .andExpect(content().json(expectedCaseData()));
         verify(postRequestedFor(urlEqualTo(NOTIFY_CONSENT_ORDER_MADE_CONTEXT_PATH))
-            .withHeader(CONTENT_TYPE, equalTo(APPLICATION_JSON_VALUE)));
+            .withHeader(CONTENT_TYPE, equalTo(MediaType.APPLICATION_JSON_VALUE)));
     }
 
     @Test
@@ -114,13 +114,13 @@ public class NotificationsTest {
         stubForNotification(NOTIFY_CONSENT_ORDER_AVAILABLE_CONTEXT_PATH, HttpStatus.OK.value());
         webClient.perform(MockMvcRequestBuilders.post(CONSENT_ORDER_AVAILABLE_URL)
             .header(AUTHORIZATION_HEADER, AUTH_TOKEN)
-            .contentType(APPLICATION_JSON_VALUE)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
             .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().isOk())
             .andDo(print())
             .andExpect(content().json(expectedCaseData()));
         verify(postRequestedFor(urlEqualTo(NOTIFY_CONSENT_ORDER_AVAILABLE_CONTEXT_PATH))
-            .withHeader(CONTENT_TYPE, equalTo(APPLICATION_JSON_VALUE)));
+            .withHeader(CONTENT_TYPE, equalTo(MediaType.APPLICATION_JSON_VALUE)));
     }
 
     @Test
@@ -128,13 +128,13 @@ public class NotificationsTest {
         stubForNotification(NOTIFY_CONSENT_ORDER_NOT_APPROVED_CONTEXT_PATH, HttpStatus.OK.value());
         webClient.perform(MockMvcRequestBuilders.post(CONSENT_ORDER_NOT_APPROVED_URL)
             .header(AUTHORIZATION_HEADER, AUTH_TOKEN)
-            .contentType(APPLICATION_JSON_VALUE)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
             .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().isOk())
             .andDo(print())
             .andExpect(content().json(expectedCaseData()));
         verify(postRequestedFor(urlEqualTo(NOTIFY_CONSENT_ORDER_NOT_APPROVED_CONTEXT_PATH))
-            .withHeader(CONTENT_TYPE, equalTo(APPLICATION_JSON_VALUE)));
+            .withHeader(CONTENT_TYPE, equalTo(MediaType.APPLICATION_JSON_VALUE)));
     }
 
     @Test
@@ -142,13 +142,13 @@ public class NotificationsTest {
         stubForNotification(NOTIFY_ASSIGN_TO_JUDGE_CONTEXT_PATH, HttpStatus.OK.value());
         webClient.perform(MockMvcRequestBuilders.post(ASSIGNED_TO_JUDGE_URL)
             .header(AUTHORIZATION_HEADER, AUTH_TOKEN)
-            .contentType(APPLICATION_JSON_VALUE)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
             .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().isOk())
             .andDo(print())
             .andExpect(content().json(expectedCaseData()));
         verify(postRequestedFor(urlEqualTo(NOTIFY_ASSIGN_TO_JUDGE_CONTEXT_PATH))
-            .withHeader(CONTENT_TYPE, equalTo(APPLICATION_JSON_VALUE)));
+            .withHeader(CONTENT_TYPE, equalTo(MediaType.APPLICATION_JSON_VALUE)));
     }
 
     private String expectedCaseData() throws JsonProcessingException {
@@ -160,7 +160,7 @@ public class NotificationsTest {
     private void stubForNotification(String url, int value) {
         notificationService.stubFor(post(urlEqualTo(url))
             .withHeader(AUTHORIZATION, equalTo(AUTH_TOKEN))
-            .withHeader(CONTENT_TYPE, equalTo(APPLICATION_JSON_VALUE))
+            .withHeader(CONTENT_TYPE, equalTo(MediaType.APPLICATION_JSON_VALUE))
             .willReturn(aResponse().withStatus(value)));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/integrationtest/NotificationsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/integrationtest/NotificationsTest.java
@@ -14,7 +14,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -36,9 +35,11 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.AUTHORIZATION_HEADER;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.TestConstants.AUTH_TOKEN;
 
 @RunWith(SpringRunner.class)
@@ -84,65 +85,70 @@ public class NotificationsTest {
     public void notifyHwfSuccessful() throws Exception {
         stubForNotification(NOTIFY_HWF_SUCCESSFUL_CONTEXT_PATH, HttpStatus.OK.value());
         webClient.perform(MockMvcRequestBuilders.post(HWF_SUCCESSFUL_URL)
-            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .header(AUTHORIZATION_HEADER, AUTH_TOKEN)
+            .contentType(APPLICATION_JSON_VALUE)
             .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().isOk())
             .andDo(print())
             .andExpect(content().json(expectedCaseData()));
         verify(postRequestedFor(urlEqualTo(NOTIFY_HWF_SUCCESSFUL_CONTEXT_PATH))
-            .withHeader(CONTENT_TYPE, equalTo(MediaType.APPLICATION_JSON_VALUE)));
+            .withHeader(CONTENT_TYPE, equalTo(APPLICATION_JSON_VALUE)));
     }
 
     @Test
     public void notifyConsentOrderMade() throws Exception {
         stubForNotification(NOTIFY_CONSENT_ORDER_MADE_CONTEXT_PATH, HttpStatus.OK.value());
         webClient.perform(MockMvcRequestBuilders.post(CONSENT_ORDER_MADE_URL)
-            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .header(AUTHORIZATION_HEADER, AUTH_TOKEN)
+            .contentType(APPLICATION_JSON_VALUE)
             .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().isOk())
             .andDo(print())
             .andExpect(content().json(expectedCaseData()));
         verify(postRequestedFor(urlEqualTo(NOTIFY_CONSENT_ORDER_MADE_CONTEXT_PATH))
-            .withHeader(CONTENT_TYPE, equalTo(MediaType.APPLICATION_JSON_VALUE)));
+            .withHeader(CONTENT_TYPE, equalTo(APPLICATION_JSON_VALUE)));
     }
 
     @Test
     public void notifyConsentOrderAvailable() throws Exception {
         stubForNotification(NOTIFY_CONSENT_ORDER_AVAILABLE_CONTEXT_PATH, HttpStatus.OK.value());
         webClient.perform(MockMvcRequestBuilders.post(CONSENT_ORDER_AVAILABLE_URL)
-            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .header(AUTHORIZATION_HEADER, AUTH_TOKEN)
+            .contentType(APPLICATION_JSON_VALUE)
             .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().isOk())
             .andDo(print())
             .andExpect(content().json(expectedCaseData()));
         verify(postRequestedFor(urlEqualTo(NOTIFY_CONSENT_ORDER_AVAILABLE_CONTEXT_PATH))
-            .withHeader(CONTENT_TYPE, equalTo(MediaType.APPLICATION_JSON_VALUE)));
+            .withHeader(CONTENT_TYPE, equalTo(APPLICATION_JSON_VALUE)));
     }
 
     @Test
     public void notifyConsentOrderNotApproved() throws Exception {
         stubForNotification(NOTIFY_CONSENT_ORDER_NOT_APPROVED_CONTEXT_PATH, HttpStatus.OK.value());
         webClient.perform(MockMvcRequestBuilders.post(CONSENT_ORDER_NOT_APPROVED_URL)
-            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .header(AUTHORIZATION_HEADER, AUTH_TOKEN)
+            .contentType(APPLICATION_JSON_VALUE)
             .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().isOk())
             .andDo(print())
             .andExpect(content().json(expectedCaseData()));
         verify(postRequestedFor(urlEqualTo(NOTIFY_CONSENT_ORDER_NOT_APPROVED_CONTEXT_PATH))
-            .withHeader(CONTENT_TYPE, equalTo(MediaType.APPLICATION_JSON_VALUE)));
+            .withHeader(CONTENT_TYPE, equalTo(APPLICATION_JSON_VALUE)));
     }
 
     @Test
     public void notifyAssignToJudge() throws Exception {
         stubForNotification(NOTIFY_ASSIGN_TO_JUDGE_CONTEXT_PATH, HttpStatus.OK.value());
         webClient.perform(MockMvcRequestBuilders.post(ASSIGNED_TO_JUDGE_URL)
-            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .header(AUTHORIZATION_HEADER, AUTH_TOKEN)
+            .contentType(APPLICATION_JSON_VALUE)
             .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().isOk())
             .andDo(print())
             .andExpect(content().json(expectedCaseData()));
         verify(postRequestedFor(urlEqualTo(NOTIFY_ASSIGN_TO_JUDGE_CONTEXT_PATH))
-            .withHeader(CONTENT_TYPE, equalTo(MediaType.APPLICATION_JSON_VALUE)));
+            .withHeader(CONTENT_TYPE, equalTo(APPLICATION_JSON_VALUE)));
     }
 
     private String expectedCaseData() throws JsonProcessingException {
@@ -154,7 +160,7 @@ public class NotificationsTest {
     private void stubForNotification(String url, int value) {
         notificationService.stubFor(post(urlEqualTo(url))
             .withHeader(AUTHORIZATION, equalTo(AUTH_TOKEN))
-            .withHeader(CONTENT_TYPE, equalTo(MediaType.APPLICATION_JSON_VALUE))
+            .withHeader(CONTENT_TYPE, equalTo(APPLICATION_JSON_VALUE))
             .willReturn(aResponse().withStatus(value)));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/document/CtscContactDetailsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/document/CtscContactDetailsTest.java
@@ -1,0 +1,32 @@
+package uk.gov.hmcts.reform.finrem.caseorchestration.model.document;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class CtscContactDetailsTest {
+
+    @Test
+    public void checkAllStatusValues() {
+
+        CtscContactDetails ctscContactDetails = CtscContactDetails.builder()
+            .serviceCentre("Courts and Tribunals Service Centre")
+            .careOf("c/o HMCTS Digital Financial Remedy")
+            .poBox("12746")
+            .town("HARLOW")
+            .postcode("CM20 9QZ")
+            .emailAddress("HMCTSFinancialRemedy@justice.gov.uk")
+            .phoneNumber("0300 303 0642")
+            .openingHours("from 8.30am to 5pm")
+            .build();
+
+        assertEquals("Courts and Tribunals Service Centre", ctscContactDetails.getServiceCentre());
+        assertEquals("c/o HMCTS Digital Financial Remedy", ctscContactDetails.getCareOf());
+        assertEquals("12746", ctscContactDetails.getPoBox());
+        assertEquals("HARLOW", ctscContactDetails.getTown());
+        assertEquals("CM20 9QZ", ctscContactDetails.getPostcode());
+        assertEquals("HMCTSFinancialRemedy@justice.gov.uk", ctscContactDetails.getEmailAddress());
+        assertEquals("0300 303 0642", ctscContactDetails.getPhoneNumber());
+        assertEquals("from 8.30am to 5pm", ctscContactDetails.getOpeningHours());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/document/CtscContactDetailsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/document/CtscContactDetailsTest.java
@@ -3,6 +3,14 @@ package uk.gov.hmcts.reform.finrem.caseorchestration.model.document;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.CTSC_CARE_OF;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.CTSC_EMAIL_ADDRESS;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.CTSC_OPENING_HOURS;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.CTSC_PHONE_NUMBER;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.CTSC_POSTCODE;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.CTSC_PO_BOX;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.CTSC_SERVICE_CENTRE;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.CTSC_TOWN;
 
 public class CtscContactDetailsTest {
 
@@ -10,23 +18,23 @@ public class CtscContactDetailsTest {
     public void checkAllStatusValues() {
 
         CtscContactDetails ctscContactDetails = CtscContactDetails.builder()
-            .serviceCentre("Courts and Tribunals Service Centre")
-            .careOf("c/o HMCTS Digital Financial Remedy")
-            .poBox("12746")
-            .town("HARLOW")
-            .postcode("CM20 9QZ")
-            .emailAddress("HMCTSFinancialRemedy@justice.gov.uk")
-            .phoneNumber("0300 303 0642")
-            .openingHours("from 8.30am to 5pm")
+            .serviceCentre(CTSC_SERVICE_CENTRE)
+            .careOf(CTSC_CARE_OF)
+            .poBox(CTSC_PO_BOX)
+            .town(CTSC_TOWN)
+            .postcode(CTSC_POSTCODE)
+            .emailAddress(CTSC_EMAIL_ADDRESS)
+            .phoneNumber(CTSC_PHONE_NUMBER)
+            .openingHours(CTSC_OPENING_HOURS)
             .build();
 
-        assertEquals("Courts and Tribunals Service Centre", ctscContactDetails.getServiceCentre());
-        assertEquals("c/o HMCTS Digital Financial Remedy", ctscContactDetails.getCareOf());
-        assertEquals("12746", ctscContactDetails.getPoBox());
-        assertEquals("HARLOW", ctscContactDetails.getTown());
-        assertEquals("CM20 9QZ", ctscContactDetails.getPostcode());
-        assertEquals("HMCTSFinancialRemedy@justice.gov.uk", ctscContactDetails.getEmailAddress());
-        assertEquals("0300 303 0642", ctscContactDetails.getPhoneNumber());
-        assertEquals("from 8.30am to 5pm", ctscContactDetails.getOpeningHours());
+        assertEquals(CTSC_SERVICE_CENTRE, ctscContactDetails.getServiceCentre());
+        assertEquals(CTSC_CARE_OF, ctscContactDetails.getCareOf());
+        assertEquals(CTSC_PO_BOX, ctscContactDetails.getPoBox());
+        assertEquals(CTSC_TOWN, ctscContactDetails.getTown());
+        assertEquals(CTSC_POSTCODE, ctscContactDetails.getPostcode());
+        assertEquals(CTSC_EMAIL_ADDRESS, ctscContactDetails.getEmailAddress());
+        assertEquals(CTSC_PHONE_NUMBER, ctscContactDetails.getPhoneNumber());
+        assertEquals(CTSC_OPENING_HOURS, ctscContactDetails.getOpeningHours());
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/AssignedToJudgeDocumentServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/AssignedToJudgeDocumentServiceTest.java
@@ -1,0 +1,141 @@
+package uk.gov.hmcts.reform.finrem.caseorchestration.service;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.finrem.caseorchestration.BaseServiceTest;
+import uk.gov.hmcts.reform.finrem.caseorchestration.client.DocumentClient;
+import uk.gov.hmcts.reform.finrem.caseorchestration.config.DocumentConfiguration;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CaseDocument;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.document.Addressee;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.document.CtscContactDetails;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.YES_VALUE;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.SetUpUtils.doCaseDocumentAssert;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.SetUpUtils.document;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.TestConstants.AUTH_TOKEN;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.TestConstants.TEST_SOLICITOR_NAME;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.TestConstants.TEST_SOLICITOR_REFERENCE;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APPLICANT_ADDRESS;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APPLICANT_FIRST_MIDDLE_NAME;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APPLICANT_LAST_NAME;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APPLICANT_REPRESENTED;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APP_RESPONDENT_FIRST_MIDDLE_NAME;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APP_RESPONDENT_LAST_NAME;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APP_SOLICITOR_ADDRESS_CCD_FIELD;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_NAME;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_REFERENCE;
+
+@ActiveProfiles("test-mock-document-client")
+public class AssignedToJudgeDocumentServiceTest extends BaseServiceTest {
+
+    @Autowired
+    private DocumentClient documentClientMock;
+
+    @Autowired
+    private AssignedToJudgeDocumentService assignedToJudgeDocumentService;
+
+    private CaseDetails caseDetails;
+
+    @Before
+    public void setUp() {
+        DocumentConfiguration config = new DocumentConfiguration();
+        config.setApplicationAssignedToJudgeTemplate("FL-FRM-LET-ENG-00318.docx");
+        config.setApplicationAssignedToJudgeFileName("AssignedToJudgeNotificationLetter.pdf");
+
+        Map<String, Object> applicantAddress = new HashMap<>();
+        applicantAddress.put("AddressLine1", "50 Applicant Street");
+        applicantAddress.put("AddressLine2", "Second Address Line");
+        applicantAddress.put("AddressLine3", "Third Address Line");
+        applicantAddress.put("County", "London");
+        applicantAddress.put("Country", "England");
+        applicantAddress.put("PostTown", "London");
+        applicantAddress.put("PostCode", "SW1");
+
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put(APPLICANT_FIRST_MIDDLE_NAME, "James");
+        caseData.put(APPLICANT_LAST_NAME, "Joyce");
+        caseData.put(APPLICANT_ADDRESS, applicantAddress);
+        caseData.put(APPLICANT_REPRESENTED, null);
+        caseData.put(APP_RESPONDENT_FIRST_MIDDLE_NAME, "Jane");
+        caseData.put(APP_RESPONDENT_LAST_NAME, "Doe");
+
+        caseDetails = CaseDetails.builder()
+            .id(123456789L)
+            .data(caseData)
+            .build();
+    }
+
+    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+    @Test
+    public void shouldGenerateAssignedToJudgeLetterForApplicant() {
+
+        when(documentClientMock.generatePdf(any(), anyString())).thenReturn(document());
+
+        CaseDocument generateAssignedToJudgeNotificationLetter
+            = assignedToJudgeDocumentService.generateAssignedToJudgeNotificationLetter(caseDetails, AUTH_TOKEN);
+
+        doCaseDocumentAssert(generateAssignedToJudgeNotificationLetter);
+        verify(documentClientMock, times(1)).generatePdf(any(), anyString());
+        verifyCtscContactDetails();
+    }
+
+    @Test
+    public void shouldGenerateAssignedToJudgeLetterForApplicantSolicitor() {
+        when(documentClientMock.generatePdf(any(), anyString())).thenReturn(document());
+
+        Map<String, Object> solicitorAddress = new HashMap<>();
+        solicitorAddress.put("AddressLine1", "123 Applicant Solicitor Street");
+        solicitorAddress.put("AddressLine2", "Second Address Line");
+        solicitorAddress.put("AddressLine3", "Third Address Line");
+        solicitorAddress.put("County", "London");
+        solicitorAddress.put("Country", "England");
+        solicitorAddress.put("PostTown", "London");
+        solicitorAddress.put("PostCode", "SE1");
+
+        Map<String, Object> caseData = caseDetails.getData();
+        caseData.replace(APPLICANT_REPRESENTED, YES_VALUE);
+        caseData.put(SOLICITOR_NAME, TEST_SOLICITOR_NAME);
+        caseData.put(SOLICITOR_REFERENCE, TEST_SOLICITOR_REFERENCE);
+        caseData.put(APP_SOLICITOR_ADDRESS_CCD_FIELD, solicitorAddress);
+
+        CaseDocument generatedAssignedToJudgeNotificationLetter
+            = assignedToJudgeDocumentService.generateAssignedToJudgeNotificationLetter(caseDetails, AUTH_TOKEN);
+
+        doCaseDocumentAssert(generatedAssignedToJudgeNotificationLetter);
+
+        Addressee addressee = Addressee.builder()
+            .name("Saul Goodman")
+            .formattedAddress("123 Applicant Solicitor Street\nSecond Address Line\nThird Address Line\nLondon\nEngland\nLondon\nSE1")
+            .build();
+        assertEquals(addressee, caseDetails.getData().get("addressee"));
+        verifyCtscContactDetails();
+    }
+
+    void verifyCtscContactDetails() {
+        CtscContactDetails ctscContactDetails = CtscContactDetails.builder()
+            .serviceCentre("Courts and Tribunals Service Centre")
+            .careOf("c/o HMCTS Digital Financial Remedy")
+            .poBox("12746")
+            .town("HARLOW")
+            .postcode("CM20 9QZ")
+            .emailAddress("HMCTSFinancialRemedy@justice.gov.uk")
+            .phoneNumber("0300 303 0642")
+            .openingHours("from 8.30am to 5pm")
+            .build();
+
+        assertEquals(ctscContactDetails, caseDetails.getData().get("ctscContactDetails"));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/AssignedToJudgeDocumentServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/AssignedToJudgeDocumentServiceTest.java
@@ -11,7 +11,6 @@ import uk.gov.hmcts.reform.finrem.caseorchestration.client.DocumentClient;
 import uk.gov.hmcts.reform.finrem.caseorchestration.config.DocumentConfiguration;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CaseDocument;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.document.Addressee;
-import uk.gov.hmcts.reform.finrem.caseorchestration.model.document.CtscContactDetails;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -23,7 +22,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.YES_VALUE;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.SetUpUtils.doCaseDocumentAssert;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.SetUpUtils.assertCaseDocument;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.SetUpUtils.document;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.TestConstants.AUTH_TOKEN;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.TestConstants.TEST_SOLICITOR_NAME;
@@ -42,7 +41,7 @@ import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigCo
 public class AssignedToJudgeDocumentServiceTest extends BaseServiceTest {
 
     @Autowired
-    private DocumentClient documentClientMock;
+    private DocumentClient documentClient;
 
     @Autowired
     private AssignedToJudgeDocumentService assignedToJudgeDocumentService;
@@ -82,19 +81,19 @@ public class AssignedToJudgeDocumentServiceTest extends BaseServiceTest {
     @Test
     public void shouldGenerateAssignedToJudgeLetterForApplicant() {
 
-        when(documentClientMock.generatePdf(any(), anyString())).thenReturn(document());
+        when(documentClient.generatePdf(any(), anyString())).thenReturn(document());
 
         CaseDocument generateAssignedToJudgeNotificationLetter
             = assignedToJudgeDocumentService.generateAssignedToJudgeNotificationLetter(caseDetails, AUTH_TOKEN);
 
-        doCaseDocumentAssert(generateAssignedToJudgeNotificationLetter);
-        verify(documentClientMock, times(1)).generatePdf(any(), anyString());
-        verifyCtscContactDetails();
+        assertCaseDocument(generateAssignedToJudgeNotificationLetter);
+        verify(documentClient, times(1)).generatePdf(any(), anyString());
+        verifyCtscContactDetails(caseDetails);
     }
 
     @Test
     public void shouldGenerateAssignedToJudgeLetterForApplicantSolicitor() {
-        when(documentClientMock.generatePdf(any(), anyString())).thenReturn(document());
+        when(documentClient.generatePdf(any(), anyString())).thenReturn(document());
 
         Map<String, Object> solicitorAddress = new HashMap<>();
         solicitorAddress.put("AddressLine1", "123 Applicant Solicitor Street");
@@ -114,28 +113,13 @@ public class AssignedToJudgeDocumentServiceTest extends BaseServiceTest {
         CaseDocument generatedAssignedToJudgeNotificationLetter
             = assignedToJudgeDocumentService.generateAssignedToJudgeNotificationLetter(caseDetails, AUTH_TOKEN);
 
-        doCaseDocumentAssert(generatedAssignedToJudgeNotificationLetter);
+        assertCaseDocument(generatedAssignedToJudgeNotificationLetter);
 
         Addressee addressee = Addressee.builder()
             .name("Saul Goodman")
             .formattedAddress("123 Applicant Solicitor Street\nSecond Address Line\nThird Address Line\nLondon\nEngland\nLondon\nSE1")
             .build();
         assertEquals(addressee, caseDetails.getData().get("addressee"));
-        verifyCtscContactDetails();
-    }
-
-    void verifyCtscContactDetails() {
-        CtscContactDetails ctscContactDetails = CtscContactDetails.builder()
-            .serviceCentre("Courts and Tribunals Service Centre")
-            .careOf("c/o HMCTS Digital Financial Remedy")
-            .poBox("12746")
-            .town("HARLOW")
-            .postcode("CM20 9QZ")
-            .emailAddress("HMCTSFinancialRemedy@justice.gov.uk")
-            .phoneNumber("0300 303 0642")
-            .openingHours("from 8.30am to 5pm")
-            .build();
-
-        assertEquals(ctscContactDetails, caseDetails.getData().get("ctscContactDetails"));
+        verifyCtscContactDetails(caseDetails);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/BulkPrintServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/BulkPrintServiceTest.java
@@ -48,6 +48,21 @@ public class BulkPrintServiceTest extends BaseServiceTest {
     }
 
     @Test
+    public void shouldSendAssignedToJudgeNotificationLetterForBulkPrint() throws Exception {
+        DocumentConfiguration config = new DocumentConfiguration();
+        config.setApplicationAssignedToJudgeTemplate("test_template");
+        config.setApplicationAssignedToJudgeFileName("test_file");
+
+        when(documentClientMock.bulkPrint(bulkPrintRequestArgumentCaptor.capture())).thenReturn(letterId);
+
+        UUID bulkPrintLetterId = bulkPrintService.sendNotificationLetterForBulkPrint(
+            new CaseDocument(), caseDetails());
+
+        assertThat(bulkPrintLetterId, is(letterId));
+        assertThat(bulkPrintRequestArgumentCaptor.getValue().getBulkPrintDocuments().size(), is(1));
+    }
+
+    @Test
     public void shouldSendOrdersForBulkPrintForApproved() throws Exception {
         when(documentClientMock.bulkPrint(bulkPrintRequestArgumentCaptor.capture())).thenReturn(letterId);
 

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/BulkPrintServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/BulkPrintServiceTest.java
@@ -28,7 +28,7 @@ import static org.mockito.Mockito.when;
 public class BulkPrintServiceTest extends BaseServiceTest {
 
     @Autowired
-    private DocumentClient documentClientMock;
+    private DocumentClient documentClient;
 
     @Autowired
     private BulkPrintService bulkPrintService;
@@ -53,18 +53,18 @@ public class BulkPrintServiceTest extends BaseServiceTest {
         config.setApplicationAssignedToJudgeTemplate("test_template");
         config.setApplicationAssignedToJudgeFileName("test_file");
 
-        when(documentClientMock.bulkPrint(bulkPrintRequestArgumentCaptor.capture())).thenReturn(letterId);
+        when(documentClient.bulkPrint(bulkPrintRequestArgumentCaptor.capture())).thenReturn(letterId);
 
         UUID bulkPrintLetterId = bulkPrintService.sendNotificationLetterForBulkPrint(
             new CaseDocument(), caseDetails());
 
         assertThat(bulkPrintLetterId, is(letterId));
-        assertThat(bulkPrintRequestArgumentCaptor.getValue().getBulkPrintDocuments().size(), is(1));
+        assertThat(bulkPrintRequestArgumentCaptor.getValue().getBulkPrintDocuments(), hasSize(1));
     }
 
     @Test
     public void shouldSendOrdersForBulkPrintForApproved() throws Exception {
-        when(documentClientMock.bulkPrint(bulkPrintRequestArgumentCaptor.capture())).thenReturn(letterId);
+        when(documentClient.bulkPrint(bulkPrintRequestArgumentCaptor.capture())).thenReturn(letterId);
 
         UUID bulkPrintLetterId = bulkPrintService.sendOrdersForBulkPrint(
             new CaseDocument(), caseDetails());
@@ -76,20 +76,20 @@ public class BulkPrintServiceTest extends BaseServiceTest {
 
     @Test
     public void shouldSendForBulkPrintForNotApproved() throws Exception {
-        when(documentClientMock.bulkPrint(bulkPrintRequestArgumentCaptor.capture())).thenReturn(letterId);
+        when(documentClient.bulkPrint(bulkPrintRequestArgumentCaptor.capture())).thenReturn(letterId);
 
         UUID bulkPrintLetterId = bulkPrintService.sendOrdersForBulkPrint(
             new CaseDocument(), caseDetailsForNonApproved());
 
         assertThat(bulkPrintLetterId, is(letterId));
-        assertThat(bulkPrintRequestArgumentCaptor.getValue().getBulkPrintDocuments().size(), is(2));
+        assertThat(bulkPrintRequestArgumentCaptor.getValue().getBulkPrintDocuments(), hasSize(2));
     }
 
     @Test
     public void shouldConvertDocument() throws Exception {
         List<BulkPrintDocument> bulkPrintDocuments = bulkPrintService.uploadOrder(caseDetails().getData());
 
-        assertThat(bulkPrintDocuments.size(), is(1));
+        assertThat(bulkPrintDocuments, hasSize(1));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/ConsentOrderApprovedDocumentServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/ConsentOrderApprovedDocumentServiceTest.java
@@ -27,8 +27,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.NO_VALUE;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.YES_VALUE;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.SetUpUtils.assertCaseDocument;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.SetUpUtils.caseDocument;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.SetUpUtils.doCaseDocumentAssert;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.SetUpUtils.document;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.SetUpUtils.pensionDocumentData;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.TestConstants.AUTH_TOKEN;
@@ -96,7 +96,7 @@ public class ConsentOrderApprovedDocumentServiceTest extends BaseServiceTest {
 
         CaseDocument caseDocument = consentOrderApprovedDocumentService.generateApprovedConsentOrderLetter(caseDetails, AUTH_TOKEN);
 
-        doCaseDocumentAssert(caseDocument);
+        assertCaseDocument(caseDocument);
         verify(documentClientMock, times(1)).generatePdf(any(), anyString());
     }
 
@@ -110,7 +110,7 @@ public class ConsentOrderApprovedDocumentServiceTest extends BaseServiceTest {
         CaseDocument generatedApprovedConsentOrderNotificationLetter =
                 consentOrderApprovedDocumentService.generateApprovedConsentOrderNotificationLetter(caseDetails, AUTH_TOKEN);
 
-        doCaseDocumentAssert(generatedApprovedConsentOrderNotificationLetter);
+        assertCaseDocument(generatedApprovedConsentOrderNotificationLetter);
 
         Addressee addressee = Addressee.builder()
                 .name("James Joyce")
@@ -141,7 +141,7 @@ public class ConsentOrderApprovedDocumentServiceTest extends BaseServiceTest {
         CaseDocument generatedApprovedConsentOrderNotificationLetter =
                 consentOrderApprovedDocumentService.generateApprovedConsentOrderNotificationLetter(caseDetails, AUTH_TOKEN);
 
-        doCaseDocumentAssert(generatedApprovedConsentOrderNotificationLetter);
+        assertCaseDocument(generatedApprovedConsentOrderNotificationLetter);
 
         Addressee addressee = Addressee.builder()
                 .name("Saul Goodman")
@@ -158,7 +158,7 @@ public class ConsentOrderApprovedDocumentServiceTest extends BaseServiceTest {
         CaseDocument caseDocument = caseDocument();
         CaseDocument annexStampDocument = consentOrderApprovedDocumentService.annexStampDocument(caseDocument, AUTH_TOKEN);
 
-        doCaseDocumentAssert(annexStampDocument);
+        assertCaseDocument(annexStampDocument);
         verify(documentClientMock, times(1)).annexStampDocument(any(), anyString());
     }
 
@@ -170,7 +170,7 @@ public class ConsentOrderApprovedDocumentServiceTest extends BaseServiceTest {
         CaseDocument caseDocument = caseDocument();
         CaseDocument stampDocument = consentOrderApprovedDocumentService.stampDocument(caseDocument, AUTH_TOKEN);
 
-        doCaseDocumentAssert(stampDocument);
+        assertCaseDocument(stampDocument);
         verify(documentClientMock, times(1)).stampDocument(any(), anyString());
     }
 
@@ -182,7 +182,7 @@ public class ConsentOrderApprovedDocumentServiceTest extends BaseServiceTest {
         List<PensionCollectionData> pensionDocuments = asList(pensionDocumentData(), pensionDocumentData());
         List<PensionCollectionData> stampPensionDocuments = consentOrderApprovedDocumentService.stampPensionDocuments(pensionDocuments, AUTH_TOKEN);
 
-        stampPensionDocuments.forEach(data -> doCaseDocumentAssert(data.getTypedCaseDocument().getPensionDocument()));
+        stampPensionDocuments.forEach(data -> assertCaseDocument(data.getTypedCaseDocument().getPensionDocument()));
         verify(documentClientMock, times(2)).stampDocument(any(), anyString());
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/HearingDocumentServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/HearingDocumentServiceTest.java
@@ -25,7 +25,7 @@ import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstant
 import static uk.gov.hmcts.reform.finrem.caseorchestration.SetUpUtils.BINARY_URL;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.SetUpUtils.DOC_URL;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.SetUpUtils.FILE_NAME;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.SetUpUtils.doCaseDocumentAssert;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.SetUpUtils.assertCaseDocument;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.TestConstants.AUTH_TOKEN;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.CASE_ALLOCATED_TO;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.FAST_TRACK_DECISION;
@@ -65,7 +65,7 @@ public class HearingDocumentServiceTest {
     @Test
     public void generateFastTrackFormC() {
         Map<String, Object> result = service.generateHearingDocuments(AUTH_TOKEN, makeItFastTrackDecisionCase());
-        doCaseDocumentAssert((CaseDocument) result.get(FORM_C));
+        assertCaseDocument((CaseDocument) result.get(FORM_C));
         ((TestDocumentClient) generatorClient).verifyAdditionalFastTrackFields();
     }
 
@@ -73,15 +73,15 @@ public class HearingDocumentServiceTest {
     public void generateJudiciaryBasedFastTrackFormC() {
         Map<String, Object> result = service.generateHearingDocuments(AUTH_TOKEN,
                 makeItJudiciaryFastTrackDecisionCase());
-        doCaseDocumentAssert((CaseDocument) result.get(FORM_C));
+        assertCaseDocument((CaseDocument) result.get(FORM_C));
         ((TestDocumentClient) generatorClient).verifyAdditionalFastTrackFields();
     }
 
     @Test
     public void generateNonFastTrackFormCAndFormG() {
         Map<String, Object> result = service.generateHearingDocuments(AUTH_TOKEN, makeItNonFastTrackDecisionCase());
-        doCaseDocumentAssert((CaseDocument) result.get(FORM_C));
-        doCaseDocumentAssert((CaseDocument) result.get(FORM_G));
+        assertCaseDocument((CaseDocument) result.get(FORM_C));
+        assertCaseDocument((CaseDocument) result.get(FORM_G));
         ((TestDocumentClient) generatorClient).verifyAdditionalNonFastTrackFields();
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/OnlineFormDocumentServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/OnlineFormDocumentServiceTest.java
@@ -17,7 +17,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 
-import static uk.gov.hmcts.reform.finrem.caseorchestration.SetUpUtils.doCaseDocumentAssert;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.SetUpUtils.assertCaseDocument;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.SetUpUtils.document;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.TestConstants.AUTH_TOKEN;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.MINI_FORM_A;
@@ -42,13 +42,13 @@ public class OnlineFormDocumentServiceTest {
     @Test
     public void generateMiniFormA() {
         service = new OnlineFormDocumentService(new DocumentClientStub(new CountDownLatch(1)), config, translator, mapper);
-        doCaseDocumentAssert(service.generateMiniFormA(AUTH_TOKEN, CaseDetails.builder().build()));
+        assertCaseDocument(service.generateMiniFormA(AUTH_TOKEN, CaseDetails.builder().build()));
     }
 
     @Test
     public void generateContestedMiniFormA() {
         service = new OnlineFormDocumentService(new DocumentClientStub(new CountDownLatch(1)), config, translator, mapper);
-        doCaseDocumentAssert(service.generateContestedMiniFormA(AUTH_TOKEN, CaseDetails.builder().build()));
+        assertCaseDocument(service.generateContestedMiniFormA(AUTH_TOKEN, CaseDetails.builder().build()));
     }
 
     @Test
@@ -59,7 +59,7 @@ public class OnlineFormDocumentServiceTest {
         CaseDocument result = service.generateDraftContestedMiniFormA(AUTH_TOKEN, CaseDetails.builder().data(caseData()).build());
         latch.await();
 
-        doCaseDocumentAssert(result);
+        assertCaseDocument(result);
     }
 
     private Map<String, Object> caseData() {

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/RefusalOrderDocumentServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/RefusalOrderDocumentServiceTest.java
@@ -30,7 +30,7 @@ import static uk.gov.hmcts.reform.finrem.caseorchestration.SetUpUtils.BINARY_URL
 import static uk.gov.hmcts.reform.finrem.caseorchestration.SetUpUtils.DOC_URL;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.SetUpUtils.FILE_NAME;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.SetUpUtils.REJECTED_ORDER_TYPE;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.SetUpUtils.doCaseDocumentAssert;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.SetUpUtils.assertCaseDocument;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.TestConstants.AUTH_TOKEN;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.ORDER_REFUSAL_COLLECTION;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.ORDER_REFUSAL_PREVIEW_COLLECTION;
@@ -71,7 +71,7 @@ public class RefusalOrderDocumentServiceTest {
         assertThat(consentOrderData.getConsentOrder().getDocumentDateAdded(), is(notNullValue()));
         assertThat(consentOrderData.getConsentOrder().getDocumentComment(), is(equalTo("System Generated")));
 
-        doCaseDocumentAssert(consentOrderData.getConsentOrder().getDocumentLink());
+        assertCaseDocument(consentOrderData.getConsentOrder().getDocumentLink());
     }
 
     @Test
@@ -90,7 +90,7 @@ public class RefusalOrderDocumentServiceTest {
         assertThat(consentOrderData.getConsentOrder().getDocumentDateAdded(), is(notNullValue()));
         assertThat(consentOrderData.getConsentOrder().getDocumentComment(), is(equalTo("System Generated")));
 
-        doCaseDocumentAssert(consentOrderData.getConsentOrder().getDocumentLink());
+        assertCaseDocument(consentOrderData.getConsentOrder().getDocumentLink());
     }
 
     @Test
@@ -99,7 +99,7 @@ public class RefusalOrderDocumentServiceTest {
         Map<String, Object> caseData = service.previewConsentOrderNotApproved(AUTH_TOKEN, caseDetails);
         CaseDocument caseDocument = getCaseDocument(caseData);
 
-        doCaseDocumentAssert(caseDocument);
+        assertCaseDocument(caseDocument);
     }
 
     private CaseDocument getCaseDocument(Map<String, Object> caseData) {

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -44,6 +44,8 @@ document.generalLetterTemplate=FL-FRM-LET-ENG-00057.docx
 document.generalLetterFileName=GeneralLetter.pdf
 document.approvedConsentOrderTemplate=FL-FRM-DEC-ENG-00071.docx
 document.approvedConsentOrderFileName=ApprovedConsentOrderLetter.pdf
+document.assignedToJudgeNotificationTemplate=FL-FRM-LET-ENG-00318.docx
+document.assignedToJudgeNotificationFileName=AssignedToJudgeNotificationLetter.pdf
 
 document.generator.service.api.baseurl=${DOCUMENT_GENERATOR_SERVICE_API_BASEURL:http://localhost:4009}
 document.generator.service.api.health.url=${document.generator.service.api.baseurl}/health


### PR DESCRIPTION
Send 'your application has been assigned to judge' notification letter to applicant/applicant solicitor when event 'assign to judge' is used.

Note: These notification letters ARE NOT supposed to be viewable in CCD by the caseworker etc