### PR TITLE
DFR-2973: Set category for uploaded documents with no document type

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/documentcatergory/UploadGeneralDocumentsCategoriser.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/documentcatergory/UploadGeneralDocumentsCategoriser.java
@@ -32,29 +32,34 @@ public class UploadGeneralDocumentsCategoriser extends DocumentCategoriser {
 
     @Override
     protected void categoriseDocuments(FinremCaseData finremCaseData) {
-
         if (CollectionUtils.isNotEmpty(finremCaseData.getUploadGeneralDocuments())) {
             finremCaseData.getUploadGeneralDocuments().forEach(doc -> checkTypeAndSetCategory(doc.getValue()));
+        }
+    }
+
+    private void checkTypeAndSetCategory(UploadGeneralDocument document) {
+        if (!isDocumentDataValid(document)) {
+            return;
+        }
+
+        if (APPLICANT_DOC_TYPES.contains(document.getDocumentType())) {
+            CaseDocument documentCopy = new CaseDocument(document.getDocumentLink());
+            setCategoryToAllOrdersDocs(documentCopy, DocumentCategory.COURT_CORRESPONDENCE_APPLICANT.getDocumentCategoryId());
+            document.setDocumentLink(documentCopy);
+        } else if (RESPONDENT_DOC_TYPES.contains(document.getDocumentType())) {
+            CaseDocument documentCopy = new CaseDocument(document.getDocumentLink());
+            setCategoryToAllOrdersDocs(documentCopy, DocumentCategory.COURT_CORRESPONDENCE_RESPONDENT.getDocumentCategoryId());
+            document.setDocumentLink(documentCopy);
+        } else {
+            CaseDocument documentCopy = new CaseDocument(document.getDocumentLink());
+            setCategoryToAllOrdersDocs(documentCopy, null);
+            document.setDocumentLink(documentCopy);
         }
 
     }
 
-    private void checkTypeAndSetCategory(UploadGeneralDocument document) {
-        if (document != null && document.getDocumentLink() != null) {
-            if (APPLICANT_DOC_TYPES.contains(document.getDocumentType())) {
-                CaseDocument documentCopy = new CaseDocument(document.getDocumentLink());
-                setCategoryToAllOrdersDocs(documentCopy, DocumentCategory.COURT_CORRESPONDENCE_APPLICANT.getDocumentCategoryId());
-                document.setDocumentLink(documentCopy);
-            } else if (RESPONDENT_DOC_TYPES.contains(document.getDocumentType())) {
-                CaseDocument documentCopy = new CaseDocument(document.getDocumentLink());
-                setCategoryToAllOrdersDocs(documentCopy, DocumentCategory.COURT_CORRESPONDENCE_RESPONDENT.getDocumentCategoryId());
-                document.setDocumentLink(documentCopy);
-            } else {
-                CaseDocument documentCopy = new CaseDocument(document.getDocumentLink());
-                setCategoryToAllOrdersDocs(documentCopy, null);
-                document.setDocumentLink(documentCopy);
-            }
-        }
+    private boolean isDocumentDataValid(UploadGeneralDocument document) {
+        return document != null && document.getDocumentLink() != null && document.getDocumentType() != null;
     }
 
     private void setCategoryToAllOrdersDocs(CaseDocument document, String categoryToApply) {

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/documentcatergory/UploadGeneralDocumentsCategoriser.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/documentcatergory/UploadGeneralDocumentsCategoriser.java
@@ -42,7 +42,11 @@ public class UploadGeneralDocumentsCategoriser extends DocumentCategoriser {
             return;
         }
 
-        if (APPLICANT_DOC_TYPES.contains(document.getDocumentType())) {
+        if (document.getDocumentType() == null) {
+            CaseDocument documentCopy = new CaseDocument(document.getDocumentLink());
+            setCategoryToAllOrdersDocs(documentCopy, DocumentCategory.CASE_DOCUMENTS.getDocumentCategoryId());
+            document.setDocumentLink(documentCopy);
+        } else if (APPLICANT_DOC_TYPES.contains(document.getDocumentType())) {
             CaseDocument documentCopy = new CaseDocument(document.getDocumentLink());
             setCategoryToAllOrdersDocs(documentCopy, DocumentCategory.COURT_CORRESPONDENCE_APPLICANT.getDocumentCategoryId());
             document.setDocumentLink(documentCopy);
@@ -55,11 +59,10 @@ public class UploadGeneralDocumentsCategoriser extends DocumentCategoriser {
             setCategoryToAllOrdersDocs(documentCopy, null);
             document.setDocumentLink(documentCopy);
         }
-
     }
 
     private boolean isDocumentDataValid(UploadGeneralDocument document) {
-        return document != null && document.getDocumentLink() != null && document.getDocumentType() != null;
+        return document != null && document.getDocumentLink() != null;
     }
 
     private void setCategoryToAllOrdersDocs(CaseDocument document, String categoryToApply) {

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/documentcatergory/UploadGeneralDocumentsCategoriserTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/documentcatergory/UploadGeneralDocumentsCategoriserTest.java
@@ -65,6 +65,21 @@ class UploadGeneralDocumentsCategoriserTest extends BaseHandlerTestSetup {
         assertNull(finremCaseData.getUploadGeneralDocuments().get(0).getValue());
     }
 
+    @Test
+    void testCategorizeDocumentsHandlesMissingDocumentType() {
+        FinremCaseData finremCaseData = FinremCaseData.builder().uploadGeneralDocuments(List.of(
+            createDocument(UploadGeneralDocumentType.LETTER_EMAIL_FROM_APPLICANT),
+            createDocument(null)
+        )).build();
+
+        uploadGeneralDocumentsCategoriser.categorise(finremCaseData);
+
+        assertEquals(2, finremCaseData.getUploadGeneralDocuments().size());
+        assertEquals(DocumentCategory.COURT_CORRESPONDENCE_APPLICANT.getDocumentCategoryId(),
+            finremCaseData.getUploadGeneralDocuments().get(0).getValue().getDocumentLink().getCategoryId());
+        assertNull(finremCaseData.getUploadGeneralDocuments().get(1).getValue().getDocumentLink().getCategoryId());
+    }
+
     private FinremCaseData buildFinremCaseData() {
         return FinremCaseData.builder().uploadGeneralDocuments(List.of(
             createDocument(UploadGeneralDocumentType.LETTER_EMAIL_FROM_APPLICANT),

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/documentcatergory/UploadGeneralDocumentsCategoriserTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/documentcatergory/UploadGeneralDocumentsCategoriserTest.java
@@ -66,18 +66,16 @@ class UploadGeneralDocumentsCategoriserTest extends BaseHandlerTestSetup {
     }
 
     @Test
-    void testCategorizeDocumentsHandlesMissingDocumentType() {
+    void testCategorizeDocumentsWithNoDocumentType() {
         FinremCaseData finremCaseData = FinremCaseData.builder().uploadGeneralDocuments(List.of(
-            createDocument(UploadGeneralDocumentType.LETTER_EMAIL_FROM_APPLICANT),
             createDocument(null)
         )).build();
 
         uploadGeneralDocumentsCategoriser.categorise(finremCaseData);
 
-        assertEquals(2, finremCaseData.getUploadGeneralDocuments().size());
-        assertEquals(DocumentCategory.COURT_CORRESPONDENCE_APPLICANT.getDocumentCategoryId(),
+        assertEquals(1, finremCaseData.getUploadGeneralDocuments().size());
+        assertEquals(DocumentCategory.CASE_DOCUMENTS.getDocumentCategoryId(),
             finremCaseData.getUploadGeneralDocuments().get(0).getValue().getDocumentLink().getCategoryId());
-        assertNull(finremCaseData.getUploadGeneralDocuments().get(1).getValue().getDocumentLink().getCategoryId());
     }
 
     private FinremCaseData buildFinremCaseData() {


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DFR-2973


### Change description ###
Uploaded documents with no document type should be categorised as Caseworker Uploaded Documents
