### PR TITLE
FR-1596 - adding endpoints for general email and tests

### DIFF
--- a/charts/finrem-cos/Chart.yaml
+++ b/charts/finrem-cos/Chart.yaml
@@ -1,7 +1,7 @@
 name: finrem-cos
 apiVersion: v1
 home: https://github.com/hmcts/finrem-case-orchestration-service
-version: 0.0.8
+version: 0.0.9
 description: Financial Remedy Case Orchestration Service
 maintainers:
   - name: HMCTS Financial Remedy Team

--- a/charts/finrem-cos/values.yaml
+++ b/charts/finrem-cos/values.yaml
@@ -8,7 +8,8 @@ java:
     IDAM_API_URL: "https://idam-api.{{ .Values.global.environment }}.platform.hmcts.net"
     IDAM_S2S_URL : "http://rpe-service-auth-provider-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
     DOCUMENT_GENERATOR_SERVICE_API_BASEURL : "http://finrem-dgcs-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
-    FINREM_NOTIFICATION_SERVICE_BASE_URL : "http://finrem-ns-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
+    FINREM_NOTIFICATION_SERVICE_BASE_URL : "https://finrem-ns-pr-146.service.core-compute-preview.internal"
+    #FINREM_NOTIFICATION_SERVICE_BASE_URL : "http://finrem-ns-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
     PAYMENT_SERVICE_API_BASEURL : "http://finrem-ps-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
   keyVaults:
     finrem:

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/config/NotificationServiceConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/config/NotificationServiceConfiguration.java
@@ -21,4 +21,5 @@ public class NotificationServiceConfiguration {
     private String contestedApplicationIssued;
     private String contestOrderApproved;
     private String contestedDraftOrder;
+    private String generalEmail;
 }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/GeneralEmailStartController.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/GeneralEmailStartController.java
@@ -1,0 +1,58 @@
+package uk.gov.hmcts.reform.finrem.caseorchestration.controllers;
+
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.hmcts.reform.ccd.client.model.AboutToStartOrSubmitCallbackResponse;
+import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.finrem.caseorchestration.service.IdamService;
+
+import javax.validation.constraints.NotNull;
+
+import java.util.Map;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.AUTHORIZATION_HEADER;
+
+@RestController
+@RequestMapping(value = "/case-orchestration")
+@Slf4j
+public class GeneralEmailStartController implements BaseController {
+
+    @Autowired
+    private IdamService service;
+
+    @PostMapping(path = "/general-email-start", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
+    @ApiOperation(value = "Clears previous entered field values. Serves as a callback from CCD")
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "Callback was processed successfully or in case of an error message is attached to the case",
+            response = AboutToStartOrSubmitCallbackResponse.class),
+        @ApiResponse(code = 400, message = "Bad Request"),
+        @ApiResponse(code = 500, message = "Internal Server Error")})
+    public ResponseEntity<AboutToStartOrSubmitCallbackResponse> initialiseGeneralEmailProperties(
+        @RequestHeader(value = AUTHORIZATION_HEADER) String authorisationToken,
+        @NotNull @RequestBody @ApiParam("CaseData") CallbackRequest callback) {
+
+        CaseDetails caseDetails = callback.getCaseDetails();
+        log.info("Received request to clear general letter fields for Case ID: {}", caseDetails.getId());
+
+        validateCaseData(callback);
+
+        Map<String, Object> caseData = caseDetails.getData();
+        caseData.put("generalEmailRecipient", null);
+        caseData.put("generalEmailCreatedBy", service.getIdamFullName(authorisationToken));
+        caseData.put("generalEmailBody", null);
+
+        return ResponseEntity.ok(AboutToStartOrSubmitCallbackResponse.builder().data(caseData).build());
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/NotificationsController.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/NotificationsController.java
@@ -17,6 +17,7 @@ import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CaseDocument;
 import uk.gov.hmcts.reform.finrem.caseorchestration.service.AssignedToJudgeDocumentService;
 import uk.gov.hmcts.reform.finrem.caseorchestration.service.BulkPrintService;
 import uk.gov.hmcts.reform.finrem.caseorchestration.service.FeatureToggleService;
+import uk.gov.hmcts.reform.finrem.caseorchestration.service.GeneralEmailService;
 import uk.gov.hmcts.reform.finrem.caseorchestration.service.HelpWithFeesDocumentService;
 import uk.gov.hmcts.reform.finrem.caseorchestration.service.NotificationService;
 
@@ -39,6 +40,7 @@ public class NotificationsController implements BaseController {
     private final FeatureToggleService featureToggleService;
     private final AssignedToJudgeDocumentService assignedToJudgeDocumentService;
     private final HelpWithFeesDocumentService helpWithFeesDocumentService;
+    private final GeneralEmailService generalEmailService;
 
     @PostMapping(value = "/case-orchestration/notify/hwf-successful", consumes = APPLICATION_JSON_VALUE)
     @ApiOperation(value = "Notify Applicant/Applicant Solicitor of HWF Successful by email or letter.")
@@ -262,5 +264,23 @@ public class NotificationsController implements BaseController {
             notificationService.sendSolicitorToDraftOrderEmail(callbackRequest);
         }
         return ResponseEntity.ok(AboutToStartOrSubmitCallbackResponse.builder().data(caseData).build());
+    }
+
+    @PostMapping(value = "/case-orchestration/notify/general-email", consumes = APPLICATION_JSON_VALUE)
+    @ApiOperation(value = "send a general email")
+    @ApiResponses(value = {
+        @ApiResponse(code = 204, message = "General e-mail sent successfully",
+            response = AboutToStartOrSubmitCallbackResponse.class)})
+    public ResponseEntity<AboutToStartOrSubmitCallbackResponse> sendGeneralEmail(
+        @RequestBody CallbackRequest callbackRequest) {
+        log.info("Received request to send email for 'Applicant Solicitor To Draft Order' for Case ID: {}", callbackRequest.getCaseDetails().getId());
+        validateCaseData(callbackRequest);
+
+        log.info("Sending general email notification");
+        notificationService.sendGeneralEmail(callbackRequest);
+
+        CaseDetails updatedDetails = generalEmailService.storeGeneralEmail(callbackRequest.getCaseDetails());
+
+        return ResponseEntity.ok(AboutToStartOrSubmitCallbackResponse.builder().data(updatedDetails.getData()).build());
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/CCDConfigConstant.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/CCDConfigConstant.java
@@ -67,6 +67,13 @@ public class CCDConfigConstant {
     public static final String FR_RESPOND_TO_ORDER = "FR_respondToOrder";
     public static final String FR_AMENDED_CONSENT_ORDER = "FR_amendedConsentOrder";
 
+    //general email
+    public static final String GENERAL_EMAIL = "generalEmailCollection";
+    public static final String GENERAL_EMAIL_RECIPIENT = "generalEmailRecipient";
+    public static final String GENERAL_EMAIL_CREATED_BY = "generalEmailCreatedBy";
+    public static final String GENERAL_EMAIL_BODY = "generalEmailBody";
+
+
     //Payment related
     public static final String ORDER_SUMMARY = "orderSummary";
     public static final String FEES = "Fees";

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/GeneralEmail.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/GeneralEmail.java
@@ -1,0 +1,14 @@
+package uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Data
+public class GeneralEmail {
+    @JsonProperty("id")
+    private String id;
+    @JsonProperty("value")
+    private GeneralEmailData generalEmailData;
+}

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/GeneralEmailData.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/GeneralEmailData.java
@@ -1,0 +1,16 @@
+package uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Data
+public class GeneralEmailData {
+    @JsonProperty("generalEmailRecipient")
+    private String recipient;
+    @JsonProperty("generalEmailCreatedBy")
+    private String createdBy;
+    @JsonProperty("generalEmailBody")
+    private String body;
+}

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/notification/NotificationRequest.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/notification/NotificationRequest.java
@@ -23,4 +23,6 @@ public class NotificationRequest {
     private String selectedCourt;
     @JsonProperty("caseType")
     private String caseType;
+    @JsonProperty("generalEmailBody")
+    private String generalEmailBody;
 }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/GeneralEmailService.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/GeneralEmailService.java
@@ -1,0 +1,73 @@
+package uk.gov.hmcts.reform.finrem.caseorchestration.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.finrem.caseorchestration.helper.DocumentHelper;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.GeneralEmail;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.GeneralEmailData;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Function;
+
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.GENERAL_EMAIL;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.GENERAL_EMAIL_BODY;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.GENERAL_EMAIL_CREATED_BY;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.GENERAL_EMAIL_RECIPIENT;
+
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class GeneralEmailService {
+
+    private final DocumentHelper documentHelper;
+    private final ObjectMapper objectMapper;
+
+    private Function<CaseDetails, GeneralEmail> createGeneralEmailData = this::applyGeneralEmailData;
+
+    public CaseDetails storeGeneralEmail(CaseDetails caseDetails) {
+
+        log.info("Storing general email for Case ID: {}", caseDetails.getId());
+        return createGeneralEmailData
+            .andThen(data -> populateGeneralEmailData(data, caseDetails))
+            .apply(documentHelper.deepCopy(caseDetails, CaseDetails.class));
+    }
+
+    private GeneralEmail applyGeneralEmailData(CaseDetails caseDetails) {
+        GeneralEmailData generalEmailData = new GeneralEmailData();
+        generalEmailData.setRecipient(Objects.toString(caseDetails.getData().get(GENERAL_EMAIL_RECIPIENT)));
+        generalEmailData.setCreatedBy(Objects.toString(caseDetails.getData().get(GENERAL_EMAIL_CREATED_BY)));
+        generalEmailData.setBody(Objects.toString(caseDetails.getData().get(GENERAL_EMAIL_BODY)));
+
+        GeneralEmail generalEmail = new GeneralEmail();
+        generalEmail.setId(UUID.randomUUID().toString());
+        generalEmail.setGeneralEmailData(generalEmailData);
+        return generalEmail;
+    }
+
+    private CaseDetails populateGeneralEmailData(GeneralEmail generalEmail, CaseDetails caseDetails) {
+        Map<String, Object> caseData = caseDetails.getData();
+
+        List<GeneralEmail> generalEmailList = Optional.ofNullable(caseData.get(GENERAL_EMAIL))
+            .map(this::convertToUploadOrderList)
+            .orElse(new ArrayList<>());
+
+        generalEmailList.add(generalEmail);
+        caseDetails.getData().put(GENERAL_EMAIL, generalEmailList);
+        return caseDetails;
+    }
+
+    private List<GeneralEmail> convertToUploadOrderList(Object object) {
+        return objectMapper.convertValue(object, new TypeReference<List<GeneralEmail>>() {
+        });
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/NotificationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/NotificationService.java
@@ -55,73 +55,73 @@ public class NotificationService {
 
     public void sendConsentedHWFSuccessfulConfirmationEmail(CallbackRequest callbackRequest) {
         URI uri = buildUri(notificationServiceConfiguration.getHwfSuccessful());
-        NotificationRequest notificationRequest = createNotificationRequest(callbackRequest);
+        notificationRequest = createNotificationRequest(callbackRequest);
         sendNotificationEmail(notificationRequest, uri);
     }
 
     public void sendAssignToJudgeConfirmationEmail(CallbackRequest callbackRequest) {
         URI uri = buildUri(notificationServiceConfiguration.getAssignToJudge());
-        NotificationRequest notificationRequest = createNotificationRequest(callbackRequest);
+        notificationRequest = createNotificationRequest(callbackRequest);
         sendNotificationEmail(notificationRequest, uri);
     }
 
     public void sendConsentOrderMadeConfirmationEmail(CallbackRequest callbackRequest) {
         URI uri = buildUri(notificationServiceConfiguration.getConsentOrderMade());
-        NotificationRequest notificationRequest = createNotificationRequest(callbackRequest);
+        notificationRequest = createNotificationRequest(callbackRequest);
         sendNotificationEmail(notificationRequest, uri);
     }
 
     public void sendConsentOrderNotApprovedEmail(CallbackRequest callbackRequest) {
         URI uri = buildUri(notificationServiceConfiguration.getConsentOrderNotApproved());
-        NotificationRequest notificationRequest = createNotificationRequest(callbackRequest);
+        notificationRequest = createNotificationRequest(callbackRequest);
         sendNotificationEmail(notificationRequest, uri);
     }
 
     public void sendConsentOrderAvailableEmail(CallbackRequest callbackRequest) {
         URI uri = buildUri(notificationServiceConfiguration.getConsentOrderAvailable());
-        NotificationRequest notificationRequest = createNotificationRequest(callbackRequest);
+        notificationRequest = createNotificationRequest(callbackRequest);
         sendNotificationEmail(notificationRequest, uri);
     }
 
     public void sendContestedHwfSuccessfulConfirmationEmail(CallbackRequest callbackRequest) {
         URI uri = buildUri(notificationServiceConfiguration.getContestedHwfSuccessful());
-        NotificationRequest notificationRequest = createNotificationRequest(callbackRequest);
+        notificationRequest = createNotificationRequest(callbackRequest);
         sendNotificationEmail(notificationRequest, uri);
     }
 
     public void sendContestedApplicationIssuedEmail(CallbackRequest callbackRequest) {
         URI uri = buildUri(notificationServiceConfiguration.getContestedApplicationIssued());
-        NotificationRequest notificationRequest = createNotificationRequest(callbackRequest);
+        notificationRequest = createNotificationRequest(callbackRequest);
         sendNotificationEmail(notificationRequest, uri);
     }
 
     public void sendContestOrderApprovedEmail(CallbackRequest callbackRequest) {
         URI uri = buildUri(notificationServiceConfiguration.getContestOrderApproved());
-        NotificationRequest notificationRequest = createNotificationRequest(callbackRequest);
+        notificationRequest = createNotificationRequest(callbackRequest);
         sendNotificationEmail(notificationRequest, uri);
     }
 
     public void sendPrepareForHearingEmail(CallbackRequest callbackRequest) {
         URI uri = buildUri(notificationServiceConfiguration.getPrepareForHearing());
-        NotificationRequest notificationRequest = createNotificationRequest(callbackRequest);
+        notificationRequest = createNotificationRequest(callbackRequest);
         sendNotificationEmail(notificationRequest, uri);
     }
 
     public void sendPrepareForHearingOrderSentEmail(CallbackRequest callbackRequest) {
         URI uri = buildUri(notificationServiceConfiguration.getPrepareForHearingOrderSent());
-        NotificationRequest notificationRequest = createNotificationRequest(callbackRequest);
+        notificationRequest = createNotificationRequest(callbackRequest);
         sendNotificationEmail(notificationRequest, uri);
     }
 
     public void sendSolicitorToDraftOrderEmail(CallbackRequest callbackRequest) {
         URI uri = buildUri(notificationServiceConfiguration.getContestedDraftOrder());
-        NotificationRequest notificationRequest = createNotificationRequest(callbackRequest);
+        notificationRequest = createNotificationRequest(callbackRequest);
         sendNotificationEmail(notificationRequest, uri);
     }
 
     public void sendGeneralEmail(CallbackRequest callbackRequest) {
         URI uri = buildUri(notificationServiceConfiguration.getGeneralEmail());
-        NotificationRequest notificationRequest = createNotificationRequest(callbackRequest);
+        notificationRequest = createNotificationRequest(callbackRequest);
         notificationRequest.setNotificationEmail(Objects.toString(callbackRequest.getCaseDetails().getData().get("generalEmailRecipient")));
         sendNotificationEmail(notificationRequest, uri);
     }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/NotificationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/NotificationService.java
@@ -22,6 +22,7 @@ import static org.springframework.web.util.UriComponentsBuilder.fromHttpUrl;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.ALLOCATED_COURT_LIST;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.CONTESTED_SOLICITOR_EMAIL;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.CONTESTED_SOLICITOR_NAME;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.GENERAL_EMAIL_BODY;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_EMAIL;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_NAME;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.SOLICITOR_REFERENCE;
@@ -54,73 +55,78 @@ public class NotificationService {
 
     public void sendConsentedHWFSuccessfulConfirmationEmail(CallbackRequest callbackRequest) {
         URI uri = buildUri(notificationServiceConfiguration.getHwfSuccessful());
-        sendNotificationEmail(callbackRequest, uri);
+        NotificationRequest notificationRequest = createNotificationRequest(callbackRequest);
+        sendNotificationEmail(notificationRequest, uri);
     }
 
     public void sendAssignToJudgeConfirmationEmail(CallbackRequest callbackRequest) {
         URI uri = buildUri(notificationServiceConfiguration.getAssignToJudge());
-        sendNotificationEmail(callbackRequest, uri);
+        NotificationRequest notificationRequest = createNotificationRequest(callbackRequest);
+        sendNotificationEmail(notificationRequest, uri);
     }
 
     public void sendConsentOrderMadeConfirmationEmail(CallbackRequest callbackRequest) {
         URI uri = buildUri(notificationServiceConfiguration.getConsentOrderMade());
-        sendNotificationEmail(callbackRequest, uri);
+        NotificationRequest notificationRequest = createNotificationRequest(callbackRequest);
+        sendNotificationEmail(notificationRequest, uri);
     }
 
     public void sendConsentOrderNotApprovedEmail(CallbackRequest callbackRequest) {
         URI uri = buildUri(notificationServiceConfiguration.getConsentOrderNotApproved());
-        sendNotificationEmail(callbackRequest, uri);
+        NotificationRequest notificationRequest = createNotificationRequest(callbackRequest);
+        sendNotificationEmail(notificationRequest, uri);
     }
 
     public void sendConsentOrderAvailableEmail(CallbackRequest callbackRequest) {
         URI uri = buildUri(notificationServiceConfiguration.getConsentOrderAvailable());
-        sendNotificationEmail(callbackRequest, uri);
+        NotificationRequest notificationRequest = createNotificationRequest(callbackRequest);
+        sendNotificationEmail(notificationRequest, uri);
     }
 
     public void sendContestedHwfSuccessfulConfirmationEmail(CallbackRequest callbackRequest) {
         URI uri = buildUri(notificationServiceConfiguration.getContestedHwfSuccessful());
-        sendNotificationEmail(callbackRequest, uri);
+        NotificationRequest notificationRequest = createNotificationRequest(callbackRequest);
+        sendNotificationEmail(notificationRequest, uri);
     }
 
     public void sendContestedApplicationIssuedEmail(CallbackRequest callbackRequest) {
         URI uri = buildUri(notificationServiceConfiguration.getContestedApplicationIssued());
-        sendNotificationEmail(callbackRequest, uri);
+        NotificationRequest notificationRequest = createNotificationRequest(callbackRequest);
+        sendNotificationEmail(notificationRequest, uri);
     }
 
     public void sendContestOrderApprovedEmail(CallbackRequest callbackRequest) {
         URI uri = buildUri(notificationServiceConfiguration.getContestOrderApproved());
-        sendNotificationEmail(callbackRequest, uri);
+        NotificationRequest notificationRequest = createNotificationRequest(callbackRequest);
+        sendNotificationEmail(notificationRequest, uri);
     }
 
     public void sendPrepareForHearingEmail(CallbackRequest callbackRequest) {
         URI uri = buildUri(notificationServiceConfiguration.getPrepareForHearing());
-        sendNotificationEmail(callbackRequest, uri);
+        NotificationRequest notificationRequest = createNotificationRequest(callbackRequest);
+        sendNotificationEmail(notificationRequest, uri);
     }
 
     public void sendPrepareForHearingOrderSentEmail(CallbackRequest callbackRequest) {
         URI uri = buildUri(notificationServiceConfiguration.getPrepareForHearingOrderSent());
-        sendNotificationEmail(callbackRequest, uri);
+        NotificationRequest notificationRequest = createNotificationRequest(callbackRequest);
+        sendNotificationEmail(notificationRequest, uri);
     }
 
     public void sendSolicitorToDraftOrderEmail(CallbackRequest callbackRequest) {
         URI uri = buildUri(notificationServiceConfiguration.getContestedDraftOrder());
-        sendNotificationEmail(callbackRequest, uri);
+        NotificationRequest notificationRequest = createNotificationRequest(callbackRequest);
+        sendNotificationEmail(notificationRequest, uri);
     }
 
-    private void sendNotificationEmail(CallbackRequest callbackRequest, URI uri) {
-        try {
-            if (isConsentedApplication(callbackRequest.getCaseDetails())) {
-                notificationRequest = buildNotificationRequest(callbackRequest, SOLICITOR_REFERENCE,
-                        SOLICITOR_NAME, SOLICITOR_EMAIL, CONSENTED);
-            } else {
-                notificationRequest = buildNotificationRequest(callbackRequest, SOLICITOR_REFERENCE,
-                        CONTESTED_SOLICITOR_NAME, CONTESTED_SOLICITOR_EMAIL, CONTESTED);
-            }
-        } catch (IOException ex) {
-            log.error("Unable to create notification request for Case Id : {}, error message : {}",
-                    callbackRequest.getCaseDetails().getId(), ex.getMessage());
-        }
+    public void sendGeneralEmail(CallbackRequest callbackRequest) {
+        URI uri = buildUri(notificationServiceConfiguration.getGeneralEmail());
+        NotificationRequest notificationRequest = createNotificationRequest(callbackRequest);
+        notificationRequest.setNotificationEmail(Objects.toString(callbackRequest.getCaseDetails().getData().get("generalEmailRecipient")));
+        sendNotificationEmail(notificationRequest, uri);
+    }
 
+    private void sendNotificationEmail(NotificationRequest notificationRequest, URI uri) {
         HttpEntity<NotificationRequest> request = new HttpEntity<>(notificationRequest, buildHeaders());
         try {
             restTemplate.exchange(uri, HttpMethod.POST, request, String.class);
@@ -132,11 +138,28 @@ public class NotificationService {
         }
     }
 
+    private NotificationRequest createNotificationRequest(CallbackRequest callbackRequest) {
+        try {
+            if (isConsentedApplication(callbackRequest.getCaseDetails())) {
+                notificationRequest = buildNotificationRequest(callbackRequest, SOLICITOR_REFERENCE,
+                    SOLICITOR_NAME, SOLICITOR_EMAIL, CONSENTED, GENERAL_EMAIL_BODY);
+            } else {
+                notificationRequest = buildNotificationRequest(callbackRequest, SOLICITOR_REFERENCE,
+                    CONTESTED_SOLICITOR_NAME, CONTESTED_SOLICITOR_EMAIL, CONTESTED, GENERAL_EMAIL_BODY);
+            }
+        } catch (IOException ex) {
+            log.error("Unable to create notification request for Case Id : {}, error message : {}",
+                callbackRequest.getCaseDetails().getId(), ex.getMessage());
+        }
+        return notificationRequest;
+    }
+
     private NotificationRequest buildNotificationRequest(CallbackRequest callbackRequest,
                                                          String solicitorReference,
                                                          String solicitorName,
                                                          String solicitorEmail,
-                                                         String caseType) throws IOException {
+                                                         String caseType,
+                                                         String generalEmailBody) throws IOException {
         NotificationRequest notificationRequest = new NotificationRequest();
         Map<String, Object> mapOfCaseData = callbackRequest.getCaseDetails().getData();
 
@@ -144,6 +167,7 @@ public class NotificationService {
         notificationRequest.setSolicitorReferenceNumber(Objects.toString(mapOfCaseData.get(solicitorReference)));
         notificationRequest.setName(Objects.toString(mapOfCaseData.get(solicitorName)));
         notificationRequest.setNotificationEmail(Objects.toString(mapOfCaseData.get(solicitorEmail)));
+        notificationRequest.setGeneralEmailBody(Objects.toString(mapOfCaseData.get(generalEmailBody)));
         notificationRequest.setCaseType(caseType);
 
         if (CONTESTED.equalsIgnoreCase(caseType)) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -67,6 +67,7 @@ finrem.notification.contestedHwfSuccessful=/contested/hwf-successful
 finrem.notification.contestedApplicationIssued=/contested/application-issued
 finrem.notification.contestOrderApproved=/contested/order-approved
 finrem.notification.contestedDraftOrder=/contested/draft-order
+finrem.notification.generalEmail=/general-email
 
 # Document
 document.miniFormTemplate=FL-FRM-APP-ENG-00002.docx

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/GeneralEmailStartControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/GeneralEmailStartControllerTest.java
@@ -1,0 +1,78 @@
+package uk.gov.hmcts.reform.finrem.caseorchestration.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.client.HttpServerErrorException;
+import uk.gov.hmcts.reform.finrem.caseorchestration.service.IdamService;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.AUTHORIZATION_HEADER;
+
+@WebMvcTest(GeneralEmailStartController.class)
+public class GeneralEmailStartControllerTest extends BaseControllerTest {
+
+    @MockBean
+    private IdamService idamService;
+
+    private String bearerToken = "eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiJqc2NyMGE0M3JnMHU5aGZpNHRva21vdHJ"
+        + "vOSIsInN1YiI6IjEiLCJpYXQiOjE1NjAyNDcyNzgsImV4cCI6MTU2MDI2NTI3OCwiZGF0YSI6ImNjZC1pbXBv"
+        + "cnQsY2NkLWltcG9ydC1sb2EwIiwidHlwZSI6IkFDQ0VTUyIsImlkIjoiMSIsImZvcmVuYW1lIjoiSW50ZWdyY"
+        + "XRpb24iLCJzdXJuYW1lIjoiVGVzdCIsImRlZmF1bHQtc2VydmljZSI6IlByb2JhdGUiLCJsb2EiOjAsImRlZm"
+        + "F1bHQtdXJsIjoiaHR0cHM6Ly9sb2NhbGhvc3Q6OTAwMC9wb2MvcHJvYmF0ZSIsImdyb3VwIjoicHJvYmF0ZS1"
+        + "wcml2YXRlLWJldGEifQ.sSeejKgphDGyKyNtw---nkFk5N_9iqWb2WYNHCiVRPY";
+
+    @Test
+    public void storeGeneralEmailSuccess() throws Exception {
+        generalEmailStartControllerSetUp();
+        when(idamService.getIdamFullName(bearerToken)).thenReturn("Firstname LastName");
+        mvc.perform(post("/case-orchestration/general-email-start")
+            .content(requestContent.toString())
+            .header(AUTHORIZATION_HEADER, bearerToken)
+            .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.generalEmailCreatedBy", is("Firstname LastName")));
+
+    }
+
+    @Test
+    public void generateGeneralEmail400Error() throws Exception {
+        doEmptyCaseDataSetUp();
+
+        mvc.perform(post("/case-orchestration/general-email-start")
+            .content(requestContent.toString())
+            .header(AUTHORIZATION_HEADER, bearerToken)
+            .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void generateGeneralLetter500Error() throws Exception {
+        generalEmailStartControllerSetUp();
+        when(idamService.getIdamFullName(bearerToken))
+            .thenThrow(new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR));
+
+        mvc.perform(post("/case-orchestration/general-email-start")
+            .content(requestContent.toString())
+            .header(AUTHORIZATION_HEADER, bearerToken)
+            .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isInternalServerError());
+    }
+
+    private void generalEmailStartControllerSetUp() throws IOException, URISyntaxException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        requestContent = objectMapper.readTree(new File(getClass()
+            .getResource("/fixtures/general-letter.json").toURI()));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/notification/NotificationRequestTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/notification/NotificationRequestTest.java
@@ -11,13 +11,14 @@ public class NotificationRequestTest {
     @Test
     public void shouldReturnNotificationRequestData() {
         underTest = new NotificationRequest("12345", "67890",
-                "Padmaja", "test@test.com", "nottingham", "consented");
+                "Padmaja", "test@test.com", "nottingham", "consented", "general body");
         assertEquals("12345", underTest.getCaseReferenceNumber());
         assertEquals("67890", underTest.getSolicitorReferenceNumber());
         assertEquals("Padmaja", underTest.getName());
         assertEquals("test@test.com", underTest.getNotificationEmail());
         assertEquals("nottingham", underTest.getSelectedCourt());
         assertEquals("consented", underTest.getCaseType());
+        assertEquals("general body", underTest.getGeneralEmailBody());
     }
 
     @Test
@@ -28,6 +29,7 @@ public class NotificationRequestTest {
         assertNull(underTest.getName());
         assertNull(underTest.getNotificationEmail());
         assertNull(underTest.getCaseType());
+        assertNull(underTest.getGeneralEmailBody());
     }
 
     @Test
@@ -39,11 +41,13 @@ public class NotificationRequestTest {
         underTest.setCaseReferenceNumber("54321");
         underTest.setSelectedCourt("nottingham");
         underTest.setCaseType("consented");
+        underTest.setGeneralEmailBody("general body");
         assertEquals("54321", underTest.getCaseReferenceNumber());
         assertEquals("67891", underTest.getSolicitorReferenceNumber());
         assertEquals("Prashanth", underTest.getName());
         assertEquals("test1@test1.com", underTest.getNotificationEmail());
         assertEquals("nottingham", underTest.getSelectedCourt());
         assertEquals("consented", underTest.getCaseType());
+        assertEquals("general body", underTest.getGeneralEmailBody());
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/GeneralEmailServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/GeneralEmailServiceTest.java
@@ -1,0 +1,58 @@
+package uk.gov.hmcts.reform.finrem.caseorchestration.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.finrem.caseorchestration.helper.DocumentHelper;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.GeneralEmail;
+
+import java.io.InputStream;
+import java.util.List;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+public class GeneralEmailServiceTest {
+
+    private DocumentHelper documentHelper;
+    private ObjectMapper mapper = new ObjectMapper();
+    private GeneralEmailService generalEmailService;
+
+    @Before
+    public void setUp() {
+        documentHelper = new DocumentHelper(mapper);
+        generalEmailService = new GeneralEmailService(documentHelper, mapper);
+    }
+
+    @Test
+    public void generateGeneralEmail() throws Exception {
+        CaseDetails caseDetails = generalEmailService.storeGeneralEmail(caseDetails());
+        List<GeneralEmail> generalEmailList = (List<GeneralEmail>)caseDetails.getData().get("generalEmailCollection");
+        caseDetails.getData();
+        assertThat(generalEmailList, hasSize(2));
+
+        GeneralEmail originalEmail = generalEmailList.get(0);
+        assertThat(originalEmail.getId(), notNullValue());
+        assertThat(originalEmail.getGeneralEmailData().getRecipient(), is("a1@a.com"));
+        assertThat(originalEmail.getGeneralEmailData().getCreatedBy(), is("first user"));
+        assertThat(originalEmail.getGeneralEmailData().getBody(), is("original email body"));
+
+        GeneralEmail addedEmail = generalEmailList.get(1);
+        assertThat(addedEmail.getId(), notNullValue());
+        assertThat(addedEmail.getGeneralEmailData().getRecipient(), is("b1@b.com"));
+        assertThat(addedEmail.getGeneralEmailData().getCreatedBy(), is("Test user"));
+        assertThat(addedEmail.getGeneralEmailData().getBody(), is("Test email body"));
+    }
+
+    private CaseDetails caseDetails() throws Exception {
+        try (InputStream resourceAsStream = getClass().getResourceAsStream("/fixtures/general-email.json")) {
+            return mapper.readValue(resourceAsStream, CallbackRequest.class).getCaseDetails();
+        }
+    }
+
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/NotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/NotificationServiceTest.java
@@ -36,6 +36,7 @@ public class NotificationServiceTest extends BaseServiceTest {
     private static final String END_POINT_CONTESTED_APPLICATION_ISSUED = "http://localhost:8086/notify/contested/application-issued";
     private static final String END_POINT_CONTEST_ORDER_APPROVED = "http://localhost:8086/notify/contested/order-approved";
     private static final String END_POINT_CONTESTED_DRAFT_ORDER = "http://localhost:8086/notify/contested/draft-order";
+    private static final String END_POINT_GENERAL_EMAIL = "http://localhost:8086/notify/general-email";
 
     private static final String ERROR_500_MESSAGE = "500 Internal Server Error";
 
@@ -526,6 +527,26 @@ public class NotificationServiceTest extends BaseServiceTest {
             .andExpect(MockRestRequestMatchers.method(HttpMethod.POST))
             .andRespond(MockRestResponseCreators.withNoContent());
         notificationService.sendContestedHwfSuccessfulConfirmationEmail(callbackRequest);
+    }
+
+    @Test
+    public void sendGeneralEmail() {
+        mockServer.expect(MockRestRequestMatchers.requestTo(END_POINT_GENERAL_EMAIL))
+            .andExpect(MockRestRequestMatchers.method(HttpMethod.POST))
+            .andRespond(MockRestResponseCreators.withNoContent());
+        notificationService.sendGeneralEmail(callbackRequest);
+    }
+
+    @Test
+    public void throwExceptionWhenGeneralEmailIsRequested() {
+        mockServer.expect(MockRestRequestMatchers.requestTo(END_POINT_GENERAL_EMAIL))
+            .andExpect(MockRestRequestMatchers.method(HttpMethod.POST))
+            .andRespond(MockRestResponseCreators.withStatus(HttpStatus.INTERNAL_SERVER_ERROR));
+        try {
+            notificationService.sendGeneralEmail(callbackRequest);
+        } catch (Exception ex) {
+            assertThat(ex.getMessage(), Is.is(ERROR_500_MESSAGE));
+        }
     }
 
     private CallbackRequest getContestedCallbackRequest(Object courtList) {

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -26,6 +26,7 @@ finrem.notification.contestedHwfSuccessful=/contested/hwf-successful
 finrem.notification.contestedApplicationIssued=/contested/application-issued
 finrem.notification.contestOrderApproved=/contested/order-approved
 finrem.notification.contestedDraftOrder=/contested/draft-order
+finrem.notification.generalEmail=/general-email
 
 # Document
 document.miniFormTemplate=FL-FRM-APP-ENG-00002.docx

--- a/src/test/resources/fixtures/general-email.json
+++ b/src/test/resources/fixtures/general-email.json
@@ -1,0 +1,116 @@
+{
+  "token": "token_test",
+  "event_id": "some_event_id",
+  "case_details": {
+    "id": 1234567890,
+    "jurisdiction": "DIVORCE",
+    "state": "applicationDrafted",
+    "case_type_id": "FinancialRemedyMVP2",
+    "case_data": {
+      "PBANumber": "PBA123456",
+      "d81Question": "No",
+      "PBAreference": "ABCD",
+      "consentOrder": {
+        "document_url": "http://document-management-store:8080/documents/015500ba-c524-4614-86e5-c569f82c718d",
+        "document_filename": "WhatsApp Image 2018-07-24 at 3.05.39 PM.jpeg",
+        "document_binary_url": "http://document-management-store:8080/documents/015500ba-c524-4614-86e5-c569f82c718d/binary"
+      },
+      "d81Applicant": {
+        "document_url": "http://document-management-store:8080/documents/2c9d3381-df6a-4817-aec3-a8a46ca0635b",
+        "document_filename": "WhatsApp Image 2018-07-24 at 3.05.39 PM.jpeg",
+        "document_binary_url": "http://document-management-store:8080/documents/2c9d3381-df6a-4817-aec3-a8a46ca0635b/binary"
+      },
+      "d81Respondent": {
+        "document_url": "http://document-management-store:8080/documents/e284fb20-47c6-4b3a-bd17-cb005666ab5f",
+        "document_filename": "WhatsApp Image 2018-07-24 at 3.05.39 PM.jpeg",
+        "document_binary_url": "http://document-management-store:8080/documents/e284fb20-47c6-4b3a-bd17-cb005666ab5f/binary"
+      },
+      "solicitorFirm": "Mr",
+      "solicitorName": "Solictor",
+      "applicantLName": "Guy",
+      "authorisation3": "2010-01-01",
+      "solicitorEmail": "test@admin.com",
+      "solicitorPhone": "9963472494",
+      "applicantFMName": "Poor",
+      "authorisation2b": "test",
+      "otherCollection": [
+        {
+          "id": "c0c5b8cc-8bb5-41da-84bf-06be40b8fa77",
+          "value": {
+            "typeOfDocument": "ScheduleOfAssets",
+            "uploadedDocument": {
+              "document_url": "http://document-management-store:8080/documents/0abf044e-3d01-45eb-b792-c06d1e6344ee",
+              "document_filename": "WhatsApp Image 2018-07-24 at 3.05.39 PM.jpeg",
+              "document_binary_url": "http://document-management-store:8080/documents/0abf044e-3d01-45eb-b792-c06d1e6344ee/binary"
+            }
+          }
+        }
+      ],
+      "respondentEmail": null,
+      "respondentPhone": "9963472494",
+      "appRespondentRep": "No",
+      "consentOrderText": {
+        "document_url": "http://document-management-store:8080/documents/d607c045-878e-475f-ab8e-b2f667d8af69",
+        "document_filename": "WhatsApp Image 2018-07-24 at 3.05.39 PM.jpeg",
+        "document_binary_url": "http://document-management-store:8080/documents/d607c045-878e-475f-ab8e-b2f667d8af69/binary"
+      },
+      "solicitorAddress": {
+        "County": "test",
+        "Country": "United Kingdom",
+        "PostCode": "b1 1ab",
+        "PostTown": "SRIKALAHASTI",
+        "AddressLine1": "House no: 6-354-2, Gandhi Street",
+        "AddressLine2": "Srikalahasti, Chittor District",
+        "AddressLine3": "test"
+      },
+      "authorisationFirm": "test",
+      "authorisationName": "test",
+      "divorceCaseNumber": "DD12D12345",
+      "respondentAddress": {
+        "County": "Essex",
+        "Country": "United Kingdom",
+        "PostCode": "SE12 9SE",
+        "PostTown": "London",
+        "AddressLine1": "252 Marvels Lane",
+        "AddressLine2": "AddressGlobalUK",
+        "AddressLine3": "London"
+      },
+      "solicitorDXnumber": null,
+      "appRespondentLName": "Korivi",
+      "solicitorReference": "LL01",
+      "appRespondentFMName": "test",
+      "divorceStageReached": "Decree Nisi",
+      "helpWithFeesQuestion": "No",
+      "orderForChildrenQuestion1": "Yes",
+      "solicitorAgreeToReceiveEmails": "Yes",
+      "generalLetterAddressTo": "applicantSolicitor",
+      "generalLetterRecipient": "",
+      "generalLetterRecipientAddress": "",
+      "generalLetterCreatedBy": "",
+      "generalLetterBody": "Test content for the letter body",
+      "generalEmailRecipient": "b1@b.com",
+      "generalEmailCreatedBy": "Test user",
+      "generalEmailBody": "Test email body",
+      "generalEmailCollection": [{
+        "id": "1",
+        "value": {
+          "generalEmailRecipient": "a1@a.com",
+          "generalEmailCreatedBy": "first user",
+          "generalEmailBody": "original email body"
+        }
+      }],
+      "generalLetterCollection": [
+        {
+          "id": "1",
+          "value": {
+            "generatedLetter": {
+              "document_url": "http://dm-store/lhjbyuivu87y989hijbb",
+              "document_filename": "app_docs.pdf",
+              "document_binary_url": "http://dm-store/lhjbyuivu87y989hijbb/binary"
+            }
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FR-1596

### Change description ###

Added endpoint for general email start to prepopulate the name of the user on the screen.
Added endpoint for sending a general email and saving the general email.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
