### PR TITLE
Bump mockito to 5.15.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ def versions = [
         hmctsNotify          : '4.1.1-RELEASE',
         junit                : '4.13.2',
         lombok               : '1.18.36',
-        mockito              : '3.12.4',
+        mockito              : '5.15.2',
         pact                 : '4.6.17',
         pdfbox               : '3.0.4',
         reformLogging        : '6.1.8',


### PR DESCRIPTION
### Change description

Mockito hasn't been updated in ages due to previous team closing the renovate PR.
Bump mockito to 5.15.2.

