### PR TITLE
Remove manifest before trying to create it

### DIFF
--- a/acb.tpl.yaml
+++ b/acb.tpl.yaml
@@ -50,7 +50,9 @@ steps:
       - runtime-arm64
 
   - id: manifest-create
-    cmd: docker manifest create {{.Run.Registry}}/{{CI_IMAGE_TAG}} {{.Run.Registry}}/{{CI_IMAGE_TAG}}-amd64 {{.Run.Registry}}/{{CI_IMAGE_TAG}}-arm64
+    cmd: |
+      docker manifest rm {{.Run.Registry}}/{{CI_IMAGE_TAG}} {{.Run.Registry}}/{{CI_IMAGE_TAG}}-amd64 {{.Run.Registry}}/{{CI_IMAGE_TAG}}-arm64 || true
+      docker manifest create {{.Run.Registry}}/{{CI_IMAGE_TAG}} {{.Run.Registry}}/{{CI_IMAGE_TAG}}-amd64 {{.Run.Registry}}/{{CI_IMAGE_TAG}}-arm64
     retries: 3
     retryDelay: 3
     when:


### PR DESCRIPTION
### Change description ###


```

[2023-11-16T12:20:13.983Z] 2023/11/16 12:20:03 Container failed during run: manifest-create, waiting 3 seconds before retrying...

[2023-11-16T12:20:13.983Z] 2023/11/16 12:20:06 Launching container with name: manifest-create

[2023-11-16T12:20:13.983Z] docker: Error response from daemon: Conflict. The container name "/manifest-create" is already in use by container "be3ec598485ee89ad9c037a48cbfb50fd4883939234d094a47948898d75ca46c". You have to remove (or rename) that container to be able to reuse that name.

[2023-11-16T12:20:13.983Z] See 'docker run --help'.

[2023-11-16T12:20:13.983Z] 2023/11/16 12:20:06 Container failed during run: manifest-create, waiting 3 seconds before retrying...

[2023-11-16T12:20:13.983Z] 2023/11/16 12:20:09 Launching container with name: manifest-create

[2023-11-16T12:20:13.983Z] docker: Error response from daemon: Conflict. The container name "/manifest-create" is already in use by container "be3ec598485ee89ad9c037a48cbfb50fd4883939234d094a47948898d75ca46c". You have to remove (or rename) that container to be able to reuse that name.

[2023-11-16T12:20:13.983Z] See 'docker run --help'.

[2023-11-16T12:20:13.983Z] 2023/11/16 12:20:09 Container failed during run: manifest-create, waiting 3 seconds before retrying...

[2023-11-16T12:20:13.983Z] 2023/11/16 12:20:12 Launching container with name: manifest-create

[2023-11-16T12:20:13.983Z] docker: Error response from daemon: Conflict. The container name "/manifest-create" is already in use by container "be3ec598485ee89ad9c037a48cbfb50fd4883939234d094a47948898d75ca46c". You have to remove (or rename) that container to be able to reuse that name.
```


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
