### PR TITLE
DFR-3129: Enable printing of documents to be overridden

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/correspondence/CaseDetailsMultiLetterOrEmailAllPartiesCorresponder.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/correspondence/CaseDetailsMultiLetterOrEmailAllPartiesCorresponder.java
@@ -34,8 +34,7 @@ public abstract class CaseDetailsMultiLetterOrEmailAllPartiesCorresponder extend
             this.emailApplicantSolicitor(caseDetails);
         } else {
             log.info("Sending letter correspondence to applicant for Case ID: {}", caseDetails.getId());
-            bulkPrintService.printApplicantDocuments(caseDetails, authorisationToken,
-                documentHelper.getCaseDocumentsAsBulkPrintDocuments(getCaseDocuments(caseDetails)));
+            printApplicantDocuments(authorisationToken, caseDetails);
         }
     }
 
@@ -46,11 +45,9 @@ public abstract class CaseDetailsMultiLetterOrEmailAllPartiesCorresponder extend
             this.emailRespondentSolicitor(caseDetails);
         } else {
             log.info("Sending letter correspondence to respondent for Case ID: {}", caseDetails.getId());
-            bulkPrintService.printRespondentDocuments(caseDetails, authorisationToken,
-                documentHelper.getCaseDocumentsAsBulkPrintDocuments(getCaseDocuments(caseDetails)));
+            printRespondentDocuments(authorisationToken, caseDetails);
         }
     }
-
 
     @SuppressWarnings("java:S1874")
     public void sendIntervenerCorrespondence(String authorisationToken, CaseDetails caseDetails) {
@@ -90,13 +87,11 @@ public abstract class CaseDetailsMultiLetterOrEmailAllPartiesCorresponder extend
         return caseDocuments;
     }
 
-
     private IntervenerHearingNoticeCollection getHearingNoticesDocumentCollection(CaseDocument hearingNotice) {
         return IntervenerHearingNoticeCollection.builder()
             .value(IntervenerHearingNotice.builder().caseDocument(hearingNotice)
                 .noticeReceivedAt(LocalDateTime.now()).build()).build();
     }
-
 
     protected boolean shouldSendApplicantSolicitorEmail(CaseDetails caseDetails) {
         return notificationService.isApplicantSolicitorDigitalAndEmailPopulated(caseDetails);
@@ -110,4 +105,13 @@ public abstract class CaseDetailsMultiLetterOrEmailAllPartiesCorresponder extend
         return notificationService.isIntervenerSolicitorDigitalAndEmailPopulated(intervenerWrapper, caseDetails);
     }
 
+    protected void printApplicantDocuments(String authorisationToken, CaseDetails caseDetails) {
+        bulkPrintService.printApplicantDocuments(caseDetails, authorisationToken,
+            documentHelper.getCaseDocumentsAsBulkPrintDocuments(getCaseDocuments(caseDetails)));
+    }
+
+    protected void printRespondentDocuments(String authorisationToken, CaseDetails caseDetails) {
+        bulkPrintService.printRespondentDocuments(caseDetails, authorisationToken,
+            documentHelper.getCaseDocumentsAsBulkPrintDocuments(getCaseDocuments(caseDetails)));
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/correspondence/FinremMultiLetterOrEmailAllPartiesCorresponder.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/correspondence/FinremMultiLetterOrEmailAllPartiesCorresponder.java
@@ -32,10 +32,8 @@ public abstract class FinremMultiLetterOrEmailAllPartiesCorresponder extends Mul
                 log.info("Sending email correspondence to applicant for Case ID: {}", caseDetails.getId());
                 this.emailApplicantSolicitor(caseDetails);
             } else {
-
                 log.info("Sending letter correspondence to applicant for Case ID: {}", caseDetails.getId());
-                bulkPrintService.printApplicantDocuments(caseDetails, authorisationToken,
-                    documentHelper.getCaseDocumentsAsBulkPrintDocuments(getCaseDocuments(caseDetails)));
+                printApplicantDocuments(authorisationToken, caseDetails);
             }
         }
     }
@@ -47,8 +45,7 @@ public abstract class FinremMultiLetterOrEmailAllPartiesCorresponder extends Mul
                 this.emailRespondentSolicitor(caseDetails);
             } else {
                 log.info("Sending letter correspondence to respondent for Case ID: {}", caseDetails.getId());
-                bulkPrintService.printRespondentDocuments(caseDetails, authorisationToken,
-                    documentHelper.getCaseDocumentsAsBulkPrintDocuments(getCaseDocuments(caseDetails)));
+                printRespondentDocuments(authorisationToken, caseDetails);
             }
         }
     }
@@ -107,4 +104,13 @@ public abstract class FinremMultiLetterOrEmailAllPartiesCorresponder extends Mul
                 .noticeReceivedAt(LocalDateTime.now()).build()).build();
     }
 
+    protected void printApplicantDocuments(String authorisationToken, FinremCaseDetails caseDetails) {
+        bulkPrintService.printApplicantDocuments(caseDetails, authorisationToken,
+            documentHelper.getCaseDocumentsAsBulkPrintDocuments(getCaseDocuments(caseDetails)));
+    }
+
+    protected void printRespondentDocuments(String authorisationToken, FinremCaseDetails caseDetails) {
+        bulkPrintService.printRespondentDocuments(caseDetails, authorisationToken,
+            documentHelper.getCaseDocumentsAsBulkPrintDocuments(getCaseDocuments(caseDetails)));
+    }
 }


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DFR-3129

### Change description

Enable printing of documents to be overridden in child classes.
Create protected methods in the abstract class and move current implementation into those methods.
This enables child classes to have different implementations for sending documents to either applicant or respondent.
This requirements is needed for DFR-3129.
