### PR TITLE
DFR-3626: Remove multiple occurrences of JSONObject

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,6 @@ def versions = [
         apacheLogging        : '2.24.3',
         idamClient           : '3.0.3',
         jjwt                 : '0.12.6',
-        skyscreamer          : '1.5.3',
         jaxbOsgi             : '2.3.9',
         springHateoas        : '1.5.6',
         tika                 : '3.1.0',
@@ -488,7 +487,6 @@ dependencies {
     functionalImplementation group: 'org.mockito', name: 'mockito-core', version: versions.mockito
     functionalImplementation group: 'org.apache.pdfbox', name: 'pdfbox', version: versions.pdfbox
     functionalImplementation group: 'org.projectlombok', name: 'lombok', version: versions.lombok
-    functionalImplementation group: 'org.skyscreamer', name: 'jsonassert', version: versions.skyscreamer
     functionalImplementation group: 'com.github.hmcts', name: 'ccd-client', version: versions.ccdClient
     functionalImplementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: versions.serviceTokenGenerator
     functionalImplementation group: 'com.github.hmcts', name: 'bsp-common-lib', version: versions.bspCommonLib
@@ -501,6 +499,10 @@ dependencies {
     contractImplementation group: 'au.com.dius.pact', name: 'consumer', version: versions.pact
     contractImplementation group: 'au.com.dius.pact.consumer', name: 'junit', version: versions.pact
     contractImplementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-loadbalancer'
+
+    configurations.configureEach {
+        exclude group: 'com.vaadin.external.google', module: 'android-json'
+    }
 }
 
 tasks.withType(Jar) {

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/AmendApplicationContestedControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/AmendApplicationContestedControllerTest.java
@@ -13,7 +13,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Objects;
 
-import static com.jayway.jsonassert.impl.matcher.IsCollectionWithSize.hasSize;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/ContestedOrderControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/ContestedOrderControllerTest.java
@@ -6,9 +6,9 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import uk.gov.hmcts.reform.finrem.caseorchestration.handler.SendOrderContestedAboutToSubmitHandler;
 import uk.gov.hmcts.reform.finrem.caseorchestration.service.IdamService;
 
-import static com.jayway.jsonassert.impl.matcher.IsCollectionWithSize.hasSize;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.when;


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DFR-3626

### Change description

- Remove multiple occurrences of JSONObject in tests - removing the android-json transitive dependency that comes from jsonassert
- Remove jsonassert dependency as it isn't required

