### PR TITLE
fix SIGSEGV jvm error on master build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -237,6 +237,10 @@ tasks.withType(Checkstyle).each { checkstyleTask ->
     }
 }
 
+jacoco {
+    toolVersion = "0.8.6"
+}
+
 jacocoTestReport {
     executionData(test)
 


### PR DESCRIPTION
Attempt to fix build error on master pipeline:


```
[2020-09-28T09:40:20.085Z] # A fatal error has been detected by the Java Runtime Environment:

[2020-09-28T09:40:20.085Z] #  SIGSEGV (0xb) at pc=0x00007fcbc5114820, pid=17685, tid=17722
```
