### PR TITLE
DFR-3135 Add in quick fix

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/mapper/NotificationRequestMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/mapper/NotificationRequestMapper.java
@@ -323,6 +323,8 @@ public class NotificationRequestMapper {
             notificationRequest.setRespondentName(Objects.toString(respName));
         }
         notificationRequest.setHearingType(Objects.toString(caseData.get(HEARING_TYPE), ""));
+        // Quick fix for DFR-3135
+        notificationRequest.setIsNotDigital(false);
         return notificationRequest;
     }
 


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DFR-3135

### Change description ###

Add missing template personalisation to default to always null for deprecated /notify/assign-to-judge endpoint

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
