### PR TITLE
Fix CFT lib missing role

### DIFF
--- a/src/cftlib/java/uk/gov/hmcts/reform/finrem/caseorchestration/CftLibConfig.java
+++ b/src/cftlib/java/uk/gov/hmcts/reform/finrem/caseorchestration/CftLibConfig.java
@@ -36,7 +36,8 @@ public class CftLibConfig implements CFTLibConfigurer {
             "caseworker-divorce-systemupdate",
             "caseworker-divorce-bulkscan",
             "caseworker-divorce-financialremedy",
-            "caseworker-caa"
+            "caseworker-caa",
+            "IDAM_SUPER_USER"
         );
     }
 


### PR DESCRIPTION
IDAM_SUPER_USER was added to definitions as a new Role but wasn't updated in the cftlib config for COS causing it to fail on import