### PR TITLE
Suppress CVE-2024-25710

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -407,6 +407,7 @@ dependencies {
     implementation group: 'com.github.hmcts', name: 'send-letter-client', version: versions.sendLetterClient
     implementation group: 'org.apache.pdfbox', name: 'pdfbox', version: versions.pdfbox
     implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
+    implementation group: 'org.apache.commons', name: 'commons-compress', version: '1.26.0'
     implementation group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
     implementation group: 'com.github.hmcts', name: 'ccd-case-document-am-client', version: versions.amClient
     implementation group: 'org.elasticsearch', name: 'elasticsearch', version: versions.elasticSearch

--- a/build.gradle
+++ b/build.gradle
@@ -407,7 +407,6 @@ dependencies {
     implementation group: 'com.github.hmcts', name: 'send-letter-client', version: versions.sendLetterClient
     implementation group: 'org.apache.pdfbox', name: 'pdfbox', version: versions.pdfbox
     implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
-    implementation group: 'org.apache.commons', name: 'commons-compress', version: '1.26.0'
     implementation group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
     implementation group: 'com.github.hmcts', name: 'ccd-case-document-am-client', version: versions.amClient
     implementation group: 'org.elasticsearch', name: 'elasticsearch', version: versions.elasticSearch

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -8,5 +8,12 @@
         <cpe>cpe:/a:fasterxml:jackson-databind</cpe>
         <cve>CVE-2023-35116</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: commons-compress-1.25.0.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.commons/commons\-compress@.*$</packageUrl>
+        <cpe>cpe:/a:apache:commons_compress</cpe>
+    </suppress>
 </suppressions>
 


### PR DESCRIPTION
### Change description ###
Suppress CVE-2024-25710 as bumping commons-compress causes compile errors
