### PR TITLE
Fix bootWithCCD startup exceptions due to missing translation service

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -357,7 +357,7 @@ bootWithCCD {
     environment("FEATURE_ASSIGN_CASE_ACCESS", "false")
 
     // ccd-definition-store-api
-    environment 'WELSH_TRANSLATION_ENABLED', 'false'
+    environment("WELSH_TRANSLATION_ENABLED", "false")
 }
 
 dependencyManagement {

--- a/build.gradle
+++ b/build.gradle
@@ -355,6 +355,9 @@ bootWithCCD {
     environment("SERVICE_AUTH_MICROSERVICE", "finrem_case_orchestration")
     environment("FEATURE_SEND_LETTER_RECIPIENT_CHECK", "false")
     environment("FEATURE_ASSIGN_CASE_ACCESS", "false")
+
+    // ccd-definition-store-api
+    environment 'WELSH_TRANSLATION_ENABLED', 'false'
 }
 
 dependencyManagement {


### PR DESCRIPTION
### Change description ###
During bootWithCCD startup, exceptions are thrown by ccd-definition-store-api due to failure to connect to the translation service. The exceptions can be avoided by disabling Welsh translations
