### PR TITLE
DFR-3667: Add callback handler logger utility

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/CallbackHandlerLogger.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/CallbackHandlerLogger.java
@@ -1,0 +1,61 @@
+package uk.gov.hmcts.reform.finrem.caseorchestration.handler;
+
+import lombok.extern.slf4j.Slf4j;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.EventType;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CaseType;
+
+/**
+ * Utility class for creating log messages for handling CCD callback requests.
+ */
+@Slf4j
+public class CallbackHandlerLogger {
+
+    private CallbackHandlerLogger() {
+        // All access through static methods
+    }
+
+    /**
+     * Creates a log message for an 'About To Start' callback request.
+     * @param callbackRequest the callback request
+     * @return the log message
+     */
+    public static String aboutToStart(FinremCallbackRequest callbackRequest) {
+        return createLogMessage("About To Start", callbackRequest);
+    }
+
+    /**
+     * Creates a log message for a 'Mid-Event' callback request.
+     * @param callbackRequest the callback request
+     * @return the log message
+     */
+    public static String midEvent(FinremCallbackRequest callbackRequest) {
+        return createLogMessage("Mid-Event", callbackRequest);
+    }
+
+    /**
+     * Creates a log message for an 'About To Submit' callback request.
+     * @param callbackRequest the callback request
+     * @return the log message
+     */
+    public static String aboutToSubmit(FinremCallbackRequest callbackRequest) {
+        return createLogMessage("About To Submit", callbackRequest);
+    }
+
+    /**
+     * Creates a log message for a 'Submitted' callback request.
+     * @param callbackRequest the callback request
+     * @return the log message
+     */
+    public static String submitted(FinremCallbackRequest callbackRequest) {
+        return createLogMessage("Submitted", callbackRequest);
+    }
+
+    private static String createLogMessage(String callbackType, FinremCallbackRequest callbackRequest) {
+        CaseType caseType = callbackRequest.getCaseDetails().getCaseType();
+        EventType eventType = callbackRequest.getEventType();
+        String caseId = String.valueOf(callbackRequest.getCaseDetails().getId());
+
+        return String.format("===> Case ID %s: Handling %s %s callback for event %s",
+            caseId, caseType, callbackType, eventType.getCcdType());
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/CallbackHandlerLogger.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/CallbackHandlerLogger.java
@@ -53,9 +53,10 @@ public class CallbackHandlerLogger {
     private static String createLogMessage(String callbackType, FinremCallbackRequest callbackRequest) {
         CaseType caseType = callbackRequest.getCaseDetails().getCaseType();
         EventType eventType = callbackRequest.getEventType();
+        String ccdEventType = eventType == null ? "null" : eventType.getCcdType();
         String caseId = String.valueOf(callbackRequest.getCaseDetails().getId());
 
         return String.format("===> Case ID %s: Handling %s %s callback for event %s",
-            caseId, caseType, callbackType, eventType.getCcdType());
+                caseId, caseType, callbackType, ccdEventType);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/casesubmission/CaseSubmissionPbaValidateMidEventHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/casesubmission/CaseSubmissionPbaValidateMidEventHandler.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.finrem.caseorchestration.ccd.callback.CallbackType;
 import uk.gov.hmcts.reform.finrem.caseorchestration.controllers.GenericAboutToStartOrSubmitCallbackResponse;
+import uk.gov.hmcts.reform.finrem.caseorchestration.handler.CallbackHandlerLogger;
 import uk.gov.hmcts.reform.finrem.caseorchestration.handler.FinremCallbackHandler;
 import uk.gov.hmcts.reform.finrem.caseorchestration.handler.FinremCallbackRequest;
 import uk.gov.hmcts.reform.finrem.caseorchestration.mapper.FinremCaseDetailsMapper;
@@ -38,12 +39,9 @@ public class CaseSubmissionPbaValidateMidEventHandler extends FinremCallbackHand
     @Override
     public GenericAboutToStartOrSubmitCallbackResponse<FinremCaseData> handle(
         FinremCallbackRequest callbackRequestWithFinremCaseDetails, String userAuthorisation) {
+        log.info(CallbackHandlerLogger.midEvent(callbackRequestWithFinremCaseDetails));
 
         FinremCaseDetails caseDetails = callbackRequestWithFinremCaseDetails.getCaseDetails();
-
-        log.info("Received request to validate PBA number for Case ID: {}",
-            caseDetails.getId());
-
         validateCaseData(callbackRequestWithFinremCaseDetails);
 
         FinremCaseData caseData = caseDetails.getData();

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/draftorders/upload/UploadDraftOrdersAboutToStartHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/draftorders/upload/UploadDraftOrdersAboutToStartHandler.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.finrem.caseorchestration.ccd.callback.CallbackType;
 import uk.gov.hmcts.reform.finrem.caseorchestration.controllers.GenericAboutToStartOrSubmitCallbackResponse;
+import uk.gov.hmcts.reform.finrem.caseorchestration.handler.CallbackHandlerLogger;
 import uk.gov.hmcts.reform.finrem.caseorchestration.handler.FinremCallbackHandler;
 import uk.gov.hmcts.reform.finrem.caseorchestration.handler.FinremCallbackRequest;
 import uk.gov.hmcts.reform.finrem.caseorchestration.mapper.FinremCaseDetailsMapper;
@@ -75,10 +76,10 @@ public class UploadDraftOrdersAboutToStartHandler extends FinremCallbackHandler 
     @Override
     public GenericAboutToStartOrSubmitCallbackResponse<FinremCaseData> handle(FinremCallbackRequest callbackRequest,
                                                                               String userAuthorisation) {
+        log.info(CallbackHandlerLogger.aboutToStart(callbackRequest));
+
         FinremCaseDetails caseDetails = callbackRequest.getCaseDetails();
         String caseId = String.valueOf(caseDetails.getId());
-        log.info("Invoking contested {} about to start callback for Case ID: {}", callbackRequest.getEventType(),
-            caseId);
 
         FinremCaseData finremCaseData = caseDetails.getData();
         DraftOrdersWrapper draftOrdersWrapper = finremCaseData.getDraftOrdersWrapper();

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/draftorders/upload/UploadDraftOrdersAboutToSubmitHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/draftorders/upload/UploadDraftOrdersAboutToSubmitHandler.java
@@ -5,6 +5,7 @@ import org.apache.commons.lang3.ObjectUtils;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.finrem.caseorchestration.ccd.callback.CallbackType;
 import uk.gov.hmcts.reform.finrem.caseorchestration.controllers.GenericAboutToStartOrSubmitCallbackResponse;
+import uk.gov.hmcts.reform.finrem.caseorchestration.handler.CallbackHandlerLogger;
 import uk.gov.hmcts.reform.finrem.caseorchestration.handler.FinremCallbackHandler;
 import uk.gov.hmcts.reform.finrem.caseorchestration.handler.FinremCallbackRequest;
 import uk.gov.hmcts.reform.finrem.caseorchestration.handler.helper.DocumentWarningsHelper;
@@ -80,10 +81,10 @@ public class UploadDraftOrdersAboutToSubmitHandler extends FinremCallbackHandler
 
     @Override
     public GenericAboutToStartOrSubmitCallbackResponse<FinremCaseData> handle(FinremCallbackRequest callbackRequest, String userAuthorisation) {
+        log.info(CallbackHandlerLogger.aboutToSubmit(callbackRequest));
+
         FinremCaseDetails caseDetailsBefore = callbackRequest.getCaseDetailsBefore();
         FinremCaseDetails caseDetails = callbackRequest.getCaseDetails();
-        log.info("Invoking contested {} about to submit callback for Case ID: {}",
-            callbackRequest.getEventType(), caseDetails.getId());
         FinremCaseData finremCaseData = caseDetails.getData();
 
         OrderFiledBy orderFiledBy = getOrderFiledBy(caseDetails, userAuthorisation);

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/draftorders/upload/UploadDraftOrdersSubmittedHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/draftorders/upload/UploadDraftOrdersSubmittedHandler.java
@@ -5,6 +5,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.finrem.caseorchestration.ccd.callback.CallbackType;
 import uk.gov.hmcts.reform.finrem.caseorchestration.controllers.GenericAboutToStartOrSubmitCallbackResponse;
+import uk.gov.hmcts.reform.finrem.caseorchestration.handler.CallbackHandlerLogger;
 import uk.gov.hmcts.reform.finrem.caseorchestration.handler.FinremCallbackHandler;
 import uk.gov.hmcts.reform.finrem.caseorchestration.handler.FinremCallbackRequest;
 import uk.gov.hmcts.reform.finrem.caseorchestration.mapper.DraftOrdersNotificationRequestMapper;
@@ -69,8 +70,7 @@ public class UploadDraftOrdersSubmittedHandler extends FinremCallbackHandler {
     @Override
     public GenericAboutToStartOrSubmitCallbackResponse<FinremCaseData> handle(
         FinremCallbackRequest finremCallbackRequest, String userAuthorisation) {
-        log.info("Invoking contested {} submitted callback for Case ID: {}",
-            finremCallbackRequest.getEventType(), finremCallbackRequest.getCaseDetails().getId());
+        log.info(CallbackHandlerLogger.submitted(finremCallbackRequest));
 
         FinremCaseDetails caseDetails = finremCallbackRequest.getCaseDetails();
         String caseReference = String.valueOf(caseDetails.getId());

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/FinremCallbackRequestFactory.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/FinremCallbackRequestFactory.java
@@ -73,6 +73,16 @@ public class FinremCallbackRequestFactory {
             .build();
     }
 
+    public static FinremCallbackRequest from(long id, CaseType caseType, EventType eventType) {
+        return FinremCallbackRequest.builder()
+            .caseDetails(FinremCaseDetails.builder()
+                .id(id)
+                .caseType(caseType)
+                .build())
+            .eventType(eventType)
+            .build();
+    }
+
     public static FinremCallbackRequest create() {
         return FinremCallbackRequest.builder()
             .caseDetails(FinremCaseDetailsBuilderFactory.from().build())

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/FinremCallbackRequestFactory.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/FinremCallbackRequestFactory.java
@@ -73,7 +73,7 @@ public class FinremCallbackRequestFactory {
             .build();
     }
 
-    public static FinremCallbackRequest from(long id, CaseType caseType, EventType eventType) {
+    public static FinremCallbackRequest from(Long id, CaseType caseType, EventType eventType) {
         return FinremCallbackRequest.builder()
             .caseDetails(FinremCaseDetails.builder()
                 .id(id)

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/CallbackHandlerLoggerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/CallbackHandlerLoggerTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.hmcts.reform.finrem.caseorchestration.FinremCallbackRequestFactory;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.EventType;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CaseType;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.FinremCaseDetails;
 
 import java.util.stream.Stream;
 
@@ -25,7 +26,9 @@ class CallbackHandlerLoggerTest {
             Arguments.of(FinremCallbackRequestFactory.from(3575975624441189L, CaseType.CONTESTED, AMEND_APP_DETAILS),
                 "===> Case ID 3575975624441189: Handling CONTESTED About To Start callback for event FR_amendApplicationDetails"),
             Arguments.of(FinremCallbackRequestFactory.from(5437803016442134L, CaseType.CONSENTED, EventType.DRAFT_ORDERS),
-                "===> Case ID 5437803016442134: Handling CONSENTED About To Start callback for event FR_draftOrders")
+                "===> Case ID 5437803016442134: Handling CONSENTED About To Start callback for event FR_draftOrders"),
+            Arguments.of(createNullLogValuesRequest(),
+                "===> Case ID null: Handling null About To Start callback for event null")
         );
     }
 
@@ -40,7 +43,9 @@ class CallbackHandlerLoggerTest {
             Arguments.of(FinremCallbackRequestFactory.from(3575975624441189L, CaseType.CONTESTED, AMEND_APP_DETAILS),
                 "===> Case ID 3575975624441189: Handling CONTESTED Mid-Event callback for event FR_amendApplicationDetails"),
             Arguments.of(FinremCallbackRequestFactory.from(5437803016442134L, CaseType.CONSENTED, EventType.DRAFT_ORDERS),
-                "===> Case ID 5437803016442134: Handling CONSENTED Mid-Event callback for event FR_draftOrders")
+                "===> Case ID 5437803016442134: Handling CONSENTED Mid-Event callback for event FR_draftOrders"),
+            Arguments.of(createNullLogValuesRequest(),
+                "===> Case ID null: Handling null Mid-Event callback for event null")
         );
     }
 
@@ -55,7 +60,9 @@ class CallbackHandlerLoggerTest {
             Arguments.of(FinremCallbackRequestFactory.from(3575975624441189L, CaseType.CONTESTED, AMEND_APP_DETAILS),
                 "===> Case ID 3575975624441189: Handling CONTESTED About To Submit callback for event FR_amendApplicationDetails"),
             Arguments.of(FinremCallbackRequestFactory.from(5437803016442134L, CaseType.CONSENTED, EventType.DRAFT_ORDERS),
-                "===> Case ID 5437803016442134: Handling CONSENTED About To Submit callback for event FR_draftOrders")
+                "===> Case ID 5437803016442134: Handling CONSENTED About To Submit callback for event FR_draftOrders"),
+            Arguments.of(createNullLogValuesRequest(),
+                "===> Case ID null: Handling null About To Submit callback for event null")
         );
     }
 
@@ -70,7 +77,16 @@ class CallbackHandlerLoggerTest {
             Arguments.of(FinremCallbackRequestFactory.from(3575975624441189L, CaseType.CONTESTED, AMEND_APP_DETAILS),
                 "===> Case ID 3575975624441189: Handling CONTESTED Submitted callback for event FR_amendApplicationDetails"),
             Arguments.of(FinremCallbackRequestFactory.from(5437803016442134L, CaseType.CONSENTED, EventType.DRAFT_ORDERS),
-                "===> Case ID 5437803016442134: Handling CONSENTED Submitted callback for event FR_draftOrders")
+                "===> Case ID 5437803016442134: Handling CONSENTED Submitted callback for event FR_draftOrders"),
+            Arguments.of(createNullLogValuesRequest(),
+                "===> Case ID null: Handling null Submitted callback for event null")
         );
+    }
+
+    private static FinremCallbackRequest createNullLogValuesRequest() {
+        return FinremCallbackRequest.builder()
+            .caseDetails(FinremCaseDetails.builder()
+                .build())
+            .build();
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/CallbackHandlerLoggerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/CallbackHandlerLoggerTest.java
@@ -1,0 +1,76 @@
+package uk.gov.hmcts.reform.finrem.caseorchestration.handler;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.hmcts.reform.finrem.caseorchestration.FinremCallbackRequestFactory;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.EventType;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CaseType;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.EventType.AMEND_APP_DETAILS;
+
+class CallbackHandlerLoggerTest {
+
+    @ParameterizedTest
+    @MethodSource("testAboutToStart")
+    void testAboutToStart(FinremCallbackRequest request, String expectedLog) {
+        assertThat(CallbackHandlerLogger.aboutToStart(request)).isEqualTo(expectedLog);
+    }
+
+    private static Stream<Arguments> testAboutToStart() {
+        return Stream.of(
+            Arguments.of(FinremCallbackRequestFactory.from(3575975624441189L, CaseType.CONTESTED, AMEND_APP_DETAILS),
+                "===> Case ID 3575975624441189: Handling CONTESTED About To Start callback for event FR_amendApplicationDetails"),
+            Arguments.of(FinremCallbackRequestFactory.from(5437803016442134L, CaseType.CONSENTED, EventType.DRAFT_ORDERS),
+                "===> Case ID 5437803016442134: Handling CONSENTED About To Start callback for event FR_draftOrders")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("testMidEvent")
+    void testMidEvent(FinremCallbackRequest request, String expectedLog) {
+        assertThat(CallbackHandlerLogger.midEvent(request)).isEqualTo(expectedLog);
+    }
+
+    private static Stream<Arguments> testMidEvent() {
+        return Stream.of(
+            Arguments.of(FinremCallbackRequestFactory.from(3575975624441189L, CaseType.CONTESTED, AMEND_APP_DETAILS),
+                "===> Case ID 3575975624441189: Handling CONTESTED Mid-Event callback for event FR_amendApplicationDetails"),
+            Arguments.of(FinremCallbackRequestFactory.from(5437803016442134L, CaseType.CONSENTED, EventType.DRAFT_ORDERS),
+                "===> Case ID 5437803016442134: Handling CONSENTED Mid-Event callback for event FR_draftOrders")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("testAboutToSubmit")
+    void testAboutToSubmit(FinremCallbackRequest request, String expectedLog) {
+        assertThat(CallbackHandlerLogger.aboutToSubmit(request)).isEqualTo(expectedLog);
+    }
+
+    private static Stream<Arguments> testAboutToSubmit() {
+        return Stream.of(
+            Arguments.of(FinremCallbackRequestFactory.from(3575975624441189L, CaseType.CONTESTED, AMEND_APP_DETAILS),
+                "===> Case ID 3575975624441189: Handling CONTESTED About To Submit callback for event FR_amendApplicationDetails"),
+            Arguments.of(FinremCallbackRequestFactory.from(5437803016442134L, CaseType.CONSENTED, EventType.DRAFT_ORDERS),
+                "===> Case ID 5437803016442134: Handling CONSENTED About To Submit callback for event FR_draftOrders")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("testSubmitted")
+    void testSubmitted(FinremCallbackRequest request, String expectedLog) {
+        assertThat(CallbackHandlerLogger.submitted(request)).isEqualTo(expectedLog);
+    }
+
+    private static Stream<Arguments> testSubmitted() {
+        return Stream.of(
+            Arguments.of(FinremCallbackRequestFactory.from(3575975624441189L, CaseType.CONTESTED, AMEND_APP_DETAILS),
+                "===> Case ID 3575975624441189: Handling CONTESTED Submitted callback for event FR_amendApplicationDetails"),
+            Arguments.of(FinremCallbackRequestFactory.from(5437803016442134L, CaseType.CONSENTED, EventType.DRAFT_ORDERS),
+                "===> Case ID 5437803016442134: Handling CONSENTED Submitted callback for event FR_draftOrders")
+        );
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/casesubmission/CaseSubmissionPbaValidateMidEventHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/casesubmission/CaseSubmissionPbaValidateMidEventHandlerTest.java
@@ -15,6 +15,8 @@ import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.FinremCaseDetails;
 import uk.gov.hmcts.reform.finrem.caseorchestration.service.PBAValidationService;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -38,22 +40,17 @@ class CaseSubmissionPbaValidateMidEventHandlerTest {
 
     @Test
     void testHandle_ValidPbaNumber_thenHandlerCanHandle() {
+        FinremCaseDetails caseDetails = new FinremCaseDetails();
         FinremCaseData caseData = new FinremCaseData();
         caseData.setHelpWithFeesQuestion(NO);
         caseData.setPbaNumber("ValidPbaNumber");
-        FinremCaseDetails caseDetails = FinremCaseDetails.builder()
-            .id(1L)
-            .data(caseData)
-            .caseType(CaseType.CONTESTED)
-            .build();
-
-        FinremCallbackRequest request = FinremCallbackRequest.builder()
-            .caseDetails(caseDetails)
-            .eventType(EventType.APPLICATION_PAYMENT_SUBMISSION)
-            .build();
+        caseDetails.setData(caseData);
 
         Mockito.when(pbaValidationService.isValidPBA("userAuthorisation", "ValidPbaNumber")).thenReturn(true);
 
+        FinremCallbackRequest request = FinremCallbackRequest.builder()
+            .caseDetails(caseDetails)
+            .build();
         var response = handler.handle(request, "userAuthorisation");
 
         assertThat(response.getErrors()).isEmpty();
@@ -62,24 +59,22 @@ class CaseSubmissionPbaValidateMidEventHandlerTest {
 
     @Test
     void testHandle_InvalidPbaNumber_thenReturnError() {
+        FinremCaseDetails caseDetails = new FinremCaseDetails();
         FinremCaseData caseData = new FinremCaseData();
         caseData.setHelpWithFeesQuestion(NO);
         caseData.setPbaNumber("InvalidPbaNumber");
-        FinremCaseDetails caseDetails = FinremCaseDetails.builder()
-            .id(1L)
-            .data(caseData)
-            .caseType(CaseType.CONTESTED)
-            .build();
-
-        FinremCallbackRequest request = FinremCallbackRequest.builder()
-            .caseDetails(caseDetails)
-            .eventType(EventType.APPLICATION_PAYMENT_SUBMISSION)
-            .build();
+        caseDetails.setData(caseData);
 
         Mockito.when(pbaValidationService.isValidPBA("userAuthorisation", "InvalidPbaNumber")).thenReturn(false);
 
+        FinremCallbackRequest request = FinremCallbackRequest.builder()
+            .caseDetails(caseDetails)
+            .build();
         var response = handler.handle(request, "userAuthorisation");
 
-        assertThat(response.getErrors()).containsExactly("PBA Account Number is not valid, please enter a valid one.");
+        assertThat(response).isNotNull();
+        assertThat(response.getErrors().size(), is(1));
+        assertThat(response.getErrors().get(0)).isEqualTo("PBA Account Number is not valid, please enter a valid one.");
     }
+
 }

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/casesubmission/CaseSubmissionPbaValidateMidEventHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/casesubmission/CaseSubmissionPbaValidateMidEventHandlerTest.java
@@ -78,3 +78,4 @@ class CaseSubmissionPbaValidateMidEventHandlerTest {
     }
 
 }
+


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DFR-3667

### Change description

Add utility class to provide consistent logging of callback requests for handlers. The goal is to make it easier to identify handler execution in AppInsights

Example log message:
`===> Case ID 1739457437734617: Handling CONTESTED About To Start callback for event FR_draftOrders`

