### PR TITLE
Add factory class for creating test objects

### DIFF
--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/FinremCallbackRequestFactory.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/FinremCallbackRequestFactory.java
@@ -1,0 +1,37 @@
+package uk.gov.hmcts.reform.finrem.caseorchestration;
+
+import uk.gov.hmcts.reform.finrem.caseorchestration.handler.FinremCallbackRequest;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.FinremCaseData;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.FinremCaseDetails;
+
+public class FinremCallbackRequestFactory {
+
+    private FinremCallbackRequestFactory() {
+        // all access through static methods
+    }
+
+    public static FinremCallbackRequest fromId(Long id) {
+        return from(id, FinremCaseData.builder().build());
+    }
+
+    public static FinremCallbackRequest from(FinremCaseData caseData) {
+        return from(null, caseData);
+    }
+
+    public static FinremCallbackRequest from(Long id, FinremCaseData caseData) {
+        return FinremCallbackRequest.builder()
+            .caseDetails(FinremCaseDetails.builder()
+                .id(id)
+                .data(caseData)
+                .build())
+            .build();
+    }
+
+    public static FinremCallbackRequest create() {
+        return FinremCallbackRequest.builder()
+            .caseDetails(FinremCaseDetails.builder()
+                .data(FinremCaseData.builder().build())
+                .build())
+            .build();
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/AmendApplicationAboutToStartHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/AmendApplicationAboutToStartHandlerTest.java
@@ -5,13 +5,13 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.google.common.collect.Lists;
 import org.junit.Before;
 import org.junit.Test;
+import uk.gov.hmcts.reform.finrem.caseorchestration.FinremCallbackRequestFactory;
 import uk.gov.hmcts.reform.finrem.caseorchestration.ccd.callback.CallbackType;
 import uk.gov.hmcts.reform.finrem.caseorchestration.controllers.GenericAboutToStartOrSubmitCallbackResponse;
 import uk.gov.hmcts.reform.finrem.caseorchestration.mapper.FinremCaseDetailsMapper;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.EventType;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CaseType;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.FinremCaseData;
-import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.FinremCaseDetails;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.Intention;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.NatureApplication;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.YesOrNo;
@@ -66,7 +66,7 @@ public class AmendApplicationAboutToStartHandlerTest {
 
     @Test
     public void givenCase_whenIntendsToIsApplyToVary_thenShouldAddToNatureList() {
-        FinremCallbackRequest callbackRequest = callbackRequest();
+        FinremCallbackRequest callbackRequest = FinremCallbackRequestFactory.fromId(123L);
 
         FinremCaseData data = callbackRequest.getCaseDetails().getData();
         data.getNatureApplicationWrapper().setNatureOfApplication2(Lists.newArrayList(
@@ -86,7 +86,7 @@ public class AmendApplicationAboutToStartHandlerTest {
 
     @Test
     public void givenCase_whenIntendsToIsNotApplyToVary_thenShouldNotDoAnything() {
-        FinremCallbackRequest callbackRequest = callbackRequest();
+        FinremCallbackRequest callbackRequest = FinremCallbackRequestFactory.fromId(123L);
 
         FinremCaseData data = callbackRequest.getCaseDetails().getData();
         data.getNatureApplicationWrapper().setNatureOfApplication2(Lists.newArrayList(
@@ -107,7 +107,7 @@ public class AmendApplicationAboutToStartHandlerTest {
 
     @Test
     public void givenCase_whenNatureListIsEmptyAndIntendsToIsApplyToVary_thenShouldAddToNatureList() {
-        FinremCallbackRequest callbackRequest = callbackRequest();
+        FinremCallbackRequest callbackRequest = FinremCallbackRequestFactory.fromId(123L);
 
         FinremCaseData data = callbackRequest.getCaseDetails().getData();
         data.setApplicantIntendsTo(Intention.APPLY_TO_VARY);
@@ -120,13 +120,5 @@ public class AmendApplicationAboutToStartHandlerTest {
         assertThat(natureOfApplication2, hasItems(NatureApplication.VARIATION_ORDER));
         assertThat(natureOfApplication2, hasSize(1));
         assertEquals(YesOrNo.NO, responseData.getCivilPartnership());
-    }
-
-    private FinremCallbackRequest callbackRequest() {
-        return FinremCallbackRequest
-            .<FinremCaseDetails>builder()
-            .caseDetails(FinremCaseDetails.builder().id(123L)
-                .data(new FinremCaseData()).build())
-            .build();
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/documentcatergory/AssignDocumentCategoriesAboutToSubmitHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/documentcatergory/AssignDocumentCategoriesAboutToSubmitHandlerTest.java
@@ -5,12 +5,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.finrem.caseorchestration.FinremCallbackRequestFactory;
 import uk.gov.hmcts.reform.finrem.caseorchestration.ccd.callback.CallbackType;
 import uk.gov.hmcts.reform.finrem.caseorchestration.handler.FinremCallbackRequest;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.EventType;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CaseType;
-import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.FinremCaseData;
-import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.FinremCaseDetails;
 import uk.gov.hmcts.reform.finrem.caseorchestration.service.documentcatergory.DocumentCategoryAssigner;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -38,11 +37,9 @@ public class AssignDocumentCategoriesAboutToSubmitHandlerTest {
 
     @Test
     public void shouldCallAssignDocumentCategories() {
-        FinremCaseData caseData = FinremCaseData.builder().build();
-        FinremCallbackRequest callbackRequest =
-            FinremCallbackRequest.builder().caseDetails(FinremCaseDetails.builder().data(caseData).build()).build();
+        FinremCallbackRequest callbackRequest = FinremCallbackRequestFactory.create();
         handler.handle(callbackRequest, "authToken");
-        verify(documentCategoryAssigner).assignDocumentCategories(caseData);
+        verify(documentCategoryAssigner).assignDocumentCategories(callbackRequest.getCaseDetails().getData());
     }
 
 }


### PR DESCRIPTION
### Change description ###
Unit tests are littered with long chains of builder code in order to create FinremCallbackRequests objects. This reduces the readability of tests.

Added factory class to abstract details of creating request object for unit tests.
Included some example usage