### PR TITLE
Convert empty string values to null in OCR case data mapping

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/bulkscan/transformation/FormAToCaseTransformer.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/bulkscan/transformation/FormAToCaseTransformer.java
@@ -307,7 +307,8 @@ public class FormAToCaseTransformer extends BulkScanFormTransformer {
 
         ContactDetailsMapper.setupContactDetailsForApplicantAndRespondent(modifiedCaseData);
 
-        modifiedCaseData.replaceAll((key, value) -> "".equals(value) ? null : value);
+        modifiedCaseData.replaceAll((key, value) -> (value instanceof String
+            && value.toString().trim().isEmpty()) ? null : value);
 
         return modifiedCaseData;
     }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/bulkscan/transformation/FormAToCaseTransformer.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/bulkscan/transformation/FormAToCaseTransformer.java
@@ -307,6 +307,8 @@ public class FormAToCaseTransformer extends BulkScanFormTransformer {
 
         ContactDetailsMapper.setupContactDetailsForApplicantAndRespondent(modifiedCaseData);
 
+        modifiedCaseData.replaceAll((key, value) -> "".equals(value) ? null : value);
+
         return modifiedCaseData;
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/bulkscan/transformation/FormAToCaseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/bulkscan/transformation/FormAToCaseTransformerTest.java
@@ -269,6 +269,14 @@ public class FormAToCaseTransformerTest {
     }
 
     @Test
+    public void childSupportAgencyCalculationMadeToNullWhenEmptySpaceString() {
+        Map<String, Object> optionOneTransformedData = formAToCaseTransformer.transformIntoCaseData(createExceptionRecord(
+            singletonList(new OcrDataField("ChildSupportAgencyCalculationMade",
+                "   "))));
+        assertThat(optionOneTransformedData, hasEntry("ChildSupportAgencyCalculationMade", null));
+    }
+
+    @Test
     public void shouldSetOrderForChildrenQuestion1ToYesIfOrderForChildrenFieldIsPopulated() {
         Map<String, Object> optionOneTransformedData = formAToCaseTransformer.transformIntoCaseData(createExceptionRecord(
             singletonList(new OcrDataField("OrderForChildren",

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/bulkscan/transformation/FormAToCaseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/bulkscan/transformation/FormAToCaseTransformerTest.java
@@ -261,6 +261,14 @@ public class FormAToCaseTransformerTest {
     }
 
     @Test
+    public void childSupportAgencyCalculationMadeToNullWhenEmptyString() {
+        Map<String, Object> optionOneTransformedData = formAToCaseTransformer.transformIntoCaseData(createExceptionRecord(
+            singletonList(new OcrDataField("ChildSupportAgencyCalculationMade",
+                ""))));
+        assertThat(optionOneTransformedData, hasEntry("ChildSupportAgencyCalculationMade", null));
+    }
+
+    @Test
     public void shouldSetOrderForChildrenQuestion1ToYesIfOrderForChildrenFieldIsPopulated() {
         Map<String, Object> optionOneTransformedData = formAToCaseTransformer.transformIntoCaseData(createExceptionRecord(
             singletonList(new OcrDataField("OrderForChildren",

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/bulkscan/transformation/FormAToCaseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/bulkscan/transformation/FormAToCaseTransformerTest.java
@@ -372,7 +372,7 @@ public class FormAToCaseTransformerTest {
         assertThat(transformedCaseData, allOf(
             hasEntry(BULK_SCAN_CASE_REFERENCE, TEST_CASE_ID),
             hasEntry(PAPER_APPLICATION, YES_VALUE),
-            hasEntry(RESP_SOLICITOR_NAME, ""),
+            hasEntry(RESP_SOLICITOR_NAME, null),
             hasEntry(CONSENTED_RESPONDENT_REPRESENTED, NO_VALUE)
         ));
     }


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [DFR-3231](https://tools.hmcts.net/jira/browse/DFR-3231)

### Change description

Convert all empty string value mappings on case data fields null. Ideally I would want to validate that mandatory fields do not come through as empty strings when not provided. 

However, the method that defines the check for fields is within the Bulkscan library abstract class BulkScanFormValidator which or service validator inherits from - this method only checks for the presence and does not check that the value is not an empty string. We cannot override this check in our concretion as the method is private.
I will raise a ticket with bulkscan to add a empty string check to this method as well [see here](https://github.com/hmcts/bsp-common-lib/blob/9be0bf74674bde8f43051ee09fc73d67f1130abc/src/main/java/uk/gov/hmcts/reform/bsp/common/service/validation/BulkScanFormValidator.java#L40). 

<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
