### PR TITLE
Rpet 74

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/GeneralOrderService.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/GeneralOrderService.java
@@ -94,10 +94,14 @@ public class GeneralOrderService {
 
         if (isConsentedApplication(caseDetails)) {
             caseData.put("RespondentName", DocumentHelper.getRespondentFullNameConsented(caseDetails));
-            caseData.put("GeneralOrderCourt", "Courts and Tribunal Service Centre");
+            caseData.put("GeneralOrderCourt", "SITTING in private");
+            caseData.put("GeneralOrderHeader", "Sitting in the Family Court");
         } else {
             caseData.put("RespondentName", DocumentHelper.getRespondentFullNameContested(caseDetails));
-            caseData.put("GeneralOrderCourt", ContestedCourtHelper.getSelectedCourt(caseDetails));
+            caseData.put("GeneralOrderCourt", "SITTING AT the Family Court at the" +
+                ContestedCourtHelper.getSelectedCourt(caseDetails));
+            caseData.put("GeneralOrderHeader", "In the Family Court sitting in the" +
+                ContestedCourtHelper.getSelectedCourt(caseDetails));
         }
 
         caseData.put("GeneralOrderJudgeDetails",

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/GeneralOrderService.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/GeneralOrderService.java
@@ -95,13 +95,13 @@ public class GeneralOrderService {
         if (isConsentedApplication(caseDetails)) {
             caseData.put("RespondentName", DocumentHelper.getRespondentFullNameConsented(caseDetails));
             caseData.put("GeneralOrderCourt", "SITTING in private");
-            caseData.put("GeneralOrderHeader", "Sitting in the Family Court");
+            caseData.put("GeneralOrderHeaderOne", "Sitting in the Family Court");
         } else {
             caseData.put("RespondentName", DocumentHelper.getRespondentFullNameContested(caseDetails));
-            caseData.put("GeneralOrderCourt", "SITTING AT the Family Court at the "
-                + ContestedCourtHelper.getSelectedCourt(caseDetails));
-            caseData.put("GeneralOrderHeader", "In the Family Court sitting in the "
-                + ContestedCourtHelper.getSelectedCourt(caseDetails));
+            caseData.put("GeneralOrderCourtSitting", "SITTING AT the Family Court at the ");
+            caseData.put("GeneralOrderCourt", ContestedCourtHelper.getSelectedCourt(caseDetails));
+            caseData.put("GeneralOrderHeaderOne", "In the Family Court");
+            caseData.put("GeneralOrderHeaderTwo", "sitting in the");
         }
 
         caseData.put("GeneralOrderJudgeDetails",

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/GeneralOrderService.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/GeneralOrderService.java
@@ -98,10 +98,10 @@ public class GeneralOrderService {
             caseData.put("GeneralOrderHeader", "Sitting in the Family Court");
         } else {
             caseData.put("RespondentName", DocumentHelper.getRespondentFullNameContested(caseDetails));
-            caseData.put("GeneralOrderCourt", "SITTING AT the Family Court at the" +
-                ContestedCourtHelper.getSelectedCourt(caseDetails));
-            caseData.put("GeneralOrderHeader", "In the Family Court sitting in the" +
-                ContestedCourtHelper.getSelectedCourt(caseDetails));
+            caseData.put("GeneralOrderCourt", "SITTING AT the Family Court at the "
+                + ContestedCourtHelper.getSelectedCourt(caseDetails));
+            caseData.put("GeneralOrderHeader", "In the Family Court sitting in the "
+                + ContestedCourtHelper.getSelectedCourt(caseDetails));
         }
 
         caseData.put("GeneralOrderJudgeDetails",

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/RefusalOrderDocumentService.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/RefusalOrderDocumentService.java
@@ -7,7 +7,6 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.finrem.caseorchestration.config.DocumentConfiguration;
-import uk.gov.hmcts.reform.finrem.caseorchestration.helper.ConsentedCourtHelper;
 import uk.gov.hmcts.reform.finrem.caseorchestration.helper.ContestedCourtHelper;
 import uk.gov.hmcts.reform.finrem.caseorchestration.helper.DocumentHelper;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CaseDocument;
@@ -124,12 +123,17 @@ public class RefusalOrderDocumentService {
         Map<String, Object> caseData = caseDetails.getData();
 
         caseData.put("ApplicantName", DocumentHelper.getApplicantFullName(caseDetails));
-        caseData.put("RespondentName", isConsentedApplication(caseDetails)
-            ? DocumentHelper.getRespondentFullNameConsented(caseDetails) :
-            DocumentHelper.getRespondentFullNameContested(caseDetails));
-        caseData.put("CourtName", isConsentedApplication(caseDetails)
-            ? ConsentedCourtHelper.getSelectedCourt(caseDetails) :
-            ContestedCourtHelper.getSelectedCourt(caseDetails));
+        caseData.put("RefusalOrderHeader", "Sitting in the Family Court");
+
+        if (isConsentedApplication(caseDetails)) {
+            caseData.put("RespondentName", DocumentHelper.getRespondentFullNameConsented(caseDetails));
+            caseData.put("CourtName", "SITTING in private");
+
+        } else {
+            caseData.put("RespondentName", DocumentHelper.getRespondentFullNameContested(caseDetails));
+            caseData.put("CourtName", "SITTING AT the Family Court at the "
+                + ContestedCourtHelper.getSelectedCourt(caseDetails));
+        }
 
         return caseDetails;
     }

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/GeneralOrderServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/GeneralOrderServiceTest.java
@@ -300,7 +300,7 @@ public class GeneralOrderServiceTest {
             assertThat(data.get("GeneralOrderRecitals"), is("Consented Recitals"));
             assertThat(data.get("GeneralOrderDate"), is("01/01/2020"));
             assertThat(data.get("GeneralOrderBodyText"), is("Test is dummy text for consented"));
-            assertThat(data.get("GeneralOrderHeader"), is("Sitting in the Family Court"));
+            assertThat(data.get("GeneralOrderHeaderOne"), is("Sitting in the Family Court"));
         }
 
         void verifyAdditionalFieldsContested() {
@@ -309,12 +309,14 @@ public class GeneralOrderServiceTest {
             assertThat(data.get("DivorceCaseNumber"), is("DD98D76543"));
             assertThat(data.get("ApplicantName"), is("Contested Applicant Name"));
             assertThat(data.get("RespondentName"), is("Contested Respondent Name"));
-            assertThat(data.get("GeneralOrderCourt"),is("SITTING AT the Family Court at the Nottingham County Court and Family Court"));
+            assertThat(data.get("GeneralOrderCourt"),is("Nottingham County Court and Family Court"));
             assertThat(data.get("GeneralOrderJudgeDetails"), is("Her Honour Judge Contested"));
             assertThat(data.get("GeneralOrderRecitals"), is("Contested Recitals"));
             assertThat(data.get("GeneralOrderDate"), is("01/06/2020"));
             assertThat(data.get("GeneralOrderBodyText"), is("Test is dummy text for contested"));
-            assertThat(data.get("GeneralOrderHeader"), is("In the Family Court sitting in the Nottingham County Court and Family Court"));
+            assertThat(data.get("GeneralOrderHeaderOne"), is("In the Family Court"));
+            assertThat(data.get("GeneralOrderHeaderTwo"), is("sitting in the"));
+            assertThat(data.get("GeneralOrderCourtSitting"), is("SITTING AT the Family Court at the "));
 
         }
 

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/GeneralOrderServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/GeneralOrderServiceTest.java
@@ -295,11 +295,12 @@ public class GeneralOrderServiceTest {
             assertThat(data.get("DivorceCaseNumber"), is("DD12D12345"));
             assertThat(data.get("ApplicantName"), is("Consented Applicant Name"));
             assertThat(data.get("RespondentName"), is("Consented Respondent Name"));
-            assertThat(data.get("GeneralOrderCourt"), is("Courts and Tribunal Service Centre"));
+            assertThat(data.get("GeneralOrderCourt"), is("SITTING in private"));
             assertThat(data.get("GeneralOrderJudgeDetails"), is("His Honour Judge Consented"));
             assertThat(data.get("GeneralOrderRecitals"), is("Consented Recitals"));
             assertThat(data.get("GeneralOrderDate"), is("01/01/2020"));
             assertThat(data.get("GeneralOrderBodyText"), is("Test is dummy text for consented"));
+            assertThat(data.get("GeneralOrderHeader"), is("Sitting in the Family Court"));
         }
 
         void verifyAdditionalFieldsContested() {
@@ -308,11 +309,13 @@ public class GeneralOrderServiceTest {
             assertThat(data.get("DivorceCaseNumber"), is("DD98D76543"));
             assertThat(data.get("ApplicantName"), is("Contested Applicant Name"));
             assertThat(data.get("RespondentName"), is("Contested Respondent Name"));
-            assertThat(data.get("GeneralOrderCourt"),is("Nottingham County Court and Family Court"));
+            assertThat(data.get("GeneralOrderCourt"),is("SITTING AT the Family Court at the Nottingham County Court and Family Court"));
             assertThat(data.get("GeneralOrderJudgeDetails"), is("Her Honour Judge Contested"));
             assertThat(data.get("GeneralOrderRecitals"), is("Contested Recitals"));
             assertThat(data.get("GeneralOrderDate"), is("01/06/2020"));
             assertThat(data.get("GeneralOrderBodyText"), is("Test is dummy text for contested"));
+            assertThat(data.get("GeneralOrderHeader"), is("In the Family Court sitting in the Nottingham County Court and Family Court"));
+
         }
 
         private Map<String, Object> data() {

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/RefusalOrderDocumentServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/RefusalOrderDocumentServiceTest.java
@@ -78,6 +78,7 @@ public class RefusalOrderDocumentServiceTest extends BaseServiceTest {
         assertThat(consentOrderData.getConsentOrder().getDocumentComment(), is(equalTo("System Generated")));
 
         assertCaseDataExtraFields();
+        assertConsentedCaseDataExtraFields();
         assertCaseDocument(consentOrderData.getConsentOrder().getDocumentLink());
     }
 
@@ -89,6 +90,7 @@ public class RefusalOrderDocumentServiceTest extends BaseServiceTest {
 
         assertThat(getDocumentList(caseData, CONTESTED_CONSENT_ORDER_NOT_APPROVED_COLLECTION), hasSize(1));
         assertCaseDataExtraFields();
+        assertContestedCaseDataExtraFields();
     }
 
     @Test
@@ -128,6 +130,7 @@ public class RefusalOrderDocumentServiceTest extends BaseServiceTest {
         CaseDocument caseDocument = getCaseDocument(caseData);
 
         assertCaseDataExtraFields();
+        assertConsentedCaseDataExtraFields();
         assertCaseDocument(caseDocument);
     }
 
@@ -144,7 +147,23 @@ public class RefusalOrderDocumentServiceTest extends BaseServiceTest {
 
         assertThat(caseData.get("ApplicantName"), is("Poor Guy"));
         assertThat(caseData.get("RespondentName"), is("john smith"));
-        assertThat(caseData.get("CourtName"), is("Birmingham Civil and Family Justice Centre"));
+        assertThat(caseData.get("RefusalOrderHeader"), is("Sitting in the Family Court"));
+    }
+
+    private void assertConsentedCaseDataExtraFields() {
+        verify(genericDocumentService, times(1)).generateDocument(any(), generateDocumentCaseDetailsCaptor.capture(),
+            any(), any());
+        Map<String, Object> caseData = generateDocumentCaseDetailsCaptor.getValue().getData();
+
+        assertThat(caseData.get("CourtName"), is("SITTING in private"));
+    }
+
+    private void assertContestedCaseDataExtraFields() {
+        verify(genericDocumentService, times(1)).generateDocument(any(), generateDocumentCaseDetailsCaptor.capture(),
+            any(), any());
+        Map<String, Object> caseData = generateDocumentCaseDetailsCaptor.getValue().getData();
+
+        assertThat(caseData.get("CourtName"), is("SITTING AT the Family Court at the Birmingham Civil and Family Justice Centre"));
     }
 
     private CaseDocument getCaseDocument(Map<String, Object> caseData) {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RPET-74

### Change description ###

Update General Order header to say "Sitting in the Family Court when it's consented and "In the Family Court sitting in the <<courtname>>" when it's contested

Update Refusual order court name to always be "SITTING in private" for consented and "SITTING AT the Family Court at the <<courtname>>" for contested

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
