### PR TITLE
DFR-3069: Added new respondentInRefuge field

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/FinremCaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/FinremCaseData.java
@@ -1023,4 +1023,11 @@ public class FinremCaseData implements HasCaseDocument {
         return draftOrdersWrapper;
     }
 
+    @JsonIgnore
+    public RefugeWrapper getRefugeWrapper() {
+        if (refugeWrapper == null) {
+            this.refugeWrapper = new RefugeWrapper();
+        }
+        return refugeWrapper;
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/FinremCaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/FinremCaseData.java
@@ -429,7 +429,6 @@ public class FinremCaseData implements HasCaseDocument {
 
     private String previousState;
     private DynamicList userCaseAccessList;
-    private YesOrNo applicantInRefuge;
 
     @JsonUnwrapped
     @Getter(AccessLevel.NONE)
@@ -1023,7 +1022,7 @@ public class FinremCaseData implements HasCaseDocument {
         }
         return refugeWrapper;
     }
-  
+
     @JsonIgnore
     public ListForHearingWrapper getListForHearingWrapper() {
         if (listForHearingWrapper == null) {

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/FinremCaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/FinremCaseData.java
@@ -46,6 +46,7 @@ import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.wrapper.RegionWrap
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.wrapper.ScheduleOneWrapper;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.wrapper.UploadCaseDocumentWrapper;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.wrapper.intevener.IntervenerWrapper;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.wrapper.RefugeWrapper;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.intervener.IntervenerChangeDetails;
 
 import java.math.BigDecimal;
@@ -436,6 +437,10 @@ public class FinremCaseData implements HasCaseDocument {
 
     private String previousState;
     private DynamicList userCaseAccessList;
+
+    @JsonUnwrapped
+    @Getter(AccessLevel.NONE)
+    private RefugeWrapper refugeWrapper;
 
     @JsonIgnore
     public CaseFlagsWrapper getCaseFlagsWrapper() {

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/FinremCaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/FinremCaseData.java
@@ -42,11 +42,11 @@ import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.wrapper.MiamWrappe
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.wrapper.NatureApplicationWrapper;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.wrapper.OrderWrapper;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.wrapper.ReferToJudgeWrapper;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.wrapper.RefugeWrapper;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.wrapper.RegionWrapper;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.wrapper.ScheduleOneWrapper;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.wrapper.UploadCaseDocumentWrapper;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.wrapper.intevener.IntervenerWrapper;
-import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.wrapper.RefugeWrapper;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.intervener.IntervenerChangeDetails;
 
 import java.math.BigDecimal;

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/wrapper/RefugeWrapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/wrapper/RefugeWrapper.java
@@ -6,7 +6,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.HasCaseDocument;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.YesOrNo;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -15,7 +14,7 @@ import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.YesOrNo;
 @AllArgsConstructor
 @NoArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class RefugeWrapper implements HasCaseDocument {
+public class RefugeWrapper {
 
     private YesOrNo respondentInRefuge;
 

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/wrapper/RefugeWrapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/wrapper/RefugeWrapper.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.YesOrNo;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class RefugeWrapper {
 
+    private YesOrNo applicantInRefuge;
     private YesOrNo respondentInRefuge;
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/wrapper/RefugeWrapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/wrapper/RefugeWrapper.java
@@ -8,6 +8,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.HasCaseDocument;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.YesOrNo;
+
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Data
 @Builder(toBuilder = true)

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/wrapper/RefugeWrapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/wrapper/RefugeWrapper.java
@@ -1,0 +1,21 @@
+package uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.wrapper;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.HasCaseDocument;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.YesOrNo;
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Data
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RefugeWrapper implements HasCaseDocument {
+
+    private YesOrNo respondentInRefuge;
+
+}


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DFR-3069

### Change description

Added new respondentInRefuge field.  Within a new RefugeWrapper.  This wrapper will accomodate the applicant and intervener refuge fields at a later point.

### Testing done

Manual CCD tests.  Unit tests. 

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] Does this PR introduce a breaking change
