### PR TITLE
Dfr 2923 View pension documents in expert reports

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/casedocuments/OtherDocumentsHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/casedocuments/OtherDocumentsHandler.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 public abstract class OtherDocumentsHandler extends PartyDocumentsHandler {
 
-    private static List<CaseDocumentType> otherDocuments = List.of(
+    private static final List<CaseDocumentType> otherDocuments = List.of(
         CaseDocumentType.OTHER,
         CaseDocumentType.FORM_B,
         CaseDocumentType.FORM_F,
@@ -31,8 +31,8 @@ public abstract class OtherDocumentsHandler extends PartyDocumentsHandler {
         CaseDocumentType.FM5
     );
 
-    public OtherDocumentsHandler(CaseDocumentCollectionType caseDocumentCollectionType,
-                                 CaseDocumentParty party, FeatureToggleService featureToggleService) {
+    protected OtherDocumentsHandler(CaseDocumentCollectionType caseDocumentCollectionType,
+                                    CaseDocumentParty party, FeatureToggleService featureToggleService) {
         super(caseDocumentCollectionType, party, featureToggleService);
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/casedocuments/OtherDocumentsHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/casedocuments/OtherDocumentsHandler.java
@@ -50,7 +50,7 @@ public abstract class OtherDocumentsHandler extends PartyDocumentsHandler {
                 return getOtherDocumentCategory();
             }
             case PENSION_PLAN -> {
-                return getPensionPlanDocumentCategory();
+                return DocumentCategory.REPORTS;
             }
             case FORM_B, FORM_F, CARE_PLAN -> {
                 return DocumentCategory.ADMINISTRATIVE_DOCUMENTS_OTHER;
@@ -90,8 +90,6 @@ public abstract class OtherDocumentsHandler extends PartyDocumentsHandler {
     }
 
     protected abstract DocumentCategory getOtherDocumentCategory();
-
-    protected abstract DocumentCategory getPensionPlanDocumentCategory();
 
     protected abstract DocumentCategory getCertificatesOfServiceDocumentCategory();
 

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/casedocuments/applicant/ApplicantOtherDocumentsHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/casedocuments/applicant/ApplicantOtherDocumentsHandler.java
@@ -21,12 +21,6 @@ public class ApplicantOtherDocumentsHandler extends OtherDocumentsHandler {
     }
 
     @Override
-    protected DocumentCategory getPensionPlanDocumentCategory() {
-        return DocumentCategory.APPLICANT_DOCUMENTS_PENSION_PLAN;
-    }
-
-
-    @Override
     protected DocumentCategory getCertificatesOfServiceDocumentCategory() {
         return DocumentCategory.APPLICANT_DOCUMENTS_CERTIFICATES_OF_SERVICE;
     }
@@ -70,7 +64,6 @@ public class ApplicantOtherDocumentsHandler extends OtherDocumentsHandler {
     protected DocumentCategory getFdrDocumentsAndFdrBundleWithoutPrejudiceOffersCategory() {
         return DocumentCategory.FDR_DOCUMENTS_AND_FDR_BUNDLE_APPLICANT_WITHOUT_PREJUDICE_OFFERS;
     }
-
 
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/casedocuments/intervenerfour/IntervenerFourOtherDocumentsHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/casedocuments/intervenerfour/IntervenerFourOtherDocumentsHandler.java
@@ -22,15 +22,9 @@ public class IntervenerFourOtherDocumentsHandler extends OtherDocumentsHandler {
     }
 
     @Override
-    protected DocumentCategory getPensionPlanDocumentCategory() {
-        return DocumentCategory.INTERVENER_DOCUMENTS_INTERVENER_4_PENSION_PLAN;
-    }
-
-    @Override
     protected DocumentCategory getCertificatesOfServiceDocumentCategory() {
         return DocumentCategory.INTERVENER_DOCUMENTS_INTERVENER_4_CERTIFICATES_OF_SERVICE;
     }
-
 
     @Override
     protected DocumentCategory getHearingDocumentsCategoryES1() {

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/casedocuments/intervenerone/IntervenerOneOtherDocumentsHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/casedocuments/intervenerone/IntervenerOneOtherDocumentsHandler.java
@@ -21,11 +21,6 @@ public class IntervenerOneOtherDocumentsHandler extends OtherDocumentsHandler {
     }
 
     @Override
-    protected DocumentCategory getPensionPlanDocumentCategory() {
-        return DocumentCategory.INTERVENER_DOCUMENTS_INTERVENER_1_PENSION_PLAN;
-    }
-
-    @Override
     protected DocumentCategory getCertificatesOfServiceDocumentCategory() {
         return DocumentCategory.INTERVENER_DOCUMENTS_INTERVENER_1_CERTIFICATES_OF_SERVICE;
     }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/casedocuments/intervenerthree/IntervenerThreeOtherDocumentsHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/casedocuments/intervenerthree/IntervenerThreeOtherDocumentsHandler.java
@@ -21,11 +21,6 @@ public class IntervenerThreeOtherDocumentsHandler extends OtherDocumentsHandler 
     }
 
     @Override
-    protected DocumentCategory getPensionPlanDocumentCategory() {
-        return DocumentCategory.INTERVENER_DOCUMENTS_INTERVENER_3_PENSION_PLAN;
-    }
-
-    @Override
     protected DocumentCategory getCertificatesOfServiceDocumentCategory() {
         return DocumentCategory.INTERVENER_DOCUMENTS_INTERVENER_3_CERTIFICATES_OF_SERVICE;
     }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/casedocuments/intervenertwo/IntervenerTwoOtherDocumentsHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/casedocuments/intervenertwo/IntervenerTwoOtherDocumentsHandler.java
@@ -22,11 +22,6 @@ public class IntervenerTwoOtherDocumentsHandler extends OtherDocumentsHandler {
     }
 
     @Override
-    protected DocumentCategory getPensionPlanDocumentCategory() {
-        return DocumentCategory.INTERVENER_DOCUMENTS_INTERVENER_2_PENSION_PLAN;
-    }
-
-    @Override
     protected DocumentCategory getCertificatesOfServiceDocumentCategory() {
         return DocumentCategory.INTERVENER_DOCUMENTS_INTERVENER_2_CERTIFICATES_OF_SERVICE;
     }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/casedocuments/respondent/RespondentOtherDocumentsHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/casedocuments/respondent/RespondentOtherDocumentsHandler.java
@@ -21,12 +21,6 @@ public class RespondentOtherDocumentsHandler extends OtherDocumentsHandler {
     }
 
     @Override
-    protected DocumentCategory getPensionPlanDocumentCategory() {
-        return DocumentCategory.RESPONDENT_DOCUMENTS_PENSION_PLAN;
-    }
-
-
-    @Override
     protected DocumentCategory getCertificatesOfServiceDocumentCategory() {
         return DocumentCategory.RESPONDENT_DOCUMENTS_CERTIFICATES_OF_SERVICE;
     }

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/casedocuments/applicant/ApplicantOtherDocumentsHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/casedocuments/applicant/ApplicantOtherDocumentsHandlerTest.java
@@ -84,7 +84,7 @@ public class ApplicantOtherDocumentsHandlerTest extends BaseManageDocumentsHandl
 
         assertThat(
             collectionService.getDocumentCategoryFromDocumentType(CaseDocumentType.PENSION_PLAN, CaseDocumentParty.APPLICANT),
-            is(DocumentCategory.APPLICANT_DOCUMENTS_PENSION_PLAN)
+            is(DocumentCategory.REPORTS)
         );
 
         assertThat(

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/casedocuments/intervenerfour/IntervenerFourOtherDocumentsHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/casedocuments/intervenerfour/IntervenerFourOtherDocumentsHandlerTest.java
@@ -91,7 +91,7 @@ public class IntervenerFourOtherDocumentsHandlerTest extends BaseManageDocuments
 
         assertThat(
             handler.getDocumentCategoryFromDocumentType(CaseDocumentType.PENSION_PLAN, CaseDocumentParty.INTERVENER_FOUR),
-            is(DocumentCategory.INTERVENER_DOCUMENTS_INTERVENER_4_PENSION_PLAN)
+            is(DocumentCategory.REPORTS)
         );
 
 

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/casedocuments/intervenerone/IntervenerOneOtherDocumentsHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/casedocuments/intervenerone/IntervenerOneOtherDocumentsHandlerTest.java
@@ -82,7 +82,7 @@ public class IntervenerOneOtherDocumentsHandlerTest extends BaseManageDocumentsH
 
         assertThat(
             handler.getDocumentCategoryFromDocumentType(CaseDocumentType.PENSION_PLAN, CaseDocumentParty.INTERVENER_ONE),
-            is(DocumentCategory.INTERVENER_DOCUMENTS_INTERVENER_1_PENSION_PLAN)
+            is(DocumentCategory.REPORTS)
         );
 
         assertThat(

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/casedocuments/intervenerthree/IntervenerThreeOtherDocumentsHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/casedocuments/intervenerthree/IntervenerThreeOtherDocumentsHandlerTest.java
@@ -96,7 +96,7 @@ public class IntervenerThreeOtherDocumentsHandlerTest extends BaseManageDocument
         assertThat(
             handler.getDocumentCategoryFromDocumentType(CaseDocumentType.PENSION_PLAN,
                 CaseDocumentParty.INTERVENER_THREE),
-            is(DocumentCategory.INTERVENER_DOCUMENTS_INTERVENER_3_PENSION_PLAN)
+            is(DocumentCategory.REPORTS)
         );
 
         assertThat(

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/casedocuments/intervenertwo/IntervenerTwoOtherDocumentsHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/casedocuments/intervenertwo/IntervenerTwoOtherDocumentsHandlerTest.java
@@ -95,7 +95,7 @@ public class IntervenerTwoOtherDocumentsHandlerTest extends BaseManageDocumentsH
         assertThat(
             handler.getDocumentCategoryFromDocumentType(CaseDocumentType.PENSION_PLAN,
                 CaseDocumentParty.INTERVENER_TWO),
-            is(DocumentCategory.INTERVENER_DOCUMENTS_INTERVENER_2_PENSION_PLAN)
+            is(DocumentCategory.REPORTS)
         );
 
 

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/casedocuments/respondent/RespondentOtherDocumentsCollectionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/casedocuments/respondent/RespondentOtherDocumentsCollectionServiceTest.java
@@ -82,7 +82,7 @@ public class RespondentOtherDocumentsCollectionServiceTest extends BaseManageDoc
 
         assertThat(
             collectionService.getDocumentCategoryFromDocumentType(CaseDocumentType.PENSION_PLAN, CaseDocumentParty.RESPONDENT),
-            is(DocumentCategory.RESPONDENT_DOCUMENTS_PENSION_PLAN)
+            is(DocumentCategory.REPORTS)
         );
 
         assertThat(


### PR DESCRIPTION
### Jira link (if applicable)
[DFR-2923](https://tools.hmcts.net/jira/browse/DFR-2923)


### Change description ###
Remove subfolder 'Pension Plan' within the 'Applicant Documents' folder
Remove subfolder 'Pension Plan' within the 'Respondent Documents' folder
Pension plan documents to go into 'Expert Reports' folder

FURTHER NOTE: Previously, the Intervener pension plan documents were moved to a another intervener category folder. However, this doesn't seem to be present in our ccd-definitions in categories.json. This is probably worth testing too.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
