### PR TITLE
Bumped CCD Client as per CCD teams request (also bumped Gradle version)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,7 +105,7 @@ configurations {
 
 def versions = [
     bspCommonLib            : '0.0.44',
-    ccdClient               : '4.7.2',
+    ccdClient               : '4.7.3',
     commonsBeanUtils        : '1.9.4',
     commonsIo               : '2.7',
     commonsLang3            : '3.11',

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
_As part of the CCD 19.1.1 release we have to revert the changes done in the JIRA ticket RDM-8751, 
 
Because the addition of the new field 'case_types_results' breaks the ccd-client library with exception Unrecognized field "case_types_results".
 
To address this issue, we have done changes in ccd-client version 4.7.3 library to ignore un-known json properties.
                @JsonIgnoreProperties(ignoreUnknown = true) has been added on most of the model classes in the ccd-client library. Even if CCD adds new fields in the response objects in the future this change is going to protect the services from throwing errors on un-known properties
Could you please upgrade the version of ccd-client library (core-case-data-store-client) to latest 4.7.3 version. It should not break any functionality on services after the upgrade._

- Also bumped Gradle Wrapper version to latest