### PR TITLE
FR-1696: Remove double space typo handling that is now fixed on Prod

### DIFF
--- a/src/functionalTests/resources/json/consented/FailurePaymentRequestPayload.json
+++ b/src/functionalTests/resources/json/consented/FailurePaymentRequestPayload.json
@@ -101,7 +101,7 @@
         "Pension Compensation Sharing Order",
         "Pension Compensation Attachment Order",
         "A settlement or a transfer of property",
-        "Property Adjustment  Order"
+        "Property Adjustment Order"
       ],
       "natureOfApplication5": "No",
       "natureOfApplication6": [

--- a/src/functionalTests/resources/json/consented/SuccessPaymentRequestPayload_Consented.json
+++ b/src/functionalTests/resources/json/consented/SuccessPaymentRequestPayload_Consented.json
@@ -101,7 +101,7 @@
         "Pension Compensation Sharing Order",
         "Pension Compensation Attachment Order",
         "A settlement or a transfer of property",
-        "Property Adjustment  Order"
+        "Property Adjustment Order"
       ],
       "natureOfApplication5": "No",
       "natureOfApplication6": [

--- a/src/functionalTests/resources/json/consented/amend-property-adjustment-details1.json
+++ b/src/functionalTests/resources/json/consented/amend-property-adjustment-details1.json
@@ -101,7 +101,7 @@
       "helpWithFeesQuestion": "No",
       "natureOfApplication2": [
         "item1",
-        "Property Adjustment  Order"
+        "Property Adjustment Order"
       ],
       "natureOfApplication5": "No",
       "natureOfApplication6": [

--- a/src/functionalTests/resources/json/consented/bulk-print.json
+++ b/src/functionalTests/resources/json/consented/bulk-print.json
@@ -117,7 +117,7 @@
         "Pension Compensation Sharing Order",
         "Pension Compensation Attachment Order",
         "A settlement or a transfer of property",
-        "Property Adjustment  Order"
+        "Property Adjustment Order"
       ],
       "natureOfApplication5": "No",
       "natureOfApplication6": [

--- a/src/functionalTests/resources/json/consented/document-rejected-order1.json
+++ b/src/functionalTests/resources/json/consented/document-rejected-order1.json
@@ -101,7 +101,7 @@
         "Pension Compensation Sharing Order",
         "Pension Compensation Attachment Order",
         "A settlement or a transfer of property",
-        "Property Adjustment  Order"
+        "Property Adjustment Order"
       ],
       "natureOfApplication5": "No",
       "natureOfApplication6": [

--- a/src/functionalTests/resources/json/consented/fee-lookup_consented.json
+++ b/src/functionalTests/resources/json/consented/fee-lookup_consented.json
@@ -101,7 +101,7 @@
         "Pension Compensation Sharing Order",
         "Pension Compensation Attachment Order",
         "A settlement or a transfer of property",
-        "Property Adjustment  Order"
+        "Property Adjustment Order"
       ],
       "natureOfApplication5": "No",
       "natureOfApplication6": [

--- a/src/functionalTests/resources/json/consented/hwfPayment.json
+++ b/src/functionalTests/resources/json/consented/hwfPayment.json
@@ -100,7 +100,7 @@
         "Pension Compensation Sharing Order",
         "Pension Compensation Attachment Order",
         "A settlement or a transfer of property",
-        "Property Adjustment  Order"
+        "Property Adjustment Order"
       ],
       "natureOfApplication5": "No",
       "natureOfApplication6": [

--- a/src/functionalTests/resources/json/consented/notify-assign-to-judge1.json
+++ b/src/functionalTests/resources/json/consented/notify-assign-to-judge1.json
@@ -101,7 +101,7 @@
         "Pension Compensation Sharing Order",
         "Pension Compensation Attachment Order",
         "A settlement or a transfer of property",
-        "Property Adjustment  Order"
+        "Property Adjustment Order"
       ],
       "natureOfApplication5": "No",
       "natureOfApplication6": [

--- a/src/functionalTests/resources/json/consented/pba-payment.json
+++ b/src/functionalTests/resources/json/consented/pba-payment.json
@@ -101,7 +101,7 @@
         "Pension Compensation Sharing Order",
         "Pension Compensation Attachment Order",
         "A settlement or a transfer of property",
-        "Property Adjustment  Order"
+        "Property Adjustment Order"
       ],
       "natureOfApplication5": "No",
       "natureOfApplication6": [

--- a/src/functionalTests/resources/json/consented/pba-validate1.json
+++ b/src/functionalTests/resources/json/consented/pba-validate1.json
@@ -101,7 +101,7 @@
         "Pension Compensation Sharing Order",
         "Pension Compensation Attachment Order",
         "A settlement or a transfer of property",
-        "Property Adjustment  Order"
+        "Property Adjustment Order"
       ],
       "natureOfApplication5": "No",
       "natureOfApplication6": [

--- a/src/functionalTests/resources/json/contested/application-submitted-to-gateKeepingState1.json
+++ b/src/functionalTests/resources/json/contested/application-submitted-to-gateKeepingState1.json
@@ -101,7 +101,7 @@
         "Pension Compensation Sharing Order",
         "Pension Compensation Attachment Order",
         "A settlement or a transfer of property",
-        "Property Adjustment  Order"
+        "Property Adjustment Order"
       ],
       "natureOfApplication5": "No",
       "natureOfApplication6": [

--- a/src/functionalTests/resources/json/contested/do-not-change-to-gateKeepingState1.json
+++ b/src/functionalTests/resources/json/contested/do-not-change-to-gateKeepingState1.json
@@ -101,7 +101,7 @@
         "Pension Compensation Sharing Order",
         "Pension Compensation Attachment Order",
         "A settlement or a transfer of property",
-        "Property Adjustment  Order"
+        "Property Adjustment Order"
       ],
       "natureOfApplication5": "No",
       "natureOfApplication6": [

--- a/src/functionalTests/resources/json/contested/generate-contested-form-A1.json
+++ b/src/functionalTests/resources/json/contested/generate-contested-form-A1.json
@@ -91,7 +91,7 @@
         "Pension Compensation Sharing Order",
         "Pension Compensation Attachment Order",
         "A settlement or a transfer of property",
-        "Property Adjustment  Order"
+        "Property Adjustment Order"
       ],
       "natureOfApplication5": "No",
       "natureOfApplication6": [

--- a/src/functionalTests/resources/json/contested/miam-attend-exempt1.json
+++ b/src/functionalTests/resources/json/contested/miam-attend-exempt1.json
@@ -104,7 +104,7 @@
         "Pension Compensation Sharing Order",
         "Pension Compensation Attachment Order",
         "A settlement or a transfer of property",
-        "Property Adjustment  Order"
+        "Property Adjustment Order"
       ],
       "natureOfApplication5": "No",
       "natureOfApplication6": [

--- a/src/functionalTests/resources/json/contested/miam-valid-attend-exempt1.json
+++ b/src/functionalTests/resources/json/contested/miam-valid-attend-exempt1.json
@@ -104,7 +104,7 @@
         "Pension Compensation Sharing Order",
         "Pension Compensation Attachment Order",
         "A settlement or a transfer of property",
-        "Property Adjustment  Order"
+        "Property Adjustment Order"
       ],
       "natureOfApplication5": "No",
       "natureOfApplication6": [

--- a/src/functionalTests/resources/json/contested/validate-hearing-successfully1.json
+++ b/src/functionalTests/resources/json/contested/validate-hearing-successfully1.json
@@ -104,7 +104,7 @@
         "Pension Compensation Sharing Order",
         "Pension Compensation Attachment Order",
         "A settlement or a transfer of property",
-        "Property Adjustment  Order"
+        "Property Adjustment Order"
       ],
       "natureOfApplication5": "No",
       "natureOfApplication6": [

--- a/src/functionalTests/resources/json/contested/validate-hearing-with-fastTrackDecision1.json
+++ b/src/functionalTests/resources/json/contested/validate-hearing-with-fastTrackDecision1.json
@@ -104,7 +104,7 @@
         "Pension Compensation Sharing Order",
         "Pension Compensation Attachment Order",
         "A settlement or a transfer of property",
-        "Property Adjustment  Order"
+        "Property Adjustment Order"
       ],
       "natureOfApplication5": "No",
       "natureOfApplication6": [

--- a/src/functionalTests/resources/json/contested/validate-hearing-with-hearingdate1.json
+++ b/src/functionalTests/resources/json/contested/validate-hearing-with-hearingdate1.json
@@ -104,7 +104,7 @@
         "Pension Compensation Sharing Order",
         "Pension Compensation Attachment Order",
         "A settlement or a transfer of property",
-        "Property Adjustment  Order"
+        "Property Adjustment Order"
       ],
       "natureOfApplication5": "No",
       "natureOfApplication6": [

--- a/src/functionalTests/resources/json/contested/validate-hearing-without-fastTrackDecision1.json
+++ b/src/functionalTests/resources/json/contested/validate-hearing-without-fastTrackDecision1.json
@@ -104,7 +104,7 @@
         "Pension Compensation Sharing Order",
         "Pension Compensation Attachment Order",
         "A settlement or a transfer of property",
-        "Property Adjustment  Order"
+        "Property Adjustment Order"
       ],
       "natureOfApplication5": "No",
       "natureOfApplication6": [

--- a/src/functionalTests/resources/json/contested/with-mini-form-A1.json
+++ b/src/functionalTests/resources/json/contested/with-mini-form-A1.json
@@ -104,7 +104,7 @@
         "Pension Compensation Sharing Order",
         "Pension Compensation Attachment Order",
         "A settlement or a transfer of property",
-        "Property Adjustment  Order"
+        "Property Adjustment Order"
       ],
       "natureOfApplication5": "No",
       "natureOfApplication6": [

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/UpdateConsentedCaseController.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/UpdateConsentedCaseController.java
@@ -101,7 +101,7 @@ public class UpdateConsentedCaseController implements BaseController {
     private void updatePropertyDetails(Map<String, Object> caseData) {
         List natureOfApplication2 = (List) caseData.get("natureOfApplication2");
 
-        if (hasNotSelected(natureOfApplication2, "Property Adjustment  Order")) {
+        if (hasNotSelected(natureOfApplication2, "Property Adjustment Order")) {
             removePropertyAdjustmentDetails(caseData);
         }
     }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/bulkscan/helper/BulkScanHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/bulkscan/helper/BulkScanHelper.java
@@ -25,8 +25,7 @@ public class BulkScanHelper {
                     .put("Pension Compensation Sharing Order", "Pension Compensation Sharing Order")
                     .put("Pension Compensation Attachment Order", "Pension Compensation Attachment Order")
                     .put("A settlement or a transfer of property", "A settlement or a transfer of property")
-                    //The below field intentionally has 2 spaces to match CCD config. Will be addressed before release
-                    .put("Property Adjustment Order", "Property Adjustment  Order")
+                    .put("Property Adjustment Order", "Property Adjustment Order")
                     .build();
 
     public static final Map<String, String> dischargePeriodicalPaymentSubstituteChecklistToCcdFieldNames =

--- a/src/test/resources/fixtures/bulkprint/bulk-print-paper-application.json
+++ b/src/test/resources/fixtures/bulkprint/bulk-print-paper-application.json
@@ -108,7 +108,7 @@
         "Pension Compensation Sharing Order",
         "Pension Compensation Attachment Order",
         "A settlement or a transfer of property",
-        "Property Adjustment  Order"
+        "Property Adjustment Order"
       ],
       "natureOfApplication5": "No",
       "natureOfApplication6": [

--- a/src/test/resources/fixtures/contested/application-submitted-to-gateKeepingState.json
+++ b/src/test/resources/fixtures/contested/application-submitted-to-gateKeepingState.json
@@ -101,7 +101,7 @@
         "Pension Compensation Sharing Order",
         "Pension Compensation Attachment Order",
         "A settlement or a transfer of property",
-        "Property Adjustment  Order"
+        "Property Adjustment Order"
       ],
       "natureOfApplication5": "No",
       "natureOfApplication6": [

--- a/src/test/resources/fixtures/contested/do-not-change-to-gateKeepingState.json
+++ b/src/test/resources/fixtures/contested/do-not-change-to-gateKeepingState.json
@@ -100,7 +100,7 @@
         "Pension Compensation Sharing Order",
         "Pension Compensation Attachment Order",
         "A settlement or a transfer of property",
-        "Property Adjustment  Order"
+        "Property Adjustment Order"
       ],
       "natureOfApplication5": "No",
       "natureOfApplication6": [

--- a/src/test/resources/fixtures/contested/generate-contested-form-A.json
+++ b/src/test/resources/fixtures/contested/generate-contested-form-A.json
@@ -103,7 +103,7 @@
         "Pension Compensation Sharing Order",
         "Pension Compensation Attachment Order",
         "A settlement or a transfer of property",
-        "Property Adjustment  Order"
+        "Property Adjustment Order"
       ],
       "natureOfApplication5": "No",
       "natureOfApplication6": [

--- a/src/test/resources/fixtures/contested/miam-attend-exempt.json
+++ b/src/test/resources/fixtures/contested/miam-attend-exempt.json
@@ -103,7 +103,7 @@
         "Pension Compensation Sharing Order",
         "Pension Compensation Attachment Order",
         "A settlement or a transfer of property",
-        "Property Adjustment  Order"
+        "Property Adjustment Order"
       ],
       "natureOfApplication5": "No",
       "natureOfApplication6": [

--- a/src/test/resources/fixtures/contested/miam-valid-attend-exempt.json
+++ b/src/test/resources/fixtures/contested/miam-valid-attend-exempt.json
@@ -103,7 +103,7 @@
         "Pension Compensation Sharing Order",
         "Pension Compensation Attachment Order",
         "A settlement or a transfer of property",
-        "Property Adjustment  Order"
+        "Property Adjustment Order"
       ],
       "natureOfApplication5": "No",
       "natureOfApplication6": [

--- a/src/test/resources/fixtures/contested/validate-hearing-successfully.json
+++ b/src/test/resources/fixtures/contested/validate-hearing-successfully.json
@@ -103,7 +103,7 @@
         "Pension Compensation Sharing Order",
         "Pension Compensation Attachment Order",
         "A settlement or a transfer of property",
-        "Property Adjustment  Order"
+        "Property Adjustment Order"
       ],
       "natureOfApplication5": "No",
       "natureOfApplication6": [

--- a/src/test/resources/fixtures/contested/validate-hearing-with-fastTrackDecision.json
+++ b/src/test/resources/fixtures/contested/validate-hearing-with-fastTrackDecision.json
@@ -103,7 +103,7 @@
         "Pension Compensation Sharing Order",
         "Pension Compensation Attachment Order",
         "A settlement or a transfer of property",
-        "Property Adjustment  Order"
+        "Property Adjustment Order"
       ],
       "natureOfApplication5": "No",
       "natureOfApplication6": [

--- a/src/test/resources/fixtures/contested/validate-hearing-with-hearingdate.json
+++ b/src/test/resources/fixtures/contested/validate-hearing-with-hearingdate.json
@@ -103,7 +103,7 @@
         "Pension Compensation Sharing Order",
         "Pension Compensation Attachment Order",
         "A settlement or a transfer of property",
-        "Property Adjustment  Order"
+        "Property Adjustment Order"
       ],
       "natureOfApplication5": "No",
       "natureOfApplication6": [

--- a/src/test/resources/fixtures/contested/validate-hearing-withoutfastTrackDecision.json
+++ b/src/test/resources/fixtures/contested/validate-hearing-withoutfastTrackDecision.json
@@ -103,7 +103,7 @@
         "Pension Compensation Sharing Order",
         "Pension Compensation Attachment Order",
         "A settlement or a transfer of property",
-        "Property Adjustment  Order"
+        "Property Adjustment Order"
       ],
       "natureOfApplication5": "No",
       "natureOfApplication6": [

--- a/src/test/resources/fixtures/contested/with-mini-form-A.json
+++ b/src/test/resources/fixtures/contested/with-mini-form-A.json
@@ -103,7 +103,7 @@
         "Pension Compensation Sharing Order",
         "Pension Compensation Attachment Order",
         "A settlement or a transfer of property",
-        "Property Adjustment  Order"
+        "Property Adjustment Order"
       ],
       "natureOfApplication5": "No",
       "natureOfApplication6": [

--- a/src/test/resources/fixtures/fee-lookup.json
+++ b/src/test/resources/fixtures/fee-lookup.json
@@ -101,7 +101,7 @@
         "Pension Compensation Sharing Order",
         "Pension Compensation Attachment Order",
         "A settlement or a transfer of property",
-        "Property Adjustment  Order"
+        "Property Adjustment Order"
       ],
       "natureOfApplication5": "No",
       "natureOfApplication6": [

--- a/src/test/resources/fixtures/hwf.json
+++ b/src/test/resources/fixtures/hwf.json
@@ -99,7 +99,7 @@
         "Pension Compensation Sharing Order",
         "Pension Compensation Attachment Order",
         "A settlement or a transfer of property",
-        "Property Adjustment  Order"
+        "Property Adjustment Order"
       ],
       "natureOfApplication5": "No",
       "natureOfApplication6": [

--- a/src/test/resources/fixtures/invalid-latest-consent-order.json
+++ b/src/test/resources/fixtures/invalid-latest-consent-order.json
@@ -100,7 +100,7 @@
         "Pension Compensation Sharing Order",
         "Pension Compensation Attachment Order",
         "A settlement or a transfer of property",
-        "Property Adjustment  Order"
+        "Property Adjustment Order"
       ],
       "natureOfApplication5": "No",
       "natureOfApplication6": [

--- a/src/test/resources/fixtures/migration/caseWithOutRedundantAddressLines.json
+++ b/src/test/resources/fixtures/migration/caseWithOutRedundantAddressLines.json
@@ -99,7 +99,7 @@
         "Pension Compensation Sharing Order",
         "Pension Compensation Attachment Order",
         "A settlement or a transfer of property",
-        "Property Adjustment  Order"
+        "Property Adjustment Order"
       ],
       "natureOfApplication5": "No",
       "natureOfApplication6": [

--- a/src/test/resources/fixtures/notify-casedata.json
+++ b/src/test/resources/fixtures/notify-casedata.json
@@ -101,7 +101,7 @@
         "Pension Compensation Sharing Order",
         "Pension Compensation Attachment Order",
         "A settlement or a transfer of property",
-        "Property Adjustment  Order"
+        "Property Adjustment Order"
       ],
       "natureOfApplication5": "No",
       "natureOfApplication6": [

--- a/src/test/resources/fixtures/pba-payment-already-exists.json
+++ b/src/test/resources/fixtures/pba-payment-already-exists.json
@@ -102,7 +102,7 @@
         "Pension Compensation Sharing Order",
         "Pension Compensation Attachment Order",
         "A settlement or a transfer of property",
-        "Property Adjustment  Order"
+        "Property Adjustment Order"
       ],
       "natureOfApplication5": "No",
       "natureOfApplication6": [

--- a/src/test/resources/fixtures/pba-payment.json
+++ b/src/test/resources/fixtures/pba-payment.json
@@ -101,7 +101,7 @@
         "Pension Compensation Sharing Order",
         "Pension Compensation Attachment Order",
         "A settlement or a transfer of property",
-        "Property Adjustment  Order"
+        "Property Adjustment Order"
       ],
       "natureOfApplication5": "No",
       "natureOfApplication6": [

--- a/src/test/resources/fixtures/pba-validate.json
+++ b/src/test/resources/fixtures/pba-validate.json
@@ -107,7 +107,7 @@
         "Pension Compensation Sharing Order",
         "Pension Compensation Attachment Order",
         "A settlement or a transfer of property",
-        "Property Adjustment  Order"
+        "Property Adjustment Order"
       ],
       "natureOfApplication5": "No",
       "natureOfApplication6": [

--- a/src/test/resources/fixtures/updatecase/amend-property-adjustment-details.json
+++ b/src/test/resources/fixtures/updatecase/amend-property-adjustment-details.json
@@ -101,7 +101,7 @@
       "helpWithFeesQuestion": "No",
       "natureOfApplication2": [
         "item1",
-        "Property Adjustment  Order"
+        "Property Adjustment Order"
       ],
       "natureOfApplication5": "No",
       "natureOfApplication6": [

--- a/src/test/resources/fixtures/valid-latest-consent-order.json
+++ b/src/test/resources/fixtures/valid-latest-consent-order.json
@@ -101,7 +101,7 @@
         "Pension Compensation Sharing Order",
         "Pension Compensation Attachment Order",
         "A settlement or a transfer of property",
-        "Property Adjustment  Order"
+        "Property Adjustment Order"
       ],
       "natureOfApplication5": "No",
       "natureOfApplication6": [


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/FR-1696

Removed handling of a bug where we allowed a double space in 'Property Adjustment  Order' 

- DB Migration has now been done to fix this - so BSP logic is now changed to match accordingly