### PR TITLE
DFR-2953: Fix FinremCaseDataTest

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/UploadCaseDocument.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/UploadCaseDocument.java
@@ -34,6 +34,8 @@ public class UploadCaseDocument {
 
     private String exceptionRecordReference;
 
+    private YesOrNo selectForUpdate;
+
     public static UploadCaseDocument from(ScannedDocumentCollection scannedDocumentCollection) {
         ScannedDocument scannedDocument = scannedDocumentCollection.getValue();
         return UploadCaseDocument.builder()


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DFR-2953


### Change description ###
Add selectForUpdate field to UploadCaseDocument class to fix failing FinremCaseDataTest.
This field is used in Manage scanned documents only. However, the test is failing because the CCD data model is shared between Manage scanned documents and Manage case documents.

