### PR TITLE
Reduce logging level for NOC error

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/noc/nocworkflows/UpdateRepresentationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/noc/nocworkflows/UpdateRepresentationService.java
@@ -80,7 +80,7 @@ public class UpdateRepresentationService {
         final ChangeOrganisationRequest changeRequest = getChangeOrganisationRequest(caseDetails);
 
         if (barristerRepresentationChecker.hasUserBeenBarristerOnCase(caseDetails.getData(), solicitorToAdd)) {
-            log.error("User has represented litigant as Barrister for Case ID: {}, REJECTING COR", caseDetails.getId());
+            log.info("User has represented litigant as Barrister for Case ID: {}, REJECTING COR", caseDetails.getId());
             changeRequest.setApprovalStatus(REJECTED);
             Map<String, Object> caseData = caseDetails.getData();
             caseData.put(CHANGE_ORGANISATION_REQUEST, changeRequest);


### PR DESCRIPTION
### Change description

Reduce logging level to info instead of error for user error in notice of change so that it does not get reported in alerts channel.