### PR TITLE
Flipped conditional logic so paperApplicant field takes preference

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/NotificationsController.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/NotificationsController.java
@@ -74,10 +74,9 @@ public class NotificationsController implements BaseController {
             callbackRequest.getCaseDetails().getId());
         validateCaseData(callbackRequest);
         Map<String, Object> caseData = callbackRequest.getCaseDetails().getData();
-        if (isSolicitorAgreedToReceiveEmails(caseData, SOLICITOR_AGREE_TO_RECEIVE_EMAILS)) {
-            log.info("Sending email notification to Solicitor for Judge successfully assigned to case");
-            notificationService.sendAssignToJudgeConfirmationEmail(callbackRequest);
-        } else if (isConsentedApplication(caseData) && isPaperApplication(caseData)) {
+        log.info("isAssignedToJudgeNotificationLetterEnabled is toggled to: {}",
+            featureToggleService.isAssignedToJudgeNotificationLetterEnabled());
+        if (isConsentedApplication(caseData) && isPaperApplication(caseData)) {
             if (featureToggleService.isAssignedToJudgeNotificationLetterEnabled()) {
                 log.info("isAssignedToJudgeNotificationLetterEnabled is toggled on");
                 log.info("Sending AssignedToJudge notification letter for bulk print");
@@ -91,6 +90,9 @@ public class NotificationsController implements BaseController {
                 // Send notification letter to Bulk Print
                 bulkPrintService.sendNotificationLetterForBulkPrint(assignedToJudgeNotificationLetter, caseDetails);
             }
+        } else if (isSolicitorAgreedToReceiveEmails(caseData, SOLICITOR_AGREE_TO_RECEIVE_EMAILS)) {
+            log.info("Sending email notification to Solicitor for Judge successfully assigned to case");
+            notificationService.sendAssignToJudgeConfirmationEmail(callbackRequest);
         }
 
         return ResponseEntity.ok(AboutToStartOrSubmitCallbackResponse.builder().data(caseData).build());


### PR DESCRIPTION
Flipped conditional logic so paperApplicant field takes preference and is checked before deciding whether to send email or letter.

_"Infer a 'yes'. Take the assumption that they have provided because they are happy to be contacted. This removes any decision-making for the caseworker. However, currently the triggers for emails are contingent on 'yes' being ticket, and we don't want paper applicants who have a 'yes' ticked for this to get emails (as they won't be able to login and see what the email is suggesting they should see."_