### PR TITLE
DFR-3124 Revert spring cloud bom version update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ def versions = [
 
 project.ext {
     pactVersion = getCheckedOutGitCommitHash()
-    springCloudBomVersion = "2023.0.2"
+    springCloudBomVersion = "2023.0.1"
     restAssuredBomVersion = "5.4.0"
 }
 


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DFR-3124


### Change description ###
DFR-3124 Revert spring cloud bom version update as it causes cftlib to fail to start
