### PR TITLE
RPET-707: filtering out null pension documents and improving logging

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/ConsentOrderApprovedController.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/ConsentOrderApprovedController.java
@@ -140,11 +140,10 @@ public class ConsentOrderApprovedController implements BaseController {
     }
 
     private void generateAndPrepareDocuments(String authToken, CaseDetails caseDetails) {
-        log.info("Generating and preparing documents for latest consent order");
+        log.info("Generating and preparing documents for latest consent order, case {}", caseDetails.getId());
 
         Map<String, Object> caseData = caseDetails.getData();
         CaseDocument latestConsentOrder = getLatestConsentOrder(caseData);
-        List<PensionCollectionData> pensionDocs = getPensionDocuments(caseData);
 
         CaseDocument approvedConsentOrderLetter = consentOrderApprovedDocumentService.generateApprovedConsentOrderLetter(caseDetails, authToken);
         CaseDocument consentOrderAnnexStamped = genericDocumentService.annexStampDocument(latestConsentOrder, authToken);
@@ -155,6 +154,7 @@ public class ConsentOrderApprovedController implements BaseController {
 
         ApprovedOrder approvedOrder = approvedOrderBuilder.build();
 
+        List<PensionCollectionData> pensionDocs = getPensionDocuments(caseData);
         if (!isEmpty(pensionDocs)) {
             log.info("Pension Documents not empty for case - stamping Pension Documents and adding to approvedOrder for case {}",
                 caseDetails.getId());

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/BulkPrintService.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/BulkPrintService.java
@@ -61,7 +61,7 @@ public class BulkPrintService {
                 .bulkPrintDocuments(documents)
                 .build());
 
-        log.info("Letter ID {} for {} document(s) of type {} sent to bulk print: {}", letterId, documents.size(), letterType, documents);
+        log.info("Case {} Letter ID {} for {} document(s) of type {} sent to bulk print: {}", caseId, letterId, documents.size(), letterType, documents);
 
         return letterId;
     }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/BulkPrintService.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/BulkPrintService.java
@@ -61,7 +61,8 @@ public class BulkPrintService {
                 .bulkPrintDocuments(documents)
                 .build());
 
-        log.info("Case {} Letter ID {} for {} document(s) of type {} sent to bulk print: {}", caseId, letterId, documents.size(), letterType, documents);
+        log.info("Case {} Letter ID {} for {} document(s) of type {} sent to bulk print: {}", caseId, letterId, documents.size(), letterType,
+            documents);
 
         return letterId;
     }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/ConsentOrderApprovedDocumentService.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/ConsentOrderApprovedDocumentService.java
@@ -80,7 +80,8 @@ public class ConsentOrderApprovedDocumentService {
 
     public List<PensionCollectionData> stampPensionDocuments(List<PensionCollectionData> pensionList, String authToken) {
         return pensionList.stream()
-            .map(data -> stampPensionDocuments(data, authToken)).collect(toList());
+            .filter(pensionCollectionData -> pensionCollectionData.getTypedCaseDocument().getPensionDocument() != null)
+            .map(pensionCollectionData -> stampPensionDocuments(pensionCollectionData, authToken)).collect(toList());
     }
 
     private PensionCollectionData stampPensionDocuments(PensionCollectionData pensionDocument, String authToken) {
@@ -92,7 +93,7 @@ public class ConsentOrderApprovedDocumentService {
     }
 
     public List<BulkPrintDocument> prepareApplicantLetterPack(CaseDetails caseDetails, String authorisationToken) {
-        log.info("Sending Approved Consent Order to applicant / solicitor for Bulk Print");
+        log.info("Sending Approved Consent Order to applicant / solicitor for Bulk Print, case {}", caseDetails.getId());
         Map<String, Object> caseData = caseDetails.getData();
 
         List<BulkPrintDocument> bulkPrintDocuments = new ArrayList<>();
@@ -195,7 +196,7 @@ public class ConsentOrderApprovedDocumentService {
             .orElse(new ArrayList<>());
 
         if (!approvedOrderCollectionData.isEmpty()) {
-            log.info("Extracting '{}' from case data for bulk print: {}", approvedOrderCollectionFieldName, data);
+            log.info("Extracting '{}' from case data for bulk print, case {}", approvedOrderCollectionFieldName, caseDetails.getId());
             Map<String, Object> lastApprovedOrder = (Map<String, Object>)(approvedOrderCollectionData.get(approvedOrderCollectionData.size() - 1)
                 .get(VALUE));
             documentHelper.getDocumentLinkAsCaseDocument(lastApprovedOrder, ORDER_LETTER).ifPresent(documents::add);
@@ -205,7 +206,8 @@ public class ConsentOrderApprovedDocumentService {
                 PENSION_DOCUMENTS,
                 "uploadedDocument"));
         } else {
-            log.info("Failed to extract '{}' from case data for bulk print as document list was empty.", approvedOrderCollectionFieldName);
+            log.info("Failed to extract '{}' from case data for bulk print as document list was empty, case {}",
+                approvedOrderCollectionFieldName, caseDetails.getId());
         }
 
         return documents;

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/ConsentOrderPrintService.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/ConsentOrderPrintService.java
@@ -48,7 +48,7 @@ public class ConsentOrderPrintService {
             generateCoversheetForRespondentAndSendOrders(caseDetails, authorisationToken);
         }
 
-        log.info("Bulk print is successful");
+        log.info("Bulk print is successful, case {}", caseDetails.getId());
     }
 
     private void generateCoversheetForRespondentAndSendOrders(CaseDetails caseDetails, String authorisationToken) {
@@ -65,7 +65,8 @@ public class ConsentOrderPrintService {
             caseData.put(BULK_PRINT_LETTER_ID_RES, respondentLetterId);
         }
 
-        log.info("Generated Respondent CoverSheet for bulk print. coversheet: {}, letterId : {}", respondentCoverSheet, respondentLetterId);
+        log.info("Generated Respondent CoverSheet for bulk print, case {}. coversheet: {}, letterId : {}", caseDetails.getId(),
+            respondentCoverSheet, respondentLetterId);
     }
 
     private UUID printApplicantConsentOrderApprovedDocuments(CaseDetails caseDetails, String authorisationToken) {
@@ -85,7 +86,7 @@ public class ConsentOrderPrintService {
     }
 
     private UUID sendConsentOrderForBulkPrintRespondent(CaseDocument coverSheet, CaseDetails caseDetails, String authorisationToken) {
-        log.info("Sending order documents to recipient / solicitor for Bulk Print");
+        log.info("Sending order documents to recipient / solicitor for Bulk Print, case {}", caseDetails.getId());
 
         List<BulkPrintDocument> bulkPrintDocuments = new ArrayList<>();
         bulkPrintDocuments.add(documentHelper.getCaseDocumentAsBulkPrintDocument(coverSheet));

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/ConsentOrderApprovedControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/ConsentOrderApprovedControllerTest.java
@@ -7,6 +7,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.finrem.caseorchestration.helper.DocumentHelper;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CaseDocument;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.PensionCollectionData;
 import uk.gov.hmcts.reform.finrem.caseorchestration.service.ConsentOrderApprovedDocumentService;
@@ -51,6 +52,7 @@ public class ConsentOrderApprovedControllerTest extends BaseControllerTest {
     @MockBean private GenericDocumentService genericDocumentService;
     @MockBean private ConsentOrderPrintService consentOrderPrintService;
     @MockBean private NotificationService notificationService;
+    @MockBean private DocumentHelper documentHelper;
     @MockBean private FeatureToggleService featureToggleService;
 
     public String consentOrderApprovedEndpoint() {
@@ -114,6 +116,7 @@ public class ConsentOrderApprovedControllerTest extends BaseControllerTest {
         whenAnnexStampingDocument().thenReturn(caseDocument());
         whenStampingDocument().thenReturn(caseDocument());
         whenStampingPensionDocuments().thenReturn(singletonList(pensionDocumentData()));
+        when(documentHelper.getPensionDocumentsData(any())).thenReturn(singletonList(caseDocument()));
 
         ResultActions result = mvc.perform(post(consentOrderApprovedEndpoint())
             .content(requestContent.toString())
@@ -134,6 +137,7 @@ public class ConsentOrderApprovedControllerTest extends BaseControllerTest {
         whenAnnexStampingDocument().thenReturn(caseDocument());
         whenStampingDocument().thenReturn(caseDocument());
         whenStampingPensionDocuments().thenReturn(singletonList(pensionDocumentData()));
+        when(documentHelper.getPensionDocumentsData(any())).thenReturn(singletonList(caseDocument()));
 
         ResultActions result = mvc.perform(post(consentOrderApprovedEndpoint())
             .content(requestContent.toString())
@@ -233,6 +237,7 @@ public class ConsentOrderApprovedControllerTest extends BaseControllerTest {
         whenAnnexStampingDocument().thenReturn(caseDocument());
         whenStampingDocument().thenReturn(caseDocument());
         whenStampingPensionDocuments().thenReturn(singletonList(pensionDocumentData()));
+        when(documentHelper.getPensionDocumentsData(any())).thenReturn(singletonList(caseDocument()));
 
         ResultActions result = mvc.perform(post(consentOrderApprovedEndpoint())
             .content(requestContent.toString())
@@ -270,7 +275,7 @@ public class ConsentOrderApprovedControllerTest extends BaseControllerTest {
             .contentType(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(status().isOk());
 
-        verify(consentOrderApprovedDocumentService, times(1)).stampAndPopulateContestedConsentApprovedOrderCollection(any(), eq(AUTH_TOKEN));
+        verify(consentOrderApprovedDocumentService).stampAndPopulateContestedConsentApprovedOrderCollection(any(), eq(AUTH_TOKEN));
     }
 
     @Test
@@ -284,7 +289,7 @@ public class ConsentOrderApprovedControllerTest extends BaseControllerTest {
             .andExpect(status().isOk());
 
         verify(consentOrderApprovedDocumentService, never()).generateApprovedConsentOrderLetter(any(), eq(AUTH_TOKEN));
-        verify(consentOrderPrintService, times(1)).sendConsentOrderToBulkPrint(any(), eq(AUTH_TOKEN));
+        verify(consentOrderPrintService).sendConsentOrderToBulkPrint(any(), eq(AUTH_TOKEN));
     }
 
     @Test
@@ -299,7 +304,7 @@ public class ConsentOrderApprovedControllerTest extends BaseControllerTest {
             .contentType(MediaType.APPLICATION_JSON_VALUE));
 
         result.andExpect(status().isOk());
-        verify(consentOrderPrintService, times(1)).sendConsentOrderToBulkPrint(any(), eq(AUTH_TOKEN));
+        verify(consentOrderPrintService).sendConsentOrderToBulkPrint(any(), eq(AUTH_TOKEN));
     }
 
     private OngoingStubbing<CaseDocument> whenServiceGeneratesDocument() {

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/ConsentOrderApprovedDocumentServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/ConsentOrderApprovedDocumentServiceTest.java
@@ -188,6 +188,22 @@ public class ConsentOrderApprovedDocumentServiceTest extends BaseServiceTest {
     }
 
     @Test
+    public void givenNullDocumentInPensionDocuments_whenStampingDocuments_thenTheNullValueIsIgnored() {
+        Mockito.reset(documentClientMock);
+        when(documentClientMock.stampDocument(any(), anyString())).thenReturn(document());
+
+        PensionCollectionData pensionCollectionDataWithNullDocument = pensionDocumentData();
+        pensionCollectionDataWithNullDocument.getTypedCaseDocument().setPensionDocument(null);
+        List<PensionCollectionData> pensionDocuments = asList(pensionDocumentData(), pensionCollectionDataWithNullDocument);
+
+        List<PensionCollectionData> stampPensionDocuments = consentOrderApprovedDocumentService.stampPensionDocuments(pensionDocuments, AUTH_TOKEN);
+
+        assertThat(stampPensionDocuments, hasSize(1));
+        stampPensionDocuments.forEach(data -> assertCaseDocument(data.getTypedCaseDocument().getPensionDocument()));
+        verify(documentClientMock, times(1)).stampDocument(any(), anyString());
+    }
+
+    @Test
     public void whenPreparingApplicantLetterPack() throws Exception {
         CaseDetails caseDetailsTemp = documentHelper.deepCopy(caseDetails, CaseDetails.class);
         addConsentOrderApprovedDataToCaseDetails(caseDetailsTemp);


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RPET-707

### Change description ###

- filtered out null pension documents when stamping
- improved logging adding case ID to log messages

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
