### PR TITLE
Update isConsentedApplication to use caseTypeId

### DIFF
--- a/src/functionalTests/resources/json/consented/FailurePaymentRequestPayload.json
+++ b/src/functionalTests/resources/json/consented/FailurePaymentRequestPayload.json
@@ -4,6 +4,7 @@
     "id": "92929292",
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123",
       "d81Question": "No",

--- a/src/functionalTests/resources/json/consented/SuccessPaymentRequestPayload_Consented.json
+++ b/src/functionalTests/resources/json/consented/SuccessPaymentRequestPayload_Consented.json
@@ -4,6 +4,7 @@
     "id": "17892000",
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA0077597",
       "d81Question": "No",

--- a/src/functionalTests/resources/json/consented/amend-consent-order-by-caseworker.json
+++ b/src/functionalTests/resources/json/consented/amend-consent-order-by-caseworker.json
@@ -5,6 +5,7 @@
     "id" : "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/functionalTests/resources/json/consented/amend-consent-order-by-solicitor.json
+++ b/src/functionalTests/resources/json/consented/amend-consent-order-by-solicitor.json
@@ -5,6 +5,7 @@
     "id" : "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/functionalTests/resources/json/consented/amend-divorce-details-d81-individual1.json
+++ b/src/functionalTests/resources/json/consented/amend-divorce-details-d81-individual1.json
@@ -5,6 +5,7 @@
     "id" : "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/functionalTests/resources/json/consented/amend-divorce-details-d81-joint.json
+++ b/src/functionalTests/resources/json/consented/amend-divorce-details-d81-joint.json
@@ -5,6 +5,7 @@
     "id" : "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "Yes",

--- a/src/functionalTests/resources/json/consented/amend-divorce-details-decree-absolute1.json
+++ b/src/functionalTests/resources/json/consented/amend-divorce-details-decree-absolute1.json
@@ -5,6 +5,7 @@
     "id" : "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/functionalTests/resources/json/consented/amend-divorce-details-decree-nisi1.json
+++ b/src/functionalTests/resources/json/consented/amend-divorce-details-decree-nisi1.json
@@ -5,6 +5,7 @@
     "id" : "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/functionalTests/resources/json/consented/amend-periodic-payment-order-without-agreement1.json
+++ b/src/functionalTests/resources/json/consented/amend-periodic-payment-order-without-agreement1.json
@@ -5,6 +5,7 @@
     "id" : "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/functionalTests/resources/json/consented/amend-periodic-payment-order1.json
+++ b/src/functionalTests/resources/json/consented/amend-periodic-payment-order1.json
@@ -5,6 +5,7 @@
     "id" : "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/functionalTests/resources/json/consented/amend-property-adjustment-details1.json
+++ b/src/functionalTests/resources/json/consented/amend-property-adjustment-details1.json
@@ -5,6 +5,7 @@
     "id" : "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/functionalTests/resources/json/consented/amend-remove-periodic-payment-order1.json
+++ b/src/functionalTests/resources/json/consented/amend-remove-periodic-payment-order1.json
@@ -5,6 +5,7 @@
     "id" : "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/functionalTests/resources/json/consented/approved-consent-order-with-applicant-solicitor.json
+++ b/src/functionalTests/resources/json/consented/approved-consent-order-with-applicant-solicitor.json
@@ -5,6 +5,7 @@
       "id" : "12345678",
       "jurisdiction": "divorce",
       "state": "referredToJudge",
+      "case_type_id": "FinancialRemedyMVP2",
       "case_data": {
         "latestConsentOrder": {
          "document_url": "http://dm-store:8080/documents/ff08dbe1-dd16-4ec5-8b72-4c5379e0455f",

--- a/src/functionalTests/resources/json/consented/approved-consent-order.json
+++ b/src/functionalTests/resources/json/consented/approved-consent-order.json
@@ -5,6 +5,7 @@
       "id" : "12345678",
       "jurisdiction": "divorce",
       "state": "referredToJudge",
+      "case_type_id": "FinancialRemedyMVP2",
       "case_data": {
       "latestConsentOrder": {
          "document_url": "http://dm-store:8080/documents/ff08dbe1-dd16-4ec5-8b72-4c5379e0455f",

--- a/src/functionalTests/resources/json/consented/bulk-print.json
+++ b/src/functionalTests/resources/json/consented/bulk-print.json
@@ -4,6 +4,7 @@
     "id": "123",
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123",
       "d81Question": "No",

--- a/src/functionalTests/resources/json/consented/ccd-migrate-request1.json
+++ b/src/functionalTests/resources/json/consented/ccd-migrate-request1.json
@@ -5,6 +5,7 @@
     "id" : "12345678",
     "jurisdiction":"divorce",
     "state":"created",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/functionalTests/resources/json/consented/ccd-request-with-solicitor-assignedToJudge1.json
+++ b/src/functionalTests/resources/json/consented/ccd-request-with-solicitor-assignedToJudge1.json
@@ -312,6 +312,7 @@
     },
     "id": "12345678",
     "jurisdiction": "divorce",
-    "state": "created"
+    "state": "created",
+    "case_type_id": "FinancialRemedyMVP2"
   }
 }

--- a/src/functionalTests/resources/json/consented/ccd-request-with-solicitor-consentOrderAvailable1.json
+++ b/src/functionalTests/resources/json/consented/ccd-request-with-solicitor-consentOrderAvailable1.json
@@ -315,7 +315,8 @@
     },
     "id": 12345,
     "jurisdiction": "string",
-    "state": "string"
+    "state": "string",
+    "case_type_id": "FinancialRemedyMVP2"
   },
   "event_id": "string",
   "token": "string"

--- a/src/functionalTests/resources/json/consented/ccd-request-with-solicitor-consentOrderMade1.json
+++ b/src/functionalTests/resources/json/consented/ccd-request-with-solicitor-consentOrderMade1.json
@@ -312,6 +312,7 @@
     },
     "id": "12345678",
     "jurisdiction": "divorce",
-    "state": "created"
+    "state": "created",
+    "case_type_id": "FinancialRemedyMVP2"
   }
 }

--- a/src/functionalTests/resources/json/consented/ccd-request-with-solicitor-consentOrderNotApproved1.json
+++ b/src/functionalTests/resources/json/consented/ccd-request-with-solicitor-consentOrderNotApproved1.json
@@ -312,6 +312,7 @@
     },
     "id": "12345678",
     "jurisdiction": "divorce",
-    "state": "created"
+    "state": "created",
+    "case_type_id": "FinancialRemedyMVP2"
   }
 }

--- a/src/functionalTests/resources/json/consented/ccd-request-with-solicitor-hwfSuccessfulEmail1.json
+++ b/src/functionalTests/resources/json/consented/ccd-request-with-solicitor-hwfSuccessfulEmail1.json
@@ -312,6 +312,7 @@
     },
     "id": "12345678",
     "jurisdiction": "divorce",
-    "state": "created"
+    "state": "created",
+    "case_type_id": "FinancialRemedyMVP2"
   }
 }

--- a/src/functionalTests/resources/json/consented/document-rejected-order1.json
+++ b/src/functionalTests/resources/json/consented/document-rejected-order1.json
@@ -4,6 +4,7 @@
   "case_details": {
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/functionalTests/resources/json/consented/documentGeneratePayload1.json
+++ b/src/functionalTests/resources/json/consented/documentGeneratePayload1.json
@@ -5,6 +5,7 @@
         "id" : "12345678",
         "jurisdiction": "divorce",
         "state": "created",
+        "case_type_id": "FinancialRemedyMVP2",
         "case_data": {
             "PBANumber": "PBA123456",
             "d81Question": "No",

--- a/src/functionalTests/resources/json/consented/documentValidation/valiadate-draft-consent-order.json
+++ b/src/functionalTests/resources/json/consented/documentValidation/valiadate-draft-consent-order.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/functionalTests/resources/json/consented/draft-consent-order.json
+++ b/src/functionalTests/resources/json/consented/draft-consent-order.json
@@ -5,6 +5,7 @@
     "id" : "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/functionalTests/resources/json/consented/empty-casedata1.json
+++ b/src/functionalTests/resources/json/consented/empty-casedata1.json
@@ -2,6 +2,7 @@
   "event_id": "some_event_id",
   "case_details": {
     "jurisdiction": "DIVORCE",
-    "state": "applicationDrafted"
+    "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyMVP2"
   }
 }

--- a/src/functionalTests/resources/json/consented/fee-lookup_consented.json
+++ b/src/functionalTests/resources/json/consented/fee-lookup_consented.json
@@ -4,6 +4,7 @@
   "case_details": {
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/functionalTests/resources/json/consented/hwfPayment.json
+++ b/src/functionalTests/resources/json/consented/hwfPayment.json
@@ -4,6 +4,7 @@
     "id": "18762000",
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "d81Question": "No",
       "PBAreference": "ABCD",

--- a/src/functionalTests/resources/json/consented/notify-assign-to-judge1.json
+++ b/src/functionalTests/resources/json/consented/notify-assign-to-judge1.json
@@ -4,6 +4,7 @@
   "case_details": {
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/functionalTests/resources/json/consented/pba-confirmation1.json
+++ b/src/functionalTests/resources/json/consented/pba-confirmation1.json
@@ -312,7 +312,8 @@
     },
     "id": "string",
     "jurisdiction": "string",
-    "state": "string"
+    "state": "string",
+    "case_type_id": "FinancialRemedyMVP2"
   },
   "event_id": "string",
   "token": "string"

--- a/src/functionalTests/resources/json/consented/pba-payment.json
+++ b/src/functionalTests/resources/json/consented/pba-payment.json
@@ -4,6 +4,7 @@
     "id": "123",
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123",
       "d81Question": "No",

--- a/src/functionalTests/resources/json/consented/pba-validate1.json
+++ b/src/functionalTests/resources/json/consented/pba-validate1.json
@@ -4,6 +4,7 @@
     "id": "95959595",
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA222",
       "d81Question": "No",

--- a/src/functionalTests/resources/json/consented/remove-property-adjustment-details1.json
+++ b/src/functionalTests/resources/json/consented/remove-property-adjustment-details1.json
@@ -5,6 +5,7 @@
     "id" : "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/functionalTests/resources/json/consented/remove-respondent-solicitor-details1.json
+++ b/src/functionalTests/resources/json/consented/remove-respondent-solicitor-details1.json
@@ -5,6 +5,7 @@
     "id" : "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/functionalTests/resources/json/consented/respond-to-order-solicitor.json
+++ b/src/functionalTests/resources/json/consented/respond-to-order-solicitor.json
@@ -5,6 +5,7 @@
     "id" : "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/functionalTests/resources/json/contested/SuccessPaymentRequestPayload.json
+++ b/src/functionalTests/resources/json/contested/SuccessPaymentRequestPayload.json
@@ -4,6 +4,7 @@
     "id": "17878767",
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "helpWithFeesQuestion": "No",
       "PBANumber": "PBA0066906",

--- a/src/functionalTests/resources/json/contested/SuccessPaymentRequestPayload_Contested.json
+++ b/src/functionalTests/resources/json/contested/SuccessPaymentRequestPayload_Contested.json
@@ -6,6 +6,7 @@
     "id": "100050018",
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
      "ignore_warning": false,
       "event_data": {

--- a/src/functionalTests/resources/json/contested/SuccessPaymentRequestPayload_Contested_Duplicate.json
+++ b/src/functionalTests/resources/json/contested/SuccessPaymentRequestPayload_Contested_Duplicate.json
@@ -6,6 +6,7 @@
     "id": "100090018",
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
      "ignore_warning": false,
       "event_data": {

--- a/src/functionalTests/resources/json/contested/amend-divorce-details-decree-absolute1.json
+++ b/src/functionalTests/resources/json/contested/amend-divorce-details-decree-absolute1.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti0012",

--- a/src/functionalTests/resources/json/contested/amend-divorce-details-decree-nisi1.json
+++ b/src/functionalTests/resources/json/contested/amend-divorce-details-decree-nisi1.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti0012",

--- a/src/functionalTests/resources/json/contested/amend-divorce-details-petition-issued1.json
+++ b/src/functionalTests/resources/json/contested/amend-divorce-details-petition-issued1.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "applicantLName": "Ramisetti",
       "dateOfMarriage": "2012-10-10",

--- a/src/functionalTests/resources/json/contested/application-submitted-to-gateKeepingState1.json
+++ b/src/functionalTests/resources/json/contested/application-submitted-to-gateKeepingState1.json
@@ -4,6 +4,7 @@
   "case_details": {
     "jurisdiction": "DIVORCE",
     "state": "applicationSubmitted",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/functionalTests/resources/json/contested/ccd-request-with-solicitor-contestApplicationIssued.json
+++ b/src/functionalTests/resources/json/contested/ccd-request-with-solicitor-contestApplicationIssued.json
@@ -58,6 +58,11 @@
         "document_filename": "file1",
         "document_binary_url": "http://file1.binary"
       },
+      "allocatedCourtList": {
+        "region": "southeast",
+        "southEastList": "kentfrc",
+        "kentSurreyCourtList": "FR_kent_surrey_hc_list_1"
+      },
       "divorceCaseNumber": "DD12D12345",
       "divorceDecreeAbsoluteDate": "2020-02-21",
       "divorceDecreeNisiDate": "2019-02-21",

--- a/src/functionalTests/resources/json/contested/ccd-request-with-solicitor-contestApplicationIssued.json
+++ b/src/functionalTests/resources/json/contested/ccd-request-with-solicitor-contestApplicationIssued.json
@@ -312,7 +312,6 @@
     },
     "id": "12345678",
     "jurisdiction": "divorce",
-    "state": "created",
-    "case_type_id": "FinancialRemedyContested"
+    "state": "created"
   }
 }

--- a/src/functionalTests/resources/json/contested/ccd-request-with-solicitor-contestApplicationIssued.json
+++ b/src/functionalTests/resources/json/contested/ccd-request-with-solicitor-contestApplicationIssued.json
@@ -312,6 +312,7 @@
     },
     "id": "12345678",
     "jurisdiction": "divorce",
-    "state": "created"
+    "state": "created",
+    "case_type_id": "FinancialRemedyContested"
   }
 }

--- a/src/functionalTests/resources/json/contested/ccd-request-with-solicitor-contestOrderApproved.json
+++ b/src/functionalTests/resources/json/contested/ccd-request-with-solicitor-contestOrderApproved.json
@@ -7,6 +7,11 @@
       "PBANumber": "PBA222",
       "PBAPaymentReference": "PBAPaymentRef123",
       "PBAreference": "PBARef123",
+      "allocatedCourtList": {
+        "region": "southeast",
+        "southEastList": "kentfrc",
+        "kentSurreyCourtList": "FR_kent_surrey_hc_list_1"
+      },
       "amendedConsentOrderCollection": [
         {
           "id": "1",

--- a/src/functionalTests/resources/json/contested/ccd-request-with-solicitor-contestOrderApproved.json
+++ b/src/functionalTests/resources/json/contested/ccd-request-with-solicitor-contestOrderApproved.json
@@ -312,7 +312,6 @@
     },
     "id": "12345678",
     "jurisdiction": "divorce",
-    "state": "created",
-    "case_type_id": "FinancialRemedyContested"
+    "state": "created"
   }
 }

--- a/src/functionalTests/resources/json/contested/ccd-request-with-solicitor-contestOrderApproved.json
+++ b/src/functionalTests/resources/json/contested/ccd-request-with-solicitor-contestOrderApproved.json
@@ -312,6 +312,7 @@
     },
     "id": "12345678",
     "jurisdiction": "divorce",
-    "state": "created"
+    "state": "created",
+    "case_type_id": "FinancialRemedyContested"
   }
 }

--- a/src/functionalTests/resources/json/contested/ccd-request-with-solicitor-prepareForHearing.json
+++ b/src/functionalTests/resources/json/contested/ccd-request-with-solicitor-prepareForHearing.json
@@ -7,6 +7,11 @@
       "PBANumber": "PBA222",
       "PBAPaymentReference": "PBAPaymentRef123",
       "PBAreference": "PBARef123",
+      "allocatedCourtList": {
+        "region": "southeast",
+        "southEastList": "kentfrc",
+        "kentSurreyCourtList": "FR_kent_surrey_hc_list_1"
+      },
       "amendedConsentOrderCollection": [
         {
           "id": "1",

--- a/src/functionalTests/resources/json/contested/ccd-request-with-solicitor-prepareForHearing.json
+++ b/src/functionalTests/resources/json/contested/ccd-request-with-solicitor-prepareForHearing.json
@@ -312,7 +312,6 @@
     },
     "id": "12345678",
     "jurisdiction": "divorce",
-    "state": "created",
-    "case_type_id": "FinancialRemedyContested"
+    "state": "created"
   }
 }

--- a/src/functionalTests/resources/json/contested/ccd-request-with-solicitor-prepareForHearing.json
+++ b/src/functionalTests/resources/json/contested/ccd-request-with-solicitor-prepareForHearing.json
@@ -312,6 +312,7 @@
     },
     "id": "12345678",
     "jurisdiction": "divorce",
-    "state": "created"
+    "state": "created",
+    "case_type_id": "FinancialRemedyContested"
   }
 }

--- a/src/functionalTests/resources/json/contested/cleanup-addtional-documents1.json
+++ b/src/functionalTests/resources/json/contested/cleanup-addtional-documents1.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti",

--- a/src/functionalTests/resources/json/contested/cleanup-miam-certification-details-when-applicant-attended-miam1.json
+++ b/src/functionalTests/resources/json/contested/cleanup-miam-certification-details-when-applicant-attended-miam1.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti",

--- a/src/functionalTests/resources/json/contested/contested-case-details-options-list1.json
+++ b/src/functionalTests/resources/json/contested/contested-case-details-options-list1.json
@@ -2,6 +2,7 @@
   "id" : "12345678",
   "jurisdiction":"divorce",
   "state":"created",
+  "case_type_id": "FinancialRemedyContested",
   "case_data": {
     "MIAMExemptionsChecklist": [
       "domesticViolence",

--- a/src/functionalTests/resources/json/contested/do-not-change-to-gateKeepingState1.json
+++ b/src/functionalTests/resources/json/contested/do-not-change-to-gateKeepingState1.json
@@ -4,6 +4,7 @@
   "case_details": {
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/functionalTests/resources/json/contested/do-not-remove-checklists1.json
+++ b/src/functionalTests/resources/json/contested/do-not-remove-checklists1.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti0012",

--- a/src/functionalTests/resources/json/contested/expected-contested-case-details1.json
+++ b/src/functionalTests/resources/json/contested/expected-contested-case-details1.json
@@ -2,6 +2,7 @@
   "id" : "12345678",
   "jurisdiction":"divorce",
   "state":"created",
+  "case_type_id": "FinancialRemedyContested",
   "case_data": {
     "MIAMExemptionsChecklist": [
       "Domestic violence",

--- a/src/functionalTests/resources/json/contested/fee-lookup_contested.json
+++ b/src/functionalTests/resources/json/contested/fee-lookup_contested.json
@@ -4,6 +4,7 @@
     "id": "123",
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "PBAreference": "ABCD",
       "helpWithFeesQuestion": "No",

--- a/src/functionalTests/resources/json/contested/generate-contested-form-A1.json
+++ b/src/functionalTests/resources/json/contested/generate-contested-form-A1.json
@@ -4,6 +4,7 @@
     "id": "123",
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "PBANumber": "PBA123",
       "d81Question": "No",

--- a/src/functionalTests/resources/json/contested/hwfPayment.json
+++ b/src/functionalTests/resources/json/contested/hwfPayment.json
@@ -4,6 +4,7 @@
     "id": "93939393",
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "helpWithFeesQuestion": "Yes",
       "applicantLName":"Guy",

--- a/src/functionalTests/resources/json/contested/is-applicant-home-court1.json
+++ b/src/functionalTests/resources/json/contested/is-applicant-home-court1.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti0012",

--- a/src/functionalTests/resources/json/contested/miam-attend-exempt1.json
+++ b/src/functionalTests/resources/json/contested/miam-attend-exempt1.json
@@ -4,6 +4,7 @@
     "id": "123",
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "PBANumber": "PBA123",
       "d81Question": "No",

--- a/src/functionalTests/resources/json/contested/miam-valid-attend-exempt1.json
+++ b/src/functionalTests/resources/json/contested/miam-valid-attend-exempt1.json
@@ -4,6 +4,7 @@
     "id": "123",
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "PBANumber": "PBA123",
       "d81Question": "No",

--- a/src/functionalTests/resources/json/contested/pba-payment_contested.json
+++ b/src/functionalTests/resources/json/contested/pba-payment_contested.json
@@ -6,6 +6,7 @@
     "id": "17878710",
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
      "ignore_warning": false,
       "event_data": {

--- a/src/functionalTests/resources/json/contested/pba-validate.json
+++ b/src/functionalTests/resources/json/contested/pba-validate.json
@@ -4,6 +4,7 @@
     "id": "989898",
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "helpWithFeesQuestion": "No",
       "applicantLName":"Guy",

--- a/src/functionalTests/resources/json/contested/remove-additional-property-details1.json
+++ b/src/functionalTests/resources/json/contested/remove-additional-property-details1.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti0012",

--- a/src/functionalTests/resources/json/contested/remove-complexity-details1.json
+++ b/src/functionalTests/resources/json/contested/remove-complexity-details1.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti0012",

--- a/src/functionalTests/resources/json/contested/remove-domestic-violence-checklist1.json
+++ b/src/functionalTests/resources/json/contested/remove-domestic-violence-checklist1.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti0012",

--- a/src/functionalTests/resources/json/contested/remove-exceptions-when-applicant-attended-miam1.json
+++ b/src/functionalTests/resources/json/contested/remove-exceptions-when-applicant-attended-miam1.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti0012",

--- a/src/functionalTests/resources/json/contested/remove-miam-certification-details1.json
+++ b/src/functionalTests/resources/json/contested/remove-miam-certification-details1.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti",

--- a/src/functionalTests/resources/json/contested/remove-other-checklist1.json
+++ b/src/functionalTests/resources/json/contested/remove-other-checklist1.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti0012",

--- a/src/functionalTests/resources/json/contested/remove-other-reason-for-complexity1.json
+++ b/src/functionalTests/resources/json/contested/remove-other-reason-for-complexity1.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti0012",

--- a/src/functionalTests/resources/json/contested/remove-periodic-payment-order-details1.json
+++ b/src/functionalTests/resources/json/contested/remove-periodic-payment-order-details1.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti0012",

--- a/src/functionalTests/resources/json/contested/remove-previousMiamAttendance-checklist1.json
+++ b/src/functionalTests/resources/json/contested/remove-previousMiamAttendance-checklist1.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti0012",

--- a/src/functionalTests/resources/json/contested/remove-property-adjustment-order-details1.json
+++ b/src/functionalTests/resources/json/contested/remove-property-adjustment-order-details1.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti0012",

--- a/src/functionalTests/resources/json/contested/remove-respondent-address-details1.json
+++ b/src/functionalTests/resources/json/contested/remove-respondent-address-details1.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti0012",

--- a/src/functionalTests/resources/json/contested/remove-respondent-solicitor-details1.json
+++ b/src/functionalTests/resources/json/contested/remove-respondent-solicitor-details1.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti0012",

--- a/src/functionalTests/resources/json/contested/remove-urgency-checklist1.json
+++ b/src/functionalTests/resources/json/contested/remove-urgency-checklist1.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti0012",

--- a/src/functionalTests/resources/json/contested/update-miam-exceptions-when-applicant-attended-family-mediator1.json
+++ b/src/functionalTests/resources/json/contested/update-miam-exceptions-when-applicant-attended-family-mediator1.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti0012",

--- a/src/functionalTests/resources/json/contested/update-miam-exceptions-when-applicant-not-claiming-exemption1.json
+++ b/src/functionalTests/resources/json/contested/update-miam-exceptions-when-applicant-not-claiming-exemption1.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti0012",

--- a/src/functionalTests/resources/json/contested/update-periodic-payment-details-for-no-payment-for-children1.json
+++ b/src/functionalTests/resources/json/contested/update-periodic-payment-details-for-no-payment-for-children1.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti0012",

--- a/src/functionalTests/resources/json/contested/update-periodic-payment-details-with-benefits-for-children1.json
+++ b/src/functionalTests/resources/json/contested/update-periodic-payment-details-with-benefits-for-children1.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti0012",

--- a/src/functionalTests/resources/json/contested/update-property-adjustment-order-details1.json
+++ b/src/functionalTests/resources/json/contested/update-property-adjustment-order-details1.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti0012",

--- a/src/functionalTests/resources/json/contested/validate-hearing-successfully1.json
+++ b/src/functionalTests/resources/json/contested/validate-hearing-successfully1.json
@@ -4,6 +4,7 @@
     "id": "123",
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "PBANumber": "PBA123",
       "d81Question": "No",

--- a/src/functionalTests/resources/json/contested/validate-hearing-with-fastTrackDecision1.json
+++ b/src/functionalTests/resources/json/contested/validate-hearing-with-fastTrackDecision1.json
@@ -4,6 +4,7 @@
     "id": "123",
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "PBANumber": "PBA123",
       "d81Question": "No",

--- a/src/functionalTests/resources/json/contested/validate-hearing-with-hearingdate1.json
+++ b/src/functionalTests/resources/json/contested/validate-hearing-with-hearingdate1.json
@@ -4,6 +4,7 @@
     "id": "123",
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "PBANumber": "PBA123",
       "d81Question": "No",

--- a/src/functionalTests/resources/json/contested/validate-hearing-without-fastTrackDecision1.json
+++ b/src/functionalTests/resources/json/contested/validate-hearing-without-fastTrackDecision1.json
@@ -4,6 +4,7 @@
     "id": "123",
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "PBANumber": "PBA123",
       "d81Question": "No",

--- a/src/functionalTests/resources/json/contested/with-mini-form-A1.json
+++ b/src/functionalTests/resources/json/contested/with-mini-form-A1.json
@@ -4,6 +4,7 @@
     "id": "123",
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "PBANumber": "PBA123",
       "d81Question": "No",

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/OrchestrationConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/OrchestrationConstants.java
@@ -13,6 +13,7 @@ public class OrchestrationConstants {
     // Bulk Scan & Printing
     public static final String BULK_SCAN_CASE_REFERENCE = "bulkScanCaseReference";
     public static final String CASE_TYPE_ID_CONSENTED = "FinancialRemedyMVP2";
+    public static final String CASE_TYPE_ID_CONTESTED = "FinancialRemedyContested";
     public static final String PAPER_APPLICATION = "paperApplication";
 
     public static final String BINARY_URL_TYPE = "binary";

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/BaseController.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/BaseController.java
@@ -7,9 +7,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
-import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.D81_QUESTION;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.HELP_WITH_FEES_QUESTION;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.PBA_PAYMENT_REFERENCE;
 
@@ -20,10 +18,6 @@ public interface BaseController {
             || callbackRequest.getCaseDetails().getData() == null) {
             throw new InvalidCaseDataException(BAD_REQUEST.value(), "Missing data from callbackRequest.");
         }
-    }
-
-    static boolean isConsentedApplication(Map<String, Object> caseData) {
-        return isNotEmpty((String) caseData.get(D81_QUESTION));
     }
 
     default boolean isPBAPayment(Map<String, Object> caseData) {

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/FeeLookupController.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/FeeLookupController.java
@@ -28,10 +28,10 @@ import java.util.Map;
 import java.util.Objects;
 
 import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.AUTHORIZATION_HEADER;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.controllers.BaseController.isConsentedApplication;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ApplicationType.CONSENTED;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ApplicationType.CONTESTED;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.PBA_REFERENCE;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.isConsentedApplication;
 
 @RestController
 @RequiredArgsConstructor
@@ -53,11 +53,11 @@ public class FeeLookupController implements BaseController {
 
         validateCaseData(callbackRequest);
 
-        Map<String, Object> mapOfCaseData = caseDetails.getData();
-        ApplicationType applicationType = isConsentedApplication(mapOfCaseData) ? CONSENTED : CONTESTED;
+        ApplicationType applicationType = isConsentedApplication(caseDetails) ? CONSENTED : CONTESTED;
         FeeResponse feeResponse = feeService.getApplicationFee(applicationType);
 
         FeeCaseData feeResponseData = FeeCaseData.builder().build();
+        Map<String, Object> mapOfCaseData = caseDetails.getData();
         updateCaseWithFee(mapOfCaseData, feeResponseData, feeResponse);
         ObjectMapper objectMapper = new ObjectMapper();
         return ResponseEntity.ok(AboutToStartOrSubmitCallbackResponse.builder()

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/NotificationsController.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/NotificationsController.java
@@ -23,8 +23,8 @@ import java.util.Map;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.AUTHORIZATION_HEADER;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.controllers.BaseController.isConsentedApplication;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.isApplicantSolicitorAgreeToReceiveEmails;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.isConsentedApplication;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.isPaperApplication;
 
 @RestController
@@ -49,7 +49,7 @@ public class NotificationsController implements BaseController {
         Map<String, Object> caseData = callbackRequest.getCaseDetails().getData();
 
         if (isApplicantSolicitorAgreeToReceiveEmails(caseData)) {
-            if (isConsentedApplication(caseData)) {
+            if (isConsentedApplication(callbackRequest.getCaseDetails())) {
                 log.info("Sending Consented HWF Successful email notification to Solicitor");
                 notificationService.sendConsentedHWFSuccessfulConfirmationEmail(callbackRequest);
             } else {

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/PBAPaymentController.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/PBAPaymentController.java
@@ -22,7 +22,6 @@ import uk.gov.hmcts.reform.finrem.caseorchestration.service.PBAPaymentService;
 import javax.validation.constraints.NotNull;
 
 import java.util.Map;
-import java.util.Objects;
 
 import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.AUTHORIZATION_HEADER;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ConsentedStatus.AWAITING_HWF_DECISION;
@@ -59,8 +58,7 @@ public class PBAPaymentController implements BaseController {
 
         if (isPBAPayment(mapOfCaseData)) {
             if (isPBAPaymentReferenceDoesNotExists(mapOfCaseData)) {
-                String ccdCaseId = Objects.toString(callbackRequest.getCaseDetails().getId());
-                PaymentResponse paymentResponse = pbaPaymentService.makePayment(authToken, ccdCaseId, mapOfCaseData);
+                PaymentResponse paymentResponse = pbaPaymentService.makePayment(authToken, caseDetails);
                 if (!paymentResponse.isPaymentSuccess()) {
                     return paymentFailure(mapOfCaseData, paymentResponse);
                 }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/PaymentConfirmationController.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/PaymentConfirmationController.java
@@ -19,7 +19,7 @@ import java.io.IOException;
 import java.util.Map;
 
 import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.AUTHORIZATION_HEADER;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.controllers.BaseController.isConsentedApplication;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.isConsentedApplication;
 
 @RestController
 @RequiredArgsConstructor
@@ -40,17 +40,17 @@ public class PaymentConfirmationController implements BaseController {
         log.info("Received request for PBA confirmation for Case ID: {}", caseDetails.getId());
 
         validateCaseData(callbackRequest);
-        Map<String,Object> caseData = caseDetails.getData();
 
         SubmittedCallbackResponse callbackResponse = SubmittedCallbackResponse.builder()
-            .confirmationBody(confirmationBody(caseData))
+            .confirmationBody(confirmationBody(caseDetails))
             .build();
 
         return ResponseEntity.ok(callbackResponse);
     }
 
-    private String confirmationBody(Map<String, Object> caseData) throws IOException {
-        boolean isConsentedApplication = isConsentedApplication(caseData);
+    private String confirmationBody(CaseDetails caseDetails) throws IOException {
+        boolean isConsentedApplication = isConsentedApplication(caseDetails);
+        Map<String,Object> caseData = caseDetails.getData();
         log.info("Application type isConsentedApplication : {}", isConsentedApplication);
 
         String confirmationBody;

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/CommonFunction.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/CommonFunction.java
@@ -4,6 +4,7 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.RespondToOrderData;
 
 import java.util.List;
@@ -13,6 +14,7 @@ import java.util.function.Function;
 
 import static uk.gov.hmcts.reform.bsp.common.mapper.AddressMapper.Field.LINE_1;
 import static uk.gov.hmcts.reform.bsp.common.mapper.AddressMapper.Field.POSTCODE;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.CASE_TYPE_ID_CONSENTED;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.PAPER_APPLICATION;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.YES_VALUE;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.AMENDED_CONSENT_ORDER;
@@ -73,5 +75,9 @@ public class CommonFunction {
 
     public static boolean isAmendedConsentOrderType(RespondToOrderData respondToOrderData) {
         return AMENDED_CONSENT_ORDER.equalsIgnoreCase(respondToOrderData.getRespondToOrder().getDocumentType());
+    }
+
+    public static boolean isConsentedApplication(CaseDetails caseDetails) {
+        return CASE_TYPE_ID_CONSENTED.equalsIgnoreCase(caseDetails.getCaseTypeId());
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/CommonFunction.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/CommonFunction.java
@@ -15,6 +15,7 @@ import java.util.function.Function;
 import static uk.gov.hmcts.reform.bsp.common.mapper.AddressMapper.Field.LINE_1;
 import static uk.gov.hmcts.reform.bsp.common.mapper.AddressMapper.Field.POSTCODE;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.CASE_TYPE_ID_CONSENTED;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.CASE_TYPE_ID_CONTESTED;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.PAPER_APPLICATION;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.YES_VALUE;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.AMENDED_CONSENT_ORDER;
@@ -79,5 +80,9 @@ public class CommonFunction {
 
     public static boolean isConsentedApplication(CaseDetails caseDetails) {
         return CASE_TYPE_ID_CONSENTED.equalsIgnoreCase(nullToEmpty(caseDetails.getCaseTypeId()));
+    }
+
+    public static boolean isContestedApplication(CaseDetails caseDetails) {
+        return CASE_TYPE_ID_CONTESTED.equalsIgnoreCase(nullToEmpty(caseDetails.getCaseTypeId()));
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/CommonFunction.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/CommonFunction.java
@@ -78,6 +78,6 @@ public class CommonFunction {
     }
 
     public static boolean isConsentedApplication(CaseDetails caseDetails) {
-        return CASE_TYPE_ID_CONSENTED.equalsIgnoreCase(caseDetails.getCaseTypeId());
+        return CASE_TYPE_ID_CONSENTED.equalsIgnoreCase(nullToEmpty(caseDetails.getCaseTypeId()));
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/NotificationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/NotificationService.java
@@ -18,15 +18,14 @@ import java.util.Map;
 import java.util.Objects;
 
 import static org.apache.commons.lang3.StringUtils.EMPTY;
-import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.springframework.web.util.UriComponentsBuilder.fromHttpUrl;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.ALLOCATED_COURT_LIST;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.CONTESTED_SOLICITOR_EMAIL;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.CONTESTED_SOLICITOR_NAME;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.D81_QUESTION;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_EMAIL;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_NAME;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_REFERENCE;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.isConsentedApplication;
 
 @Service
 @Slf4j
@@ -100,7 +99,7 @@ public class NotificationService {
 
     private void sendNotificationEmail(CallbackRequest callbackRequest, URI uri) {
         try {
-            if (isConsentedApplication(callbackRequest.getCaseDetails().getData())) {
+            if (isConsentedApplication(callbackRequest.getCaseDetails())) {
                 notificationRequest = buildNotificationRequest(callbackRequest, SOLICITOR_REFERENCE,
                         SOLICITOR_NAME, SOLICITOR_EMAIL, CONSENTED);
             } else {
@@ -162,11 +161,7 @@ public class NotificationService {
         return headers;
     }
 
-    private boolean isConsentedApplication(Map<String, Object> caseData) {
-        return isNotEmpty((String) caseData.get(D81_QUESTION));
-    }
-
-    private String getSelectedCourt(Object allocatedCourtList) throws IOException {
+    private String getSelectedCourt(Object allocatedCourtList) {
         HashMap<String, Object> allocatedCourtMap = (HashMap<String, Object>) allocatedCourtList;
         String region = (String) allocatedCourtMap.get(REGION);
         if ("midlands".equalsIgnoreCase(region)) {

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/PBAPaymentControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/PBAPaymentControllerTest.java
@@ -68,7 +68,7 @@ public class PBAPaymentControllerTest extends BaseControllerTest {
         requestContent = objectMapper.readTree(new File(getClass().getResource("/fixtures/pba-payment.json").toURI()));
 
         when(feeService.getApplicationFee(CONSENTED)).thenReturn(fee(CONSENTED));
-        when(pbaPaymentService.makePayment(anyString(), anyString(), any())).thenReturn(paymentResponse(success));
+        when(pbaPaymentService.makePayment(anyString(), any())).thenReturn(paymentResponse(success));
     }
 
     private void doPBAPaymentReferenceAlreadyExistsSetup() throws Exception {
@@ -76,7 +76,7 @@ public class PBAPaymentControllerTest extends BaseControllerTest {
         requestContent = objectMapper.readTree(new File(getClass().getResource(pbaPaymentAlreadyExists).toURI()));
 
         when(feeService.getApplicationFee(CONSENTED)).thenReturn(fee(CONSENTED));
-        when(pbaPaymentService.makePayment(anyString(), anyString(), any())).thenReturn(paymentResponse(true));
+        when(pbaPaymentService.makePayment(anyString(), any())).thenReturn(paymentResponse(true));
     }
 
     private void doHWFSetUp() throws Exception {
@@ -102,7 +102,7 @@ public class PBAPaymentControllerTest extends BaseControllerTest {
                 .andExpect(jsonPath("$.data.amountToPay", is("1000")))
                 .andExpect(jsonPath("$.errors", is(emptyOrNullString())))
                 .andExpect(jsonPath("$.warnings", is(emptyOrNullString())));
-        verify(pbaPaymentService, never()).makePayment(anyString(), anyString(), any());
+        verify(pbaPaymentService, never()).makePayment(anyString(), any());
     }
 
     @Test
@@ -115,7 +115,7 @@ public class PBAPaymentControllerTest extends BaseControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.errors", hasSize(1)))
                 .andExpect(jsonPath("$.warnings", is(emptyOrNullString())));
-        verify(pbaPaymentService, times(1)).makePayment(anyString(), anyString(), any());
+        verify(pbaPaymentService, times(1)).makePayment(anyString(), any());
 
     }
 
@@ -134,7 +134,7 @@ public class PBAPaymentControllerTest extends BaseControllerTest {
                 .andExpect(jsonPath("$.data.amountToPay", is("1000")))
                 .andExpect(jsonPath("$.errors", is(emptyOrNullString())))
                 .andExpect(jsonPath("$.warnings", is(emptyOrNullString())));
-        verify(pbaPaymentService, times(1)).makePayment(anyString(), anyString(), any());
+        verify(pbaPaymentService, times(1)).makePayment(anyString(), any());
     }
 
     @Test
@@ -147,6 +147,6 @@ public class PBAPaymentControllerTest extends BaseControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.errors", is(emptyOrNullString())))
                 .andExpect(jsonPath("$.warnings", is(emptyOrNullString())));
-        verify(pbaPaymentService, times(0)).makePayment(anyString(), anyString(), any());
+        verify(pbaPaymentService, times(0)).makePayment(anyString(), any());
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/CommonFunctionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/CommonFunctionTest.java
@@ -29,6 +29,7 @@ import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunctio
 import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.isApplicantRepresentedByASolicitor;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.isApplicantSolicitorAgreeToReceiveEmails;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.isConsentedApplication;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.isContestedApplication;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.isNotEmpty;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.isRespondentRepresentedByASolicitor;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.nullToEmpty;
@@ -247,6 +248,30 @@ public class CommonFunctionTest {
             "/fixtures/empty-casedata.json"), CallbackRequest.class).getCaseDetails();
 
         assertThat(isConsentedApplication(caseDetails), is(false));
+    }
+
+    @Test
+    public void isContestedApplicationShouldReturnTrueWheCaseTypeIsSetToContested() throws IOException {
+        CaseDetails caseDetails = mapper.readValue(getClass().getResourceAsStream(
+            "/fixtures/contested/contested-hwf-without-solicitor-consent.json"), CallbackRequest.class).getCaseDetails();
+
+        assertThat(isContestedApplication(caseDetails), is(true));
+    }
+
+    @Test
+    public void isContestedApplicationShouldReturnFalseWheCaseTypeIsSetToConsented() throws IOException {
+        CaseDetails caseDetails = mapper.readValue(getClass().getResourceAsStream(
+            "/fixtures/valid-latest-consent-order.json"), CallbackRequest.class).getCaseDetails();
+
+        assertThat(isContestedApplication(caseDetails), is(false));
+    }
+
+    @Test
+    public void isContestedApplicationShouldReturnFalseWheCaseTypeIsSetToNull() throws IOException {
+        CaseDetails caseDetails = mapper.readValue(getClass().getResourceAsStream(
+            "/fixtures/empty-casedata.json"), CallbackRequest.class).getCaseDetails();
+
+        assertThat(isContestedApplication(caseDetails), is(false));
     }
 
     private static RespondToOrderData getRespondToOrderData(String s) {

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/CommonFunctionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/CommonFunctionTest.java
@@ -1,10 +1,14 @@
 package uk.gov.hmcts.reform.finrem.caseorchestration.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
+import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.RespondToOrder;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.RespondToOrderData;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -24,12 +28,14 @@ import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunctio
 import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.isAmendedConsentOrderType;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.isApplicantRepresentedByASolicitor;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.isApplicantSolicitorAgreeToReceiveEmails;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.isConsentedApplication;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.isNotEmpty;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.isRespondentRepresentedByASolicitor;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CommonFunction.nullToEmpty;
 
 public class CommonFunctionTest {
 
+    private final ObjectMapper mapper = new ObjectMapper();
     private static String F_NAME = "f";
     private static String L_NAME = "l";
 
@@ -217,6 +223,30 @@ public class CommonFunctionTest {
     @Test
     public void isAmendedConsentOrderTypeShouldReturnTrueWhenDocumentTypeIsAmendedConsentOrder() {
         assertThat(isAmendedConsentOrderType(getRespondToOrderData(AMENDED_CONSENT_ORDER)), is(true));
+    }
+
+    @Test
+    public void isConsentedApplicationShouldReturnTrueWheCaseTypeIsSetToConsentedCaseType() throws IOException {
+        CaseDetails caseDetails = mapper.readValue(getClass().getResourceAsStream(
+            "/fixtures/valid-latest-consent-order.json"), CallbackRequest.class).getCaseDetails();
+
+        assertThat(isConsentedApplication(caseDetails), is(true));
+    }
+
+    @Test
+    public void isConsentedApplicationShouldReturnFalseWhenCaseTypeIsSetToContested() throws IOException {
+        CaseDetails caseDetails = mapper.readValue(getClass().getResourceAsStream(
+            "/fixtures/contested/contested-hwf-without-solicitor-consent.json"), CallbackRequest.class).getCaseDetails();
+
+        assertThat(isConsentedApplication(caseDetails), is(false));
+    }
+
+    @Test
+    public void isConsentedApplicationShouldReturnFalseWhenCaseTypeIsNull() throws IOException {
+        CaseDetails caseDetails = mapper.readValue(getClass().getResourceAsStream(
+            "/fixtures/empty-casedata.json"), CallbackRequest.class).getCaseDetails();
+
+        assertThat(isConsentedApplication(caseDetails), is(false));
     }
 
     private static RespondToOrderData getRespondToOrderData(String s) {

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/NotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/NotificationServiceTest.java
@@ -49,7 +49,7 @@ public class NotificationServiceTest extends BaseServiceTest {
     @Before
     public void setUp() {
         mockServer = MockRestServiceServer.createServer(restTemplate);
-        callbackRequest = getCallbackRequest();
+        callbackRequest = getConsentedCallbackRequest();
     }
 
     @Test
@@ -88,7 +88,7 @@ public class NotificationServiceTest extends BaseServiceTest {
 
 
         try {
-            notificationService.sendAssignToJudgeConfirmationEmail(getCallbackRequest());
+            notificationService.sendAssignToJudgeConfirmationEmail(getConsentedCallbackRequest());
         } catch (Exception ex) {
             assertThat(ex.getMessage(), Is.is(ERROR_500_MESSAGE));
         }
@@ -494,20 +494,21 @@ public class NotificationServiceTest extends BaseServiceTest {
         caseData.put(BULK_PRINT_LETTER_ID_RES, "notingham");
         return CallbackRequest.builder()
             .caseDetails(CaseDetails.builder()
+                .caseTypeId("FinancialRemedyContested")
                 .id(12345L)
                 .data(caseData)
                 .build())
             .build();
     }
 
-    private CallbackRequest getCallbackRequest() {
+    private CallbackRequest getConsentedCallbackRequest() {
         Map<String, Object> caseData = new HashMap<>();
-        caseData.put("d81Question", "No");
         caseData.put("solicitorEmail", "test@test.com");
         caseData.put("solicitorName", "solicitorName");
         caseData.put("solicitorReference", "56789");
         return CallbackRequest.builder()
             .caseDetails(CaseDetails.builder()
+                .caseTypeId("FinancialRemedyMVP2")
                 .id(12345L)
                 .data(caseData)
                 .build())

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/PBAPaymentServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/PBAPaymentServiceTest.java
@@ -59,8 +59,7 @@ public class PBAPaymentServiceTest extends BaseServiceTest {
                         + " ]"
                         + "}");
 
-        PaymentResponse paymentResponse = pbaPaymentService.makePayment(AUTH_TOKEN, "123",
-                callbackRequest.getCaseDetails().getData());
+        PaymentResponse paymentResponse = pbaPaymentService.makePayment(AUTH_TOKEN, callbackRequest.getCaseDetails());
 
         assertThat(paymentResponse.getReference(), is("RC-1545-2396-5857-4110"));
         assertThat(paymentResponse.getStatus(), is("Success"));
@@ -88,8 +87,7 @@ public class PBAPaymentServiceTest extends BaseServiceTest {
                         + " ]"
                         + "}");
 
-        PaymentResponse paymentResponse = pbaPaymentService.makePayment(AUTH_TOKEN, "123",
-                callbackRequest.getCaseDetails().getData());
+        PaymentResponse paymentResponse = pbaPaymentService.makePayment(AUTH_TOKEN, callbackRequest.getCaseDetails());
 
         assertThat(paymentResponse.getReference(), is("RC-1545-2396-5857-4110"));
         assertThat(paymentResponse.getStatus(), is("Failed"));
@@ -120,8 +118,7 @@ public class PBAPaymentServiceTest extends BaseServiceTest {
                         + " ]"
                         + "}");
 
-        PaymentResponse paymentResponse = pbaPaymentService.makePayment(AUTH_TOKEN, "123",
-                callbackRequest.getCaseDetails().getData());
+        PaymentResponse paymentResponse = pbaPaymentService.makePayment(AUTH_TOKEN, callbackRequest.getCaseDetails());
 
         assertThat(paymentResponse.getReference(), is("RC-1545-2396-5857-4110"));
         assertThat(paymentResponse.getStatus(), is("Failed"));
@@ -151,8 +148,7 @@ public class PBAPaymentServiceTest extends BaseServiceTest {
                         + " ]"
                         + "}");
 
-        PaymentResponse paymentResponse = pbaPaymentService.makePayment(AUTH_TOKEN, "123",
-                callbackRequest.getCaseDetails().getData());
+        PaymentResponse paymentResponse = pbaPaymentService.makePayment(AUTH_TOKEN, callbackRequest.getCaseDetails());
 
         assertThat(paymentResponse.getReference(), is("RC-1545-2396-5857-4110"));
         assertThat(paymentResponse.getStatus(), is("Failed"));
@@ -175,8 +171,7 @@ public class PBAPaymentServiceTest extends BaseServiceTest {
                         + "  \"path\": \"/credit-account-payments\""
                         + "}");
 
-        PaymentResponse paymentResponse = pbaPaymentService.makePayment(AUTH_TOKEN, "123",
-                callbackRequest.getCaseDetails().getData());
+        PaymentResponse paymentResponse = pbaPaymentService.makePayment(AUTH_TOKEN, callbackRequest.getCaseDetails());
 
         assertThat(paymentResponse.getReference(), nullValue());
         assertThat(paymentResponse.getStatus(), is("403"));

--- a/src/test/resources/fixtures/bulkprint/bulk-print-empty-solicitor-address.json
+++ b/src/test/resources/fixtures/bulkprint/bulk-print-empty-solicitor-address.json
@@ -5,6 +5,7 @@
     "id": 1234567890,
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/test/resources/fixtures/bulkprint/bulk-print-not-approved.json
+++ b/src/test/resources/fixtures/bulkprint/bulk-print-not-approved.json
@@ -5,6 +5,7 @@
     "id": 1234567890,
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/test/resources/fixtures/bulkprint/bulk-print-paper-application.json
+++ b/src/test/resources/fixtures/bulkprint/bulk-print-paper-application.json
@@ -4,6 +4,7 @@
     "id": "123",
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "state": "applicationDrafted",
       "PBANumber": "PBA123",

--- a/src/test/resources/fixtures/bulkprint/bulk-print-with-solicitors.json
+++ b/src/test/resources/fixtures/bulkprint/bulk-print-with-solicitors.json
@@ -5,6 +5,7 @@
     "id": 1234567890,
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/test/resources/fixtures/bulkprint/bulk-print.json
+++ b/src/test/resources/fixtures/bulkprint/bulk-print.json
@@ -5,6 +5,7 @@
     "id": 1234567890,
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/test/resources/fixtures/ccd-request-with-solicitor-email-consent.json
+++ b/src/test/resources/fixtures/ccd-request-with-solicitor-email-consent.json
@@ -5,6 +5,7 @@
     "id" : "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/test/resources/fixtures/ccd-request-without-field.json
+++ b/src/test/resources/fixtures/ccd-request-without-field.json
@@ -5,6 +5,7 @@
     "id" : "12345678",
     "jurisdiction":"divorce",
     "state":"created",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "amountToPay": "5000",
       "PBANumber": "PBA123456",

--- a/src/test/resources/fixtures/contested/amend-applicant-details.json
+++ b/src/test/resources/fixtures/contested/amend-applicant-details.json
@@ -4,6 +4,7 @@
     "id": "123",
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "helpWithFeesQuestion": "Yes",
       "applicantLName":"Guy",

--- a/src/test/resources/fixtures/contested/amend-applicant-solicitor-details.json
+++ b/src/test/resources/fixtures/contested/amend-applicant-solicitor-details.json
@@ -4,6 +4,7 @@
     "id": "123",
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "helpWithFeesQuestion": "Yes",
       "applicantLName":"Guy",

--- a/src/test/resources/fixtures/contested/amend-divorce-details-decree-absolute.json
+++ b/src/test/resources/fixtures/contested/amend-divorce-details-decree-absolute.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti0012",

--- a/src/test/resources/fixtures/contested/amend-divorce-details-decree-nisi.json
+++ b/src/test/resources/fixtures/contested/amend-divorce-details-decree-nisi.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti0012",

--- a/src/test/resources/fixtures/contested/amend-divorce-details-petition-issued.json
+++ b/src/test/resources/fixtures/contested/amend-divorce-details-petition-issued.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "applicantLName": "Ramisetti",
       "dateOfMarriage": "2012-10-10",

--- a/src/test/resources/fixtures/contested/application-submitted-to-gateKeepingState.json
+++ b/src/test/resources/fixtures/contested/application-submitted-to-gateKeepingState.json
@@ -4,6 +4,7 @@
   "case_details": {
     "jurisdiction": "DIVORCE",
     "state": "applicationSubmitted",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/test/resources/fixtures/contested/bulk_print_consent_order_approved.json
+++ b/src/test/resources/fixtures/contested/bulk_print_consent_order_approved.json
@@ -4,6 +4,7 @@
     "id": "123",
     "jurisdiction": "DIVORCE",
     "state": "consentOrderApproved",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "applicantRepresented": "Yes",
       "solicitorAgreeToReceiveEmails": "Yes",

--- a/src/test/resources/fixtures/contested/bulk_print_consent_order_not_approved.json
+++ b/src/test/resources/fixtures/contested/bulk_print_consent_order_not_approved.json
@@ -4,6 +4,7 @@
     "id": "123",
     "jurisdiction": "DIVORCE",
     "state": "orderMade",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "applicantRepresented": "No",
       "uploadOrder":[

--- a/src/test/resources/fixtures/contested/bulk_print_simple.json
+++ b/src/test/resources/fixtures/contested/bulk_print_simple.json
@@ -4,6 +4,7 @@
     "id": "123",
     "jurisdiction": "DIVORCE",
     "state": "consentOrderApproved",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "applicantRepresented": "Yes",
       "solicitorAgreeToReceiveEmails": "No",

--- a/src/test/resources/fixtures/contested/cleanup-addtional-documents.json
+++ b/src/test/resources/fixtures/contested/cleanup-addtional-documents.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti",

--- a/src/test/resources/fixtures/contested/cleanup-miam-certification-details-when-applicant-attended-miam.json
+++ b/src/test/resources/fixtures/contested/cleanup-miam-certification-details-when-applicant-attended-miam.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti",

--- a/src/test/resources/fixtures/contested/contested-case-details-options-list.json
+++ b/src/test/resources/fixtures/contested/contested-case-details-options-list.json
@@ -2,6 +2,7 @@
   "id" : "12345678",
   "jurisdiction":"divorce",
   "state":"created",
+  "case_type_id": "FinancialRemedyContested",
   "case_data": {
     "MIAMExemptionsChecklist": [
       "domesticViolence",

--- a/src/test/resources/fixtures/contested/contested-hwf-without-solicitor-consent.json
+++ b/src/test/resources/fixtures/contested/contested-hwf-without-solicitor-consent.json
@@ -4,6 +4,7 @@
     "id": "123",
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "helpWithFeesQuestion": "Yes",
       "applicantLName":"Guy",

--- a/src/test/resources/fixtures/contested/do-not-change-to-gateKeepingState.json
+++ b/src/test/resources/fixtures/contested/do-not-change-to-gateKeepingState.json
@@ -4,9 +4,9 @@
   "case_details": {
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "PBANumber": "PBA123456",
-      "d81Question": "No",
       "PBAreference": "ABCD",
       "consentOrder": {
         "document_url": "http://document-management-store:8080/documents/015500ba-c524-4614-86e5-c569f82c718d",

--- a/src/test/resources/fixtures/contested/do-not-remove-checklists.json
+++ b/src/test/resources/fixtures/contested/do-not-remove-checklists.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti0012",

--- a/src/test/resources/fixtures/contested/expected-contested-case-details.json
+++ b/src/test/resources/fixtures/contested/expected-contested-case-details.json
@@ -2,6 +2,7 @@
   "id" : "12345678",
   "jurisdiction":"divorce",
   "state":"created",
+  "case_type_id": "FinancialRemedyContested",
   "case_data": {
     "MIAMExemptionsChecklist": [
       "Domestic violence",

--- a/src/test/resources/fixtures/contested/fee-lookup.json
+++ b/src/test/resources/fixtures/contested/fee-lookup.json
@@ -4,6 +4,7 @@
     "id": "123",
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "PBAreference": "ABCD",
       "helpWithFeesQuestion": "No",

--- a/src/test/resources/fixtures/contested/generate-contested-form-A.json
+++ b/src/test/resources/fixtures/contested/generate-contested-form-A.json
@@ -4,9 +4,9 @@
     "id": "123",
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "PBANumber": "PBA123",
-      "d81Question": "No",
       "PBAreference": "ABCD",
       "consentOrder": {
         "document_url": "http://document-management-store:8080/documents/015500ba-c524-4614-86e5-c569f82c718d",

--- a/src/test/resources/fixtures/contested/hwf.json
+++ b/src/test/resources/fixtures/contested/hwf.json
@@ -4,6 +4,7 @@
     "id": "123",
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "helpWithFeesQuestion": "Yes",
       "applicantLName":"Guy",

--- a/src/test/resources/fixtures/contested/is-applicant-home-court.json
+++ b/src/test/resources/fixtures/contested/is-applicant-home-court.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti0012",

--- a/src/test/resources/fixtures/contested/miam-attend-exempt.json
+++ b/src/test/resources/fixtures/contested/miam-attend-exempt.json
@@ -4,9 +4,9 @@
     "id": "123",
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "PBANumber": "PBA123",
-      "d81Question": "No",
       "PBAreference": "ABCD",
       "consentOrder": {
         "document_url": "http://document-management-store:8080/documents/015500ba-c524-4614-86e5-c569f82c718d",

--- a/src/test/resources/fixtures/contested/miam-valid-attend-exempt.json
+++ b/src/test/resources/fixtures/contested/miam-valid-attend-exempt.json
@@ -4,9 +4,9 @@
     "id": "123",
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "PBANumber": "PBA123",
-      "d81Question": "No",
       "PBAreference": "ABCD",
       "consentOrder": {
         "document_url": "http://document-management-store:8080/documents/015500ba-c524-4614-86e5-c569f82c718d",

--- a/src/test/resources/fixtures/contested/pba-validate.json
+++ b/src/test/resources/fixtures/contested/pba-validate.json
@@ -4,6 +4,7 @@
     "id": "123",
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "helpWithFeesQuestion": "No",
       "applicantLName":"Guy",

--- a/src/test/resources/fixtures/contested/remove-additional-property-details.json
+++ b/src/test/resources/fixtures/contested/remove-additional-property-details.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti0012",

--- a/src/test/resources/fixtures/contested/remove-complexity-details.json
+++ b/src/test/resources/fixtures/contested/remove-complexity-details.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti0012",

--- a/src/test/resources/fixtures/contested/remove-domestic-violence-checklist.json
+++ b/src/test/resources/fixtures/contested/remove-domestic-violence-checklist.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti0012",

--- a/src/test/resources/fixtures/contested/remove-exceptions-when-applicant-attended-miam.json
+++ b/src/test/resources/fixtures/contested/remove-exceptions-when-applicant-attended-miam.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti0012",

--- a/src/test/resources/fixtures/contested/remove-miam-certification-details.json
+++ b/src/test/resources/fixtures/contested/remove-miam-certification-details.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti",

--- a/src/test/resources/fixtures/contested/remove-other-checklist.json
+++ b/src/test/resources/fixtures/contested/remove-other-checklist.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti0012",

--- a/src/test/resources/fixtures/contested/remove-other-reason-for-complexity.json
+++ b/src/test/resources/fixtures/contested/remove-other-reason-for-complexity.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti0012",

--- a/src/test/resources/fixtures/contested/remove-periodic-payment-order-details.json
+++ b/src/test/resources/fixtures/contested/remove-periodic-payment-order-details.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti0012",

--- a/src/test/resources/fixtures/contested/remove-previousMiamAttendance-checklist.json
+++ b/src/test/resources/fixtures/contested/remove-previousMiamAttendance-checklist.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti0012",

--- a/src/test/resources/fixtures/contested/remove-property-adjustment-order-details.json
+++ b/src/test/resources/fixtures/contested/remove-property-adjustment-order-details.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti0012",

--- a/src/test/resources/fixtures/contested/remove-respondent-address-details.json
+++ b/src/test/resources/fixtures/contested/remove-respondent-address-details.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti0012",

--- a/src/test/resources/fixtures/contested/remove-respondent-solicitor-details.json
+++ b/src/test/resources/fixtures/contested/remove-respondent-solicitor-details.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti0012",

--- a/src/test/resources/fixtures/contested/remove-urgency-checklist.json
+++ b/src/test/resources/fixtures/contested/remove-urgency-checklist.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti0012",

--- a/src/test/resources/fixtures/contested/update-miam-exceptions-when-applicant-attended-family-mediator.json
+++ b/src/test/resources/fixtures/contested/update-miam-exceptions-when-applicant-attended-family-mediator.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti0012",

--- a/src/test/resources/fixtures/contested/update-miam-exceptions-when-applicant-not-claiming-exemption.json
+++ b/src/test/resources/fixtures/contested/update-miam-exceptions-when-applicant-not-claiming-exemption.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti0012",

--- a/src/test/resources/fixtures/contested/update-periodic-payment-details-for-no-payment-for-children.json
+++ b/src/test/resources/fixtures/contested/update-periodic-payment-details-for-no-payment-for-children.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti0012",

--- a/src/test/resources/fixtures/contested/update-periodic-payment-details-with-benefits-for-children.json
+++ b/src/test/resources/fixtures/contested/update-periodic-payment-details-with-benefits-for-children.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti0012",

--- a/src/test/resources/fixtures/contested/update-property-adjustment-order-details.json
+++ b/src/test/resources/fixtures/contested/update-property-adjustment-order-details.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "cfcCourtList": "FR_s_CFCList_2",
       "applicantLName": "Ramisetti0012",

--- a/src/test/resources/fixtures/contested/validate-hearing-successfully.json
+++ b/src/test/resources/fixtures/contested/validate-hearing-successfully.json
@@ -4,9 +4,9 @@
     "id": "123",
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "PBANumber": "PBA123",
-      "d81Question": "No",
       "PBAreference": "ABCD",
       "consentOrder": {
         "document_url": "http://document-management-store:8080/documents/015500ba-c524-4614-86e5-c569f82c718d",

--- a/src/test/resources/fixtures/contested/validate-hearing-with-fastTrackDecision.json
+++ b/src/test/resources/fixtures/contested/validate-hearing-with-fastTrackDecision.json
@@ -4,9 +4,9 @@
     "id": "123",
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "PBANumber": "PBA123",
-      "d81Question": "No",
       "PBAreference": "ABCD",
       "consentOrder": {
         "document_url": "http://document-management-store:8080/documents/015500ba-c524-4614-86e5-c569f82c718d",

--- a/src/test/resources/fixtures/contested/validate-hearing-with-hearingdate.json
+++ b/src/test/resources/fixtures/contested/validate-hearing-with-hearingdate.json
@@ -4,9 +4,9 @@
     "id": "123",
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "PBANumber": "PBA123",
-      "d81Question": "No",
       "PBAreference": "ABCD",
       "consentOrder": {
         "document_url": "http://document-management-store:8080/documents/015500ba-c524-4614-86e5-c569f82c718d",

--- a/src/test/resources/fixtures/contested/validate-hearing-withoutfastTrackDecision.json
+++ b/src/test/resources/fixtures/contested/validate-hearing-withoutfastTrackDecision.json
@@ -4,9 +4,9 @@
     "id": "123",
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "PBANumber": "PBA123",
-      "d81Question": "No",
       "PBAreference": "ABCD",
       "consentOrder": {
         "document_url": "http://document-management-store:8080/documents/015500ba-c524-4614-86e5-c569f82c718d",

--- a/src/test/resources/fixtures/contested/with-mini-form-A.json
+++ b/src/test/resources/fixtures/contested/with-mini-form-A.json
@@ -4,9 +4,9 @@
     "id": "123",
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyContested",
     "case_data": {
       "PBANumber": "PBA123",
-      "d81Question": "No",
       "PBAreference": "ABCD",
       "consentOrder": {
         "document_url": "http://document-management-store:8080/documents/015500ba-c524-4614-86e5-c569f82c718d",

--- a/src/test/resources/fixtures/fee-lookup.json
+++ b/src/test/resources/fixtures/fee-lookup.json
@@ -4,6 +4,7 @@
   "case_details": {
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/test/resources/fixtures/general-letter.json
+++ b/src/test/resources/fixtures/general-letter.json
@@ -5,6 +5,7 @@
     "id": 1234567890,
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/test/resources/fixtures/hwf.json
+++ b/src/test/resources/fixtures/hwf.json
@@ -3,6 +3,7 @@
   "case_details": {
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "d81Question": "No",
       "PBAreference": "ABCD",

--- a/src/test/resources/fixtures/latestConsentedConsentOrder/amend-consent-order-by-caseworker.json
+++ b/src/test/resources/fixtures/latestConsentedConsentOrder/amend-consent-order-by-caseworker.json
@@ -5,6 +5,7 @@
     "id" : "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/test/resources/fixtures/latestConsentedConsentOrder/amend-consent-order-by-solicitor.json
+++ b/src/test/resources/fixtures/latestConsentedConsentOrder/amend-consent-order-by-solicitor.json
@@ -5,6 +5,7 @@
     "id" : "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/test/resources/fixtures/latestConsentedConsentOrder/draft-consent-order.json
+++ b/src/test/resources/fixtures/latestConsentedConsentOrder/draft-consent-order.json
@@ -5,6 +5,7 @@
     "id" : "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/test/resources/fixtures/latestConsentedConsentOrder/respond-to-order-solicitor.json
+++ b/src/test/resources/fixtures/latestConsentedConsentOrder/respond-to-order-solicitor.json
@@ -5,6 +5,7 @@
     "id" : "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/test/resources/fixtures/latestConsentedConsentOrder/respond-to-order-without-consent-order.json
+++ b/src/test/resources/fixtures/latestConsentedConsentOrder/respond-to-order-without-consent-order.json
@@ -5,6 +5,7 @@
     "id" : "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/test/resources/fixtures/latestConsentedConsentOrder/validate-pension-collection-without-pension-data.json
+++ b/src/test/resources/fixtures/latestConsentedConsentOrder/validate-pension-collection-without-pension-data.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/test/resources/fixtures/latestConsentedConsentOrder/validate-pension-collection.json
+++ b/src/test/resources/fixtures/latestConsentedConsentOrder/validate-pension-collection.json
@@ -5,6 +5,7 @@
     "id": "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/test/resources/fixtures/migration/caseWithOutRedundantAddressLines.json
+++ b/src/test/resources/fixtures/migration/caseWithOutRedundantAddressLines.json
@@ -3,6 +3,7 @@
   "case_details": {
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "d81Question": "No",
       "PBAreference": "ABCD",

--- a/src/test/resources/fixtures/migration/caseWithRedundantAddressLines.json
+++ b/src/test/resources/fixtures/migration/caseWithRedundantAddressLines.json
@@ -3,6 +3,7 @@
   "case_details": {
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "d81Question": "No",
       "PBAreference": "ABCD",

--- a/src/test/resources/fixtures/model/case-details-multiple-orders.json
+++ b/src/test/resources/fixtures/model/case-details-multiple-orders.json
@@ -2,6 +2,7 @@
    "id" : "12345678",
    "jurisdiction":"divorce",
    "state":"created",
+   "case_type_id": "FinancialRemedyMVP2",
    "case_data":{
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/test/resources/fixtures/model/case-details.json
+++ b/src/test/resources/fixtures/model/case-details.json
@@ -2,6 +2,7 @@
    "id" : "12345678",
    "jurisdiction":"divorce",
    "state":"created",
+   "case_type_id": "FinancialRemedyMVP2",
    "case_data":{
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/test/resources/fixtures/model/ccd-request.json
+++ b/src/test/resources/fixtures/model/ccd-request.json
@@ -5,6 +5,7 @@
     "id" : "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/test/resources/fixtures/model/copy-case-details-multiple-orders.json
+++ b/src/test/resources/fixtures/model/copy-case-details-multiple-orders.json
@@ -2,6 +2,7 @@
    "id" : "12345678",
    "jurisdiction":"divorce",
    "state":"created",
+   "case_type_id": "FinancialRemedyMVP2",
    "case_data":{
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/test/resources/fixtures/model/copy-order-refusal-collection-empty.json
+++ b/src/test/resources/fixtures/model/copy-order-refusal-collection-empty.json
@@ -2,6 +2,7 @@
    "id" : "12345678",
    "jurisdiction":"divorce",
    "state":"created",
+   "case_type_id": "FinancialRemedyMVP2",
    "case_data":{
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/test/resources/fixtures/model/prod/case-details.json
+++ b/src/test/resources/fixtures/model/prod/case-details.json
@@ -2,6 +2,7 @@
    "id" : "12345678",
    "jurisdiction":"divorce",
    "state":"created",
+   "case_type_id": "FinancialRemedyMVP2",
    "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/test/resources/fixtures/model/prod/ccd-request.json
+++ b/src/test/resources/fixtures/model/prod/ccd-request.json
@@ -5,6 +5,7 @@
     "id" : "12345678",
     "jurisdiction":"divorce",
     "state":"created",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/test/resources/fixtures/notify-casedata.json
+++ b/src/test/resources/fixtures/notify-casedata.json
@@ -4,6 +4,7 @@
   "case_details": {
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/test/resources/fixtures/pba-payment-already-exists.json
+++ b/src/test/resources/fixtures/pba-payment-already-exists.json
@@ -4,6 +4,7 @@
     "id": "123",
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123",
       "PBAPaymentReference": "RC-123456",

--- a/src/test/resources/fixtures/pba-payment.json
+++ b/src/test/resources/fixtures/pba-payment.json
@@ -4,6 +4,7 @@
     "id": "123",
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123",
       "d81Question": "No",

--- a/src/test/resources/fixtures/pba-validate.json
+++ b/src/test/resources/fixtures/pba-validate.json
@@ -4,6 +4,7 @@
     "id": "123",
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "state": "applicationDrafted",
       "PBANumber": "PBA123",

--- a/src/test/resources/fixtures/updatecase/amend-divorce-details-d81-individual.json
+++ b/src/test/resources/fixtures/updatecase/amend-divorce-details-d81-individual.json
@@ -5,6 +5,7 @@
     "id" : "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/test/resources/fixtures/updatecase/amend-divorce-details-d81-joint.json
+++ b/src/test/resources/fixtures/updatecase/amend-divorce-details-d81-joint.json
@@ -5,6 +5,7 @@
     "id" : "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "Yes",

--- a/src/test/resources/fixtures/updatecase/amend-divorce-details-decree-absolute.json
+++ b/src/test/resources/fixtures/updatecase/amend-divorce-details-decree-absolute.json
@@ -5,6 +5,7 @@
     "id" : "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/test/resources/fixtures/updatecase/amend-divorce-details-decree-nisi.json
+++ b/src/test/resources/fixtures/updatecase/amend-divorce-details-decree-nisi.json
@@ -5,6 +5,7 @@
     "id" : "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/test/resources/fixtures/updatecase/amend-periodic-payment-order-without-agreement.json
+++ b/src/test/resources/fixtures/updatecase/amend-periodic-payment-order-without-agreement.json
@@ -5,6 +5,7 @@
     "id" : "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/test/resources/fixtures/updatecase/amend-periodic-payment-order.json
+++ b/src/test/resources/fixtures/updatecase/amend-periodic-payment-order.json
@@ -5,6 +5,7 @@
     "id" : "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/test/resources/fixtures/updatecase/amend-property-adjustment-details.json
+++ b/src/test/resources/fixtures/updatecase/amend-property-adjustment-details.json
@@ -5,6 +5,7 @@
     "id" : "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/test/resources/fixtures/updatecase/amend-remove-periodic-payment-order.json
+++ b/src/test/resources/fixtures/updatecase/amend-remove-periodic-payment-order.json
@@ -5,6 +5,7 @@
     "id" : "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/test/resources/fixtures/updatecase/remove-property-adjustment-details.json
+++ b/src/test/resources/fixtures/updatecase/remove-property-adjustment-details.json
@@ -5,6 +5,7 @@
     "id" : "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/test/resources/fixtures/updatecase/remove-respondent-solicitor-details.json
+++ b/src/test/resources/fixtures/updatecase/remove-respondent-solicitor-details.json
@@ -5,6 +5,7 @@
     "id" : "12345678",
     "jurisdiction": "divorce",
     "state": "created",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123456",
       "d81Question": "No",

--- a/src/test/resources/fixtures/valid-latest-consent-order.json
+++ b/src/test/resources/fixtures/valid-latest-consent-order.json
@@ -4,6 +4,7 @@
     "id": "123",
     "jurisdiction": "DIVORCE",
     "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyMVP2",
     "case_data": {
       "PBANumber": "PBA123",
       "d81Question": "No",


### PR DESCRIPTION
- Removed logic that checked for an answer to D81 question to infer if case was consented or not
- Replaced with check on 'caseTypeId' field from Case Details which should always be set to either ‘FinancialRemedyMVP2’ for consented cases, or ‘FinancialRemedyContested’ for contested cases
- Moved check from BaseController to CommonFunctions so it can be used easily elsewhere in application and added appropriate unit tests