### PR TITLE
Refactor isSolicitorAgreeToReceieveEmails to ignore case type

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/BulkPrintController.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/BulkPrintController.java
@@ -28,12 +28,12 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.AUTHORIZATION_HEADER;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.NO_VALUE;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APPLICANT_REPRESENTED;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APP_SOL_AGREE_TO_RECEIVE_EMAILS_CONSENTED;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.BULK_PRINT_COVER_SHEET;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.BULK_PRINT_COVER_SHEET_APP;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.BULK_PRINT_COVER_SHEET_RES;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.BULK_PRINT_LETTER_ID_APP;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.BULK_PRINT_LETTER_ID_RES;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_AGREE_TO_RECEIVE_EMAILS;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.nullToEmpty;
 
 @RestController
@@ -114,6 +114,6 @@ public class BulkPrintController implements BaseController {
 
     private boolean solicitorDidNotAgreeToReceiveEmails(Map<String, Object> caseData) {
 
-        return NO_VALUE.equalsIgnoreCase(nullToEmpty(caseData.get(SOLICITOR_AGREE_TO_RECEIVE_EMAILS)));
+        return NO_VALUE.equalsIgnoreCase(nullToEmpty(caseData.get(APP_SOL_AGREE_TO_RECEIVE_EMAILS_CONSENTED)));
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/NotificationsController.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/NotificationsController.java
@@ -20,13 +20,11 @@ import uk.gov.hmcts.reform.finrem.caseorchestration.service.FeatureToggleService
 import uk.gov.hmcts.reform.finrem.caseorchestration.service.NotificationService;
 
 import java.util.Map;
-import java.util.Objects;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.AUTHORIZATION_HEADER;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.YES_VALUE;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.controllers.BaseController.isConsentedApplication;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_AGREE_TO_RECEIVE_EMAILS;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.isApplicantSolicitorAgreeToReceiveEmails;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.isPaperApplication;
 
 @RestController
@@ -50,12 +48,11 @@ public class NotificationsController implements BaseController {
         validateCaseData(callbackRequest);
         Map<String, Object> caseData = callbackRequest.getCaseDetails().getData();
         if (isConsentedApplication(caseData)) {
-            if (isSolicitorAgreedToReceiveEmails(caseData, SOLICITOR_AGREE_TO_RECEIVE_EMAILS)) {
+            if (isApplicantSolicitorAgreeToReceiveEmails(caseData)) {
                 log.info("Sending Consented HWF Successful email notification to Solicitor");
                 notificationService.sendHWFSuccessfulConfirmationEmail(callbackRequest);
             }
-        } else if (isSolicitorAgreedToReceiveEmails(caseData,
-                "applicantSolicitorConsentForEmails")) {
+        } else if (isApplicantSolicitorAgreeToReceiveEmails(caseData)) {
             log.info("Sending Contested HWF Successful email notification to Solicitor");
             notificationService.sendContestedHwfSuccessfulConfirmationEmail(callbackRequest);
         }
@@ -74,7 +71,7 @@ public class NotificationsController implements BaseController {
             callbackRequest.getCaseDetails().getId());
         validateCaseData(callbackRequest);
         Map<String, Object> caseData = callbackRequest.getCaseDetails().getData();
-        if (isSolicitorAgreedToReceiveEmails(caseData, SOLICITOR_AGREE_TO_RECEIVE_EMAILS)) {
+        if (isApplicantSolicitorAgreeToReceiveEmails(caseData)) {
             log.info("Sending email notification to Solicitor for Judge successfully assigned to case");
             notificationService.sendAssignToJudgeConfirmationEmail(callbackRequest);
         } else if (isConsentedApplication(caseData) && isPaperApplication(caseData)) {
@@ -109,7 +106,7 @@ public class NotificationsController implements BaseController {
         log.info("Received request to send email for 'Consent Order Made' for Case ID: {}", callbackRequest.getCaseDetails().getId());
         validateCaseData(callbackRequest);
         Map<String, Object> caseData = callbackRequest.getCaseDetails().getData();
-        if (isSolicitorAgreedToReceiveEmails(caseData, SOLICITOR_AGREE_TO_RECEIVE_EMAILS)) {
+        if (isApplicantSolicitorAgreeToReceiveEmails(caseData)) {
             log.info("Sending email notification to Solicitor for 'Consent Order Made'");
             notificationService.sendConsentOrderMadeConfirmationEmail(callbackRequest);
         }
@@ -126,7 +123,7 @@ public class NotificationsController implements BaseController {
         log.info("Received request to send email for 'Consent Order Not Approved' for Case ID: {}", callbackRequest.getCaseDetails().getId());
         validateCaseData(callbackRequest);
         Map<String, Object> caseData = callbackRequest.getCaseDetails().getData();
-        if (isSolicitorAgreedToReceiveEmails(caseData, SOLICITOR_AGREE_TO_RECEIVE_EMAILS)) {
+        if (isApplicantSolicitorAgreeToReceiveEmails(caseData)) {
             log.info("Sending email notification to Solicitor for 'Consent Order Not Approved'");
             notificationService.sendConsentOrderNotApprovedEmail(callbackRequest);
         }
@@ -143,16 +140,11 @@ public class NotificationsController implements BaseController {
         log.info("Received request to send email for 'Consent Order Available' for Case ID: {}", callbackRequest.getCaseDetails().getId());
         validateCaseData(callbackRequest);
         Map<String, Object> caseData = callbackRequest.getCaseDetails().getData();
-        if (isSolicitorAgreedToReceiveEmails(caseData, SOLICITOR_AGREE_TO_RECEIVE_EMAILS)) {
+        if (isApplicantSolicitorAgreeToReceiveEmails(caseData)) {
             log.info("Sending email notification to Solicitor for 'Consent Order Available'");
             notificationService.sendConsentOrderAvailableEmail(callbackRequest);
         }
         return ResponseEntity.ok(AboutToStartOrSubmitCallbackResponse.builder().data(caseData).build());
-    }
-
-    private boolean isSolicitorAgreedToReceiveEmails(Map<String, Object> mapOfCaseData, String solicitorAgreeToReceiveEmails) {
-        return YES_VALUE.equalsIgnoreCase(Objects.toString(mapOfCaseData
-                .get(solicitorAgreeToReceiveEmails)));
     }
 
     private void cleanupCaseDataBeforeSubmittingToCcd(CaseDetails caseDetails) {

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/UpdateConsentedCaseController.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/UpdateConsentedCaseController.java
@@ -22,8 +22,8 @@ import java.util.Map;
 
 import static java.util.Objects.nonNull;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.AUTHORIZATION_HEADER;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APP_SOL_AGREE_TO_RECEIVE_EMAILS_CONSENTED;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.LATEST_CONSENT_ORDER;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_AGREE_TO_RECEIVE_EMAILS;
 
 @RestController
 @RequestMapping(value = "/case-orchestration")
@@ -160,7 +160,7 @@ public class UpdateConsentedCaseController implements BaseController {
         caseData.put("solicitorPhone", null);
         caseData.put("solicitorEmail", null);
         caseData.put("solicitorDXnumber", null);
-        caseData.put(SOLICITOR_AGREE_TO_RECEIVE_EMAILS, null);
+        caseData.put(APP_SOL_AGREE_TO_RECEIVE_EMAILS_CONSENTED, null);
     }
 
     private void removeApplicantAddress(Map<String, Object> caseData) {

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/CCDConfigConstant.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/CCDConfigConstant.java
@@ -30,7 +30,8 @@ public class CCDConfigConstant {
     public static final String CONTESTED_SOLICITOR_NAME = "applicantSolicitorName";
     public static final String SOLICITOR_FIRM = "solicitorFirm";
     public static final String APP_SOLICITOR_ADDRESS_CCD_FIELD = "solicitorAddress";
-    public static final String SOLICITOR_AGREE_TO_RECEIVE_EMAILS = "solicitorAgreeToReceiveEmails";
+    public static final String APP_SOL_AGREE_TO_RECEIVE_EMAILS_CONSENTED = "solicitorAgreeToReceiveEmails";
+    public static final String APP_SOL_AGREE_TO_RECEIVE_EMAILS_CONTESTED = "applicantSolicitorConsentForEmails";
     public static final String APPLICANT_REPRESENTED = "applicantRepresented";
     public static final String APPLICANT_REPRESENTED_PAPER = "applicantRepresentedPaper";
 

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/CommonFunction.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/CommonFunction.java
@@ -17,8 +17,9 @@ import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstant
 import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.YES_VALUE;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.AMENDED_CONSENT_ORDER;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APPLICANT_REPRESENTED;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APP_SOL_AGREE_TO_RECEIVE_EMAILS_CONSENTED;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APP_SOL_AGREE_TO_RECEIVE_EMAILS_CONTESTED;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.RESP_SOLICITOR_NAME;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_AGREE_TO_RECEIVE_EMAILS;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CommonFunction {
@@ -54,7 +55,8 @@ public class CommonFunction {
     }
 
     public static boolean isApplicantSolicitorAgreeToReceiveEmails(Map<String, Object> caseData) {
-        return YES_VALUE.equalsIgnoreCase(nullToEmpty(caseData.get(SOLICITOR_AGREE_TO_RECEIVE_EMAILS)));
+        return YES_VALUE.equalsIgnoreCase(nullToEmpty(caseData.get(APP_SOL_AGREE_TO_RECEIVE_EMAILS_CONSENTED)))
+            || YES_VALUE.equalsIgnoreCase(nullToEmpty(caseData.get(APP_SOL_AGREE_TO_RECEIVE_EMAILS_CONTESTED)));
     }
 
     public static boolean isRespondentRepresentedByASolicitor(Map<String, Object> caseData) {

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/bulkscan/transformation/FormAToCaseTransformer.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/bulkscan/transformation/FormAToCaseTransformer.java
@@ -35,13 +35,13 @@ import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigCo
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APPLICANT_REPRESENTED;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APPLICANT_REPRESENTED_PAPER;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APP_RESPONDENT_FIRST_MIDDLE_NAME;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APP_SOL_AGREE_TO_RECEIVE_EMAILS_CONSENTED;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.CONSENT_ORDER;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.LATEST_CONSENT_ORDER;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.OTHER_DOCS_COLLECTION;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.PENSION_DOCS_COLLECTION;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.RESPONDENT_REPRESENTED;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.RESP_SOLICITOR_NAME;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_AGREE_TO_RECEIVE_EMAILS;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.isNotEmpty;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.nullToEmpty;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.service.bulkscan.helper.BulkScanHelper.applicantRepresentedPaperToCcdFieldNames;
@@ -196,7 +196,7 @@ public class FormAToCaseTransformer extends BulkScanFormTransformer {
 
         modifiedCaseData.put(PAPER_APPLICATION, YES_VALUE);
         modifiedCaseData.put(APPLICANT_REPRESENTED, getValueForIsRepresented(modifiedCaseData));
-        modifiedCaseData.put(SOLICITOR_AGREE_TO_RECEIVE_EMAILS, getSolicitorAgreeToReceiveEmailsField(modifiedCaseData));
+        modifiedCaseData.put(APP_SOL_AGREE_TO_RECEIVE_EMAILS_CONSENTED, getSolicitorAgreeToReceiveEmailsField(modifiedCaseData));
         modifiedCaseData.put(RESPONDENT_REPRESENTED, getRespondentRepresentedField(modifiedCaseData));
 
         // If OrderForChildren is populated then set orderForChildrenQuestion1 to Yes

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/CommonFunctionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/CommonFunctionTest.java
@@ -17,8 +17,9 @@ import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstant
 import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.YES_VALUE;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.AMENDED_CONSENT_ORDER;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APPLICANT_REPRESENTED;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APP_SOL_AGREE_TO_RECEIVE_EMAILS_CONSENTED;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APP_SOL_AGREE_TO_RECEIVE_EMAILS_CONTESTED;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.RESP_SOLICITOR_NAME;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_AGREE_TO_RECEIVE_EMAILS;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.addressLineOneAndPostCodeAreBothNotEmpty;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.buildFullName;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.isAmendedConsentOrderType;
@@ -123,17 +124,33 @@ public class CommonFunctionTest {
     }
 
     @Test
-    public void isApplicantSolicitorAgreeToReceiveEmailsShouldReturnTrueWhenApplicantRepresentedIsYes() {
+    public void isApplicantSolicitorAgreeToReceiveEmailsShouldReturnTrueWhenAppSolAgreedToReceiveEmailsIsYesForConsented() {
         Map<String, Object> data = new HashMap<>();
-        data.put(SOLICITOR_AGREE_TO_RECEIVE_EMAILS, YES_VALUE);
+        data.put(APP_SOL_AGREE_TO_RECEIVE_EMAILS_CONSENTED, YES_VALUE);
 
         assertThat(isApplicantSolicitorAgreeToReceiveEmails(data), is(true));
     }
 
     @Test
-    public void isApplicantSolicitorAgreeToReceiveEmailsShouldReturnFalseWhenApplicantRepresentedIsNo() {
+    public void isApplicantSolicitorAgreeToReceiveEmailsShouldReturnFalseWhenAppSolAgreedToReceiveEmailsIsNoForConsented() {
         Map<String, Object> data = new HashMap<>();
-        data.put(SOLICITOR_AGREE_TO_RECEIVE_EMAILS, null);
+        data.put(APP_SOL_AGREE_TO_RECEIVE_EMAILS_CONSENTED, null);
+
+        assertThat(isApplicantSolicitorAgreeToReceiveEmails(data), is(false));
+    }
+
+    @Test
+    public void isApplicantSolicitorAgreeToReceiveEmailsShouldReturnTrueWhenAppSolAgreedToReceiveEmailsIsYesForContested() {
+        Map<String, Object> data = new HashMap<>();
+        data.put(APP_SOL_AGREE_TO_RECEIVE_EMAILS_CONTESTED, YES_VALUE);
+
+        assertThat(isApplicantSolicitorAgreeToReceiveEmails(data), is(true));
+    }
+
+    @Test
+    public void isApplicantSolicitorAgreeToReceiveEmailsShouldReturnFalseWhenAppSolAgreedToReceiveEmailsIsNoForContested() {
+        Map<String, Object> data = new HashMap<>();
+        data.put(APP_SOL_AGREE_TO_RECEIVE_EMAILS_CONTESTED, null);
 
         assertThat(isApplicantSolicitorAgreeToReceiveEmails(data), is(false));
     }

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/bulk/scan/transformation/FormAToCaseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/bulk/scan/transformation/FormAToCaseTransformerTest.java
@@ -39,11 +39,11 @@ import static uk.gov.hmcts.reform.finrem.caseorchestration.TestConstants.TEST_SO
 import static uk.gov.hmcts.reform.finrem.caseorchestration.TestConstants.TEST_SOLICITOR_NAME;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APPLICANT_REPRESENTED;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APPLICANT_REPRESENTED_PAPER;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APP_SOL_AGREE_TO_RECEIVE_EMAILS_CONSENTED;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.DIVORCE_CASE_NUMBER;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.PBA_NUMBER;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.RESPONDENT_REPRESENTED;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.RESP_SOLICITOR_NAME;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_AGREE_TO_RECEIVE_EMAILS;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_EMAIL;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_FIRM;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_NAME;
@@ -275,7 +275,7 @@ public class FormAToCaseTransformerTest {
             hasEntry(BULK_SCAN_CASE_REFERENCE, TEST_CASE_ID),
             hasEntry(PAPER_APPLICATION, YES_VALUE),
             hasEntry(SOLICITOR_EMAIL, TEST_SOLICITOR_EMAIL),
-            hasEntry(SOLICITOR_AGREE_TO_RECEIVE_EMAILS, YES_VALUE)
+            hasEntry(APP_SOL_AGREE_TO_RECEIVE_EMAILS_CONSENTED, YES_VALUE)
         ));
     }
 
@@ -290,7 +290,7 @@ public class FormAToCaseTransformerTest {
         assertThat(transformedCaseData, allOf(
             hasEntry(BULK_SCAN_CASE_REFERENCE, TEST_CASE_ID),
             hasEntry(PAPER_APPLICATION, YES_VALUE),
-            hasEntry(SOLICITOR_AGREE_TO_RECEIVE_EMAILS, NO_VALUE)
+            hasEntry(APP_SOL_AGREE_TO_RECEIVE_EMAILS_CONSENTED, NO_VALUE)
         ));
     }
 


### PR DESCRIPTION
For some reason we have both 'applicantSolicitorConsentForEmails' & 'solicitorAgreeToReceiveEmails' which both essentially do the same thing.

(Field 'applicantSolicitorConsentForEmails' is for Contested cases. Field 'solicitorAgreeToReceiveEmails' is for Consented)

Renamed Constants to make it clear which usage is for which case type and refactored common method to handle both scenarios
