### PR TITLE
reverting cft plugin upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ and a few docker containers for Postgres, ES, LS and XUI:
 
 on `build.gradle` you can find our customisation for the plugin task on `bootWithCCD`:
 
+- if running it with `authMode = uk.gov.hmcts.rse.AuthMode.AAT`, 
+an `.aat-env` file is needed so the automated process can set up the environment variables
+to point the services to AAT. As these will contain service keys, we are not keeping these under source control, 
+ask a colleague to provide them or copy them from the pods running in AAT.
+(As AAT is heavily used on this setup you must be always on the VPN)
+
 - if running it with `authMode = uk.gov.hmcts.rse.AuthMode.Local` in addition to CCD services an IDAM and S2S simulators
 are also made available so there is no dependency on AAT. 
 

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ plugins {
     id 'org.owasp.dependencycheck' version '6.2.2'
     id 'org.sonarqube' version '3.0'
     id 'org.springframework.boot' version '2.3.11.RELEASE'
-    id 'com.github.hmcts.rse-cft-lib' version '0.17.152'
+    id 'com.github.hmcts.rse-cft-lib' version '0.16.140'
 }
 
 apply plugin: 'au.com.dius.pact'
@@ -449,6 +449,15 @@ task buildCCDXlsx(type: Exec) {
 
 bootWithCCD {
     dependsOn(buildCCDXlsx)
+
+    doFirst() {
+        project.file('./.aat-env').readLines().each() {
+            def index = it.indexOf("=")
+            def key = it.substring(0, index)
+            def value = it.substring(index + 1)
+            environment(key, value)
+        }
+    }
 
     //AAT or Local (IDAM and S2S Simulators)
     authMode = uk.gov.hmcts.rse.AuthMode.AAT


### PR DESCRIPTION
bug on the latest cft lib plugin won't pickup finrem secrets so we need the .aat-env file back