### PR TITLE
DFR-3329: Refactor access to court details

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/config/CourtDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/config/CourtDetails.java
@@ -1,8 +1,14 @@
 package uk.gov.hmcts.reform.finrem.caseorchestration.config;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
+@Builder
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class CourtDetails {
     private String courtName;
     private String courtAddress;

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/config/CourtDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/config/CourtDetails.java
@@ -1,0 +1,11 @@
+package uk.gov.hmcts.reform.finrem.caseorchestration.config;
+
+import lombok.Data;
+
+@Data
+public class CourtDetails {
+    private String courtName;
+    private String courtAddress;
+    private String phoneNumber;
+    private String email;
+}

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/config/CourtDetailsConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/config/CourtDetailsConfiguration.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.reform.finrem.caseorchestration.config;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Getter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+
+@Configuration
+@Getter
+public class CourtDetailsConfiguration {
+    private final Map<String, CourtDetails> courts;
+
+    public CourtDetailsConfiguration(ObjectMapper objectMapper) throws IOException {
+        File file = new ClassPathResource("./json/court-details.json").getFile();
+        courts = objectMapper.readValue(file, new TypeReference<Map<String, CourtDetails>>() {});
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/CaseHearingFunctions.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/CaseHearingFunctions.java
@@ -7,6 +7,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants;
+import uk.gov.hmcts.reform.finrem.caseorchestration.config.CourtDetailsConfiguration;
 import uk.gov.hmcts.reform.finrem.caseorchestration.error.CourtDetailsParseException;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.FinremCaseData;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.document.CourtDetailsTemplateFields;
@@ -414,6 +415,13 @@ public final class CaseHearingFunctions {
             .build();
     }
 
+    /**
+     * Get court details as a Json string.
+     *
+     * @return Json string of court details
+     * @deprecated Use {@link CourtDetailsConfiguration#getCourts()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static String getCourtDetailsString() {
         try (InputStream inputStream = CaseHearingFunctions.class.getResourceAsStream("/json/court-details.json")) {
             return IOUtils.toString(inputStream, UTF_8);

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/CaseHearingFunctions.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/CaseHearingFunctions.java
@@ -421,7 +421,7 @@ public final class CaseHearingFunctions {
      * @return Json string of court details
      * @deprecated Use {@link CourtDetailsConfiguration#getCourts()} instead.
      */
-    @Deprecated(forRemoval = true)
+    @Deprecated(since = "4 Nov 2024")
     public static String getCourtDetailsString() {
         try (InputStream inputStream = CaseHearingFunctions.class.getResourceAsStream("/json/court-details.json")) {
             return IOUtils.toString(inputStream, UTF_8);

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/config/CourtDetailsConfigurationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/config/CourtDetailsConfigurationTest.java
@@ -1,0 +1,27 @@
+package uk.gov.hmcts.reform.finrem.caseorchestration.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CourtDetailsConfigurationTest {
+
+    @Test
+    void testConstructor() throws IOException {
+        CourtDetailsConfiguration config = new CourtDetailsConfiguration(new ObjectMapper());
+
+        assertThat(config.getCourts()).hasSize(137);
+        config.getCourts().forEach((k,v) -> {
+            assertThat(k).isNotNull();
+            assertThat(v).isNotNull();
+        });
+        CourtDetails courtDetails = config.getCourts().get("FR_s_CFCList_1");
+        assertThat(courtDetails.getCourtName()).isEqualTo("Bromley County Court And Family Court");
+        assertThat(courtDetails.getCourtAddress()).isEqualTo("Bromley County Court, College Road, Bromley, BR1 3PX");
+        assertThat(courtDetails.getPhoneNumber()).isEqualTo("0300 123 5577");
+        assertThat(courtDetails.getEmail()).isEqualTo("FRCLondon@justice.gov.uk");
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/config/CourtDetailsConfigurationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/config/CourtDetailsConfigurationTest.java
@@ -17,6 +17,7 @@ class CourtDetailsConfigurationTest {
         config.getCourts().forEach((k,v) -> {
             assertThat(k).isNotNull();
             assertThat(v).isNotNull();
+            assertThat(v.getEmail()).isNotNull();
         });
         CourtDetails courtDetails = config.getCourts().get("FR_s_CFCList_1");
         assertThat(courtDetails.getCourtName()).isEqualTo("Bromley County Court And Family Court");

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/integrationtest/barristers/ManageBarristersITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/integrationtest/barristers/ManageBarristersITest.java
@@ -21,6 +21,7 @@ import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.finrem.caseorchestration.client.CaseDataApiV2;
 import uk.gov.hmcts.reform.finrem.caseorchestration.client.DataStoreClient;
 import uk.gov.hmcts.reform.finrem.caseorchestration.client.OrganisationApi;
+import uk.gov.hmcts.reform.finrem.caseorchestration.config.CourtDetailsConfiguration;
 import uk.gov.hmcts.reform.finrem.caseorchestration.config.DocumentConfiguration;
 import uk.gov.hmcts.reform.finrem.caseorchestration.config.NotificationServiceConfiguration;
 import uk.gov.hmcts.reform.finrem.caseorchestration.config.PrdOrganisationConfiguration;
@@ -107,7 +108,7 @@ import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CcdServiceTes
     EvidenceManagementDownloadService.class, LetterAddresseeGeneratorMapper.class, ApplicantLetterAddresseeGenerator.class,
     RespondentLetterAddresseeGenerator.class, IntervenerOneLetterAddresseeGenerator.class, IntervenerTwoLetterAddresseeGenerator.class,
     IntervenerThreeLetterAddresseeGenerator.class, IntervenerFourLetterAddresseeGenerator.class,
-    InternationalPostalService.class})
+    InternationalPostalService.class, CourtDetailsConfiguration.class})
 public class ManageBarristersITest implements IntegrationTest {
 
     private static final String SERVICE_AUTH_TOKEN = "serviceAuth";

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/FinremNotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/FinremNotificationServiceTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.finrem.caseorchestration.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -16,6 +15,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.HttpClientErrorException;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.finrem.caseorchestration.config.CourtDetails;
+import uk.gov.hmcts.reform.finrem.caseorchestration.config.CourtDetailsConfiguration;
 import uk.gov.hmcts.reform.finrem.caseorchestration.config.NotificationServiceConfiguration;
 import uk.gov.hmcts.reform.finrem.caseorchestration.mapper.FinremNotificationRequestMapper;
 import uk.gov.hmcts.reform.finrem.caseorchestration.mapper.NotificationRequestMapper;
@@ -31,14 +32,11 @@ import uk.gov.hmcts.reform.finrem.caseorchestration.model.wrapper.SolicitorCaseD
 import uk.gov.hmcts.reform.finrem.caseorchestration.notifications.service.EmailService;
 import uk.gov.hmcts.reform.finrem.caseorchestration.service.evidencemanagement.EvidenceManagementDownloadService;
 import uk.gov.hmcts.reform.finrem.caseorchestration.service.noc.solicitors.CheckSolicitorIsDigitalService;
-import uk.gov.hmcts.reform.finrem.caseorchestration.util.TestLogger;
-import uk.gov.hmcts.reform.finrem.caseorchestration.util.TestLogs;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -60,7 +58,6 @@ import static uk.gov.hmcts.reform.finrem.caseorchestration.TestConstants.TEST_SO
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APP_SOLICITOR_AGREE_TO_RECEIVE_EMAILS_CONSENTED;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.APP_SOLICITOR_AGREE_TO_RECEIVE_EMAILS_CONTESTED;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.CONTESTED_SOLICITOR_EMAIL;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.COURT_DETAILS_EMAIL_KEY;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.RESP_SOLICITOR_EMAIL;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.RESP_SOLICITOR_NOTIFICATIONS_EMAIL_CONSENT;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.notifications.TestData.getConsentedFinremCaseDetails;
@@ -112,17 +109,12 @@ import static uk.gov.hmcts.reform.finrem.caseorchestration.notifications.domain.
 import static uk.gov.hmcts.reform.finrem.caseorchestration.notifications.domain.EmailTemplateNames.FR_INTERVENER_SOLICITOR_REMOVED_EMAIL;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.notifications.domain.EmailTemplateNames.FR_REJECT_GENERAL_APPLICATION;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.notifications.domain.EmailTemplateNames.FR_TRANSFER_TO_LOCAL_COURT;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.service.CaseHearingFunctions.getCourtDetailsString;
 
 @ExtendWith(MockitoExtension.class)
 class FinremNotificationServiceTest {
 
     @InjectMocks
     private NotificationService notificationService;
-
-    @TestLogs
-    private final TestLogger logs = new TestLogger(NotificationService.class);
-
     @Mock
     private FeatureToggleService featureToggleService;
     @Mock
@@ -141,13 +133,15 @@ class FinremNotificationServiceTest {
     private NotificationServiceConfiguration notificationServiceConfiguration;
     @Mock
     private EvidenceManagementDownloadService evidenceManagementDownloadService;
+    @Mock
+    private CourtDetailsConfiguration courtDetailsConfiguration;
 
     private final FinremCaseDetails consentedFinremCaseDetails = getConsentedFinremCaseDetails();
     private final FinremCaseDetails contestedFinremCaseDetails = getContestedFinremCaseDetails();
     private SolicitorCaseDataKeysWrapper dataKeysWrapper;
 
     @BeforeEach
-    void setUp() throws JsonProcessingException {
+    void setUp() {
         dataKeysWrapper = SolicitorCaseDataKeysWrapper.builder().build();
 
         NotificationRequest notificationRequest = new NotificationRequest();
@@ -174,8 +168,11 @@ class FinremNotificationServiceTest {
         lenient().when(finremNotificationRequestMapper.buildNotificationRequest(any(FinremCaseDetails.class), any(IntervenerOne.class),
             anyString(), anyString(), anyString())).thenReturn(notificationRequest);
 
-        lenient().when(objectMapper.readValue(getCourtDetailsString(), HashMap.class))
-            .thenReturn(new HashMap(Map.of("email", "FRCLondon@justice.gov.uk")));
+        Map<String, CourtDetails> courtDetailsMap = Map.of(
+            "FR_s_NottinghamList_1", CourtDetails.builder().email("FRCLondon@justice.gov.uk").build(),
+            "someCourt", CourtDetails.builder().email("court@example.com").build()
+        );
+        lenient().when(courtDetailsConfiguration.getCourts()).thenReturn(courtDetailsMap);
     }
 
     @Test
@@ -976,57 +973,19 @@ class FinremNotificationServiceTest {
 
     @ParameterizedTest
     @MethodSource("provideCourtDetailsTestCases")
-    void testGetRecipientEmailFromSelectedCourt(Map<String, Object> courtDetailsMap, String selectedAllocatedCourt, String expectedEmail,
-                                                boolean throwsException, String expectedLogMessage) throws Exception {
-        if (throwsException) {
-            lenient().when(objectMapper.readValue(anyString(), eq(HashMap.class))).thenThrow(new JsonProcessingException("error") {});
-        } else {
-            lenient().when(objectMapper.readValue(anyString(), eq(HashMap.class))).thenReturn((HashMap) courtDetailsMap);
-        }
-
-        // Call the method
+    void testGetRecipientEmailFromSelectedCourt(String selectedAllocatedCourt, String expectedEmail) {
         String result = notificationService.getRecipientEmailFromSelectedCourt(selectedAllocatedCourt);
-
-        // Verify the result
         assertEquals(expectedEmail, result);
-
-        // Verify log messages if expected
-        if (expectedLogMessage != null) {
-            assertThat(logs.getErrors()).containsExactly(expectedLogMessage);
-        } else {
-            assertThat(logs.getErrors()).isEmpty();
-        }
     }
 
     // MethodSource for the parameterized test
     static Stream<Arguments> provideCourtDetailsTestCases() {
-        Map<String, Object> validCourtDetailsMap = new HashMap<>();
-        Map<String, Object> courtWithValidEmail = new HashMap<>();
-        courtWithValidEmail.put(COURT_DETAILS_EMAIL_KEY, "court@example.com");
-        validCourtDetailsMap.put("someCourt", courtWithValidEmail);
-
-        Map<String, Object> courtWithEmptyEmail = new HashMap<>();
-        courtWithEmptyEmail.put(COURT_DETAILS_EMAIL_KEY, "");
-        Map<String, Object> emptyEmailCourtDetailsMap = new HashMap<>();
-        emptyEmailCourtDetailsMap.put("someCourt", courtWithEmptyEmail);
-
-        Map<String, Object> missingCourtDetailsMap = new HashMap<>(); // No court details for this test
-
         return Stream.of(
             // Scenario: valid court email is found, no error log expected
-            Arguments.of(validCourtDetailsMap, "someCourt", "court@example.com", false, null),
+            Arguments.of("someCourt", "court@example.com"),
 
             // Scenario: court details not found, log the error
-            Arguments.of(missingCourtDetailsMap, "nonExistentCourt", "fr_applicant_solicitor1@mailinator.com",
-                false, "Unable to lookup court details of nonExistentCourt from 'court-details.json'. Use DEFAULT_EMAIL instead"),
-
-            // Scenario: court email is empty, log the error
-            Arguments.of(emptyEmailCourtDetailsMap, "someCourt", "fr_applicant_solicitor1@mailinator.com",
-                false, "Get an empty email after looking up court details of someCourt from 'court-details.json'. Use DEFAULT_EMAIL instead"),
-
-            // Scenario: JsonProcessingException thrown, log the error
-            Arguments.of(null, "someCourt", "fr_applicant_solicitor1@mailinator.com",
-                true, "Fail to read 'court-details.json'")
+            Arguments.of("nonExistentCourt", "fr_applicant_solicitor1@mailinator.com")
         );
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/NotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/NotificationServiceTest.java
@@ -13,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.finrem.caseorchestration.BaseServiceTest;
+import uk.gov.hmcts.reform.finrem.caseorchestration.config.CourtDetailsConfiguration;
 import uk.gov.hmcts.reform.finrem.caseorchestration.handler.FinremCallbackRequest;
 import uk.gov.hmcts.reform.finrem.caseorchestration.helper.ConsentedHearingHelper;
 import uk.gov.hmcts.reform.finrem.caseorchestration.mapper.FinremNotificationRequestMapper;
@@ -123,6 +124,8 @@ public class NotificationServiceTest extends BaseServiceTest {
     private EmailService emailService;
     @Autowired
     private ConsentedHearingHelper helper;
+    @Autowired
+    private CourtDetailsConfiguration courtDetailsConfiguration;
 
     @MockBean
     private FeatureToggleService featureToggleService;


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DFR-3329

### Change description

- Refactor integration of resources/json/court-details.json
- Currently this is repeatedly read in and deserialised for every request to get a court email address.
- Refactor so that the court details are read in once and made available in a Spring bean - CourtDetailsConfiguration
