### PR TITLE
fix-depend-issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ def versions = [
         jjwt                 : '0.9.1',
         skyscreamer          : '1.5.0',
         jaxbOsgi             : '2.3.3',
-        springHateoas        : '1.5.1',
+        springHateoas        : '2.1.1',
         tika                 : '2.4.1',
         amClient             : '1.7.3',
         sendLetterClient     : '3.0.16',

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ def versions = [
         jjwt                 : '0.9.1',
         skyscreamer          : '1.5.0',
         jaxbOsgi             : '2.3.3',
-        springHateoas        : '2.1.1',
+        springHateoas        : '1.5.1',
         tika                 : '2.4.1',
         amClient             : '1.7.3',
         sendLetterClient     : '3.0.16',

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -182,4 +182,11 @@
         <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
         <cve>CVE-2023-35116</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: spring-hateoas-1.5.1.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework\.hateoas/spring\-hateoas@.*$</packageUrl>
+        <cve>CVE-2023-34036</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
[CVE-2023-34036](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2023-34036)  

Reactive web applications that use Spring HATEOAS to produce hypermedia-based responses might be exposed to malicious forwarded headers if they are not behind a trusted proxy that ensures correctness of such headers, or if they don't have anything else in place to handle (and possibly discard) forwarded headers either in WebFlux or at the level of the underlying HTTP server.

For the application to be affected, it needs to satisfy the following requirements:

  *  It needs to use the reactive web stack (Spring WebFlux) and Spring HATEOAS to create links in hypermedia-based responses.
  *  The application infrastructure does not guard against clients submitting (X-)Forwarded… headers.