### PR TITLE
DFR-2912 - INC5600505: CS - Error when trying to update FRC details. Set gender to NOT_GIVEN.

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/ChildrenInfo.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/ChildrenInfo.java
@@ -12,6 +12,8 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.Gender.NOT_GIVEN;
+
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Data
 @Builder
@@ -23,7 +25,7 @@ public class ChildrenInfo {
     @JsonSerialize(using = LocalDateSerializer.class)
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate dateOfBirth;
-    private Gender gender;
+    private Gender gender = NOT_GIVEN;
     private String relationshipToRespondent;
     private String relationshipToApplicant;
     private String countryOfResidence;


### PR DESCRIPTION
### Jira link (if applicable)
[DFR-2912](https://tools.hmcts.net/jira/browse/DFR-2912)


### Change description ###
Azure log:
```
.jackson.databind.exc.InvalidFormatException: Cannot coerce empty String ("") to 
`uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.Gender` value 
(but could if coercion was enabled using `CoercionConfig`)
```

We have two options of either:
1. Adding `@JsonInclude(JsonInclude.Include.NON_NULL)` to the class.
2. Setting the Gender field to `NOT_GIVEN` as a default state.

If we are happy with choosing a default state for the gender field then we can give this a shot. However, it might be worth trying option one given that we have used this in other classes before.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
