### PR TITLE
DFR-3659: Prevent logging production data 

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/CaseOrchestrationApplication.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/CaseOrchestrationApplication.java
@@ -7,6 +7,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.web.filter.CommonsRequestLoggingFilter;
 import uk.gov.hmcts.reform.authorisation.ServiceAuthorisationApi;
@@ -45,6 +46,7 @@ public class CaseOrchestrationApplication  implements CommandLineRunner {
     }
 
     @Bean
+    @Profile("local")
     public CommonsRequestLoggingFilter requestLoggingFilter() {
         CommonsRequestLoggingFilter loggingFilter = new CommonsRequestLoggingFilter();
         loggingFilter.setIncludeClientInfo(false);


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DFR-3659

### Change description

Prevent logging production data. This will happening due to the presence of a CommonsRequestLoggingFilter bean.
Only enable CommonsRequestLoggingFilter in development. 
