### PR TITLE
Revert update to spring-cloud-dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,5 +4,6 @@
     "local>hmcts/.github:renovate-config",
     "local>hmcts/.github//renovate/automerge-minor"
   ],
-  "automergeSchedule": ["after 7am and before 9am every weekday"]
+  "automergeSchedule": ["after 7am and before 9am every weekday"],
+  "ignoreDeps": ["spring-cloud-dependencies"]
 }

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ def versions = [
 
 project.ext {
     pactVersion = getCheckedOutGitCommitHash()
-    springCloudBomVersion = "2023.0.3"
+    springCloudBomVersion = "2023.0.1"
     restAssuredBomVersion = "5.5.0"
 }
 


### PR DESCRIPTION
### Change description ###
Revert update to spring-cloud-dependencies as it breaks cftlib
Update renovate to ignore spring-cloud-dependencies
