### PR TITLE
DFR-3137: Corrected so that logging in area of apply-noc-decision is correct

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/UpdateRepresentationController.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/UpdateRepresentationController.java
@@ -60,7 +60,6 @@ public class UpdateRepresentationController extends BaseController {
         validateCaseData(ccdRequest);
         caseDetails.getData().remove(IS_NOC_REJECTED);
         assignCaseAccessService.findAndRevokeCreatorRole(caseDetails);
-        log.info("The creator role has been revoked on case {}", caseDetails.getId());
         Map<String, Object> caseData = updateRepresentationService.updateRepresentationAsSolicitor(caseDetails, authToken);
         log.info("Solicitor representation has been updated on case {}", caseDetails.getId());
         caseDetails.getData().putAll(caseData);

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/AssignCaseAccessService.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/AssignCaseAccessService.java
@@ -170,6 +170,12 @@ public class AssignCaseAccessService {
         log.info("About to start revoking creator role for Case ID: {}", caseDetails.getId());
         List<CaseAssignmentUserRole> allRoles = getUserRoles(caseDetails.getId().toString())
             .getCaseAssignmentUserRoles();
+
+        if (allRoles.isEmpty()) {
+            log.info("No user roles found for Case ID: {}", caseDetails.getId());
+            return null;
+        }
+
         List<CaseAssignmentUserRole> creatorRoles = getCreatorRoles(allRoles);
 
         if (creatorRoles.isEmpty()) {
@@ -178,7 +184,8 @@ public class AssignCaseAccessService {
         }
 
         if (creatorRoles.size() > 1) {
-            throw new IllegalStateException("Multiple creator roles found for case");
+            throw new IllegalStateException(
+                    String.format("Multiple creator roles found for case ID: %s", caseDetails.getId()));
         }
 
         Optional<CaseAssignmentUserRole> userToRemove = getUserToRemove(creatorRoles, allRoles);
@@ -188,6 +195,7 @@ public class AssignCaseAccessService {
             return null;
         }
 
+        log.info("Attempting to revoke CREATOR role for case {}", caseDetails.getId());
         return revokeCreatorRole(caseDetails, userToRemove.get().getUserId());
     }
 


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DFR-3137

### Change description ###

This is only to fix logging. DFR-3137 has highlighted that /apply-noc-decision **always** logged this message

```
log.info("The creator role has been revoked on case {}", caseDetails.getId()); 
```

But did this even when the CREATOR role **hadn't** been revoked.  This makes support more difficult.

Removed this log line, and added a little more log information to make tackling NOC issues more transparent.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [X] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
