### PR TITLE
Added suppressions to get pipeline green

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -25,7 +25,6 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
 }
 
 withPipeline(type, product, app) {
-    installCharts()
     loadVaultSecrets(secrets)
 
     after('functionalTest:aat') {

--- a/build.gradle
+++ b/build.gradle
@@ -130,7 +130,7 @@ def versions = [
         serviceTokenGenerator   : '3.0.0',
         springfoxSwagger        : '2.9.2',
         sonarPitest             : '0.5',
-        wiremock                : '2.25.1'
+        wiremock                : '2.26.3'
 ]
 
 dependencyManagement {

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -58,7 +58,18 @@
         <packageUrl regex="true">^pkg:javascript/handlebars\.js@.*$</packageUrl>
         <vulnerabilityName>A prototype pollution vulnerability in handlebars is exploitable if an attacker can control the template</vulnerabilityName>
     </suppress>
-
+    <suppress>
+        <notes>A prototype pollution vulnerability in handlebars is exploitable if an attacker can control the template</notes>
+        <packageUrl regex="true">^pkg:javascript/handlebars@.*$</packageUrl>
+        <vulnerabilityName>A prototype pollution vulnerability in handlebars is exploitable if an attacker can control the template</vulnerabilityName>
+        <vulnerabilityName>Disallow calling helperMissing and blockHelperMissing directly</vulnerabilityName>
+        <vulnerabilityName>Prototype pollution</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes>Regex in its jQuery.htmlPrefilter sometimes may introduce XSS</notes>
+        <packageUrl regex="true">^pkg:javascript/jquery@.*$</packageUrl>
+        <vulnerabilityName>Regex in its jQuery.htmlPrefilter  sometimes may introduce XSS</vulnerabilityName>
+    </suppress>
     <suppress>
         <notes>Regex in its jQuery.htmlPrefilter  sometimes may introduce XSS</notes>
         <packageUrl regex="true">^pkg:javascript/jquery\.js@.*$</packageUrl>


### PR DESCRIPTION
- Added suppressions for JS vulnerability in Wiremock that currently does not have a resolution. 

- Removed deprecated configuration:
_installCharts() is deprecated and no longer does anything, please remove this flag before the pipeline starts failing., This configuration will stop working by 25/05/2020 00:00 AM ( in 13 days )_