### PR TITLE
adding check for test type before setting default org policy

### DIFF
--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/CaseDataControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/CaseDataControllerTest.java
@@ -29,6 +29,7 @@ public class CaseDataControllerTest extends BaseControllerTest {
     private static final String MOVE_VALUES_SAMPLE_JSON = "/fixtures/move-values-sample.json";
     private static final String CONTESTED_HWF_JSON = "/fixtures/contested/hwf.json";
     private static final String CONTESTED_VALIDATE_HEARING_SUCCESSFULLY_JSON = "/fixtures/contested/validate-hearing-successfully.json";
+    private static final String INVALID_CASE_TYPE_JSON = "/fixtures/invalid-case-type.json";
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     @MockBean
@@ -283,6 +284,22 @@ public class CaseDataControllerTest extends BaseControllerTest {
 
         requestContent = objectMapper.readTree(new File(getClass()
             .getResource(CONTESTED_VALIDATE_HEARING_SUCCESSFULLY_JSON).toURI()));
+        mvc.perform(post("/case-orchestration/contested/set-paper-case-defaults")
+            .content(requestContent.toString())
+            .header(AUTHORIZATION_HEADER, AUTH_TOKEN)
+            .contentType(APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andDo(print())
+            .andExpect(jsonPath("$.data.ApplicantOrganisationPolicy").doesNotExist());
+    }
+
+    @Test
+    public void shouldNotSetOrgPolicyIfFeatureEnabledButInvalidCaseType() throws Exception {
+        when(idamService.isUserRoleAdmin(isA(String.class))).thenReturn(Boolean.FALSE);
+        when(featureToggleService.isShareACaseEnabled()).thenReturn(false);
+
+        requestContent = objectMapper.readTree(new File(getClass()
+            .getResource(INVALID_CASE_TYPE_JSON).toURI()));
         mvc.perform(post("/case-orchestration/contested/set-paper-case-defaults")
             .content(requestContent.toString())
             .header(AUTHORIZATION_HEADER, AUTH_TOKEN)

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/CaseDataControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/CaseDataControllerTest.java
@@ -296,7 +296,7 @@ public class CaseDataControllerTest extends BaseControllerTest {
     @Test
     public void shouldNotSetOrgPolicyIfFeatureEnabledButInvalidCaseType() throws Exception {
         when(idamService.isUserRoleAdmin(isA(String.class))).thenReturn(Boolean.FALSE);
-        when(featureToggleService.isShareACaseEnabled()).thenReturn(false);
+        when(featureToggleService.isShareACaseEnabled()).thenReturn(true);
 
         requestContent = objectMapper.readTree(new File(getClass()
             .getResource(INVALID_CASE_TYPE_JSON).toURI()));

--- a/src/test/resources/fixtures/invalid-case-type.json
+++ b/src/test/resources/fixtures/invalid-case-type.json
@@ -1,0 +1,11 @@
+{
+  "event_id": "some_event_id",
+  "case_details": {
+    "jurisdiction": "DIVORCE",
+    "state": "applicationDrafted",
+    "case_type_id": "InvalidCaseType",
+    "case_data": {
+      "d81Question": "No"
+    }
+  }
+}


### PR DESCRIPTION


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FR-1778

### Change description ###

XUI use a version of our config to test and develop on share a case. We updated out config for demo and have it pre populating a field on our cases in callback. 
As they use a branched version of consent it also makes the callback but doesn't have the field which is being prepopulated on demo. So they can't make new cases.
This change simply checks the case type is consent or contested before prepopulating the field.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
