### PR TITLE
DFR-3845: Disable Jackson feature AUTO_CLOSE_JSON_CONTENT

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/config/JacksonConfigurationVerifier.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/config/JacksonConfigurationVerifier.java
@@ -1,0 +1,16 @@
+package uk.gov.hmcts.reform.finrem.caseorchestration.config;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JacksonConfigurationVerifier {
+
+    public JacksonConfigurationVerifier(ObjectMapper objectMapper) {
+        if (objectMapper.getFactory().isEnabled(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT)) {
+            throw new IllegalStateException("Jackson ObjectMapper is configured with AUTO_CLOSE_JSON_CONTENT enabled. "
+                + "This can cause issues with streaming JSON responses and must be disabled.");
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/config/ObjectMapperConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/config/ObjectMapperConfiguration.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.finrem.caseorchestration.config;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.BeanDescription;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -35,6 +36,7 @@ public class ObjectMapperConfiguration {
             .addModule(new ParameterNamesModule(JsonCreator.Mode.PROPERTIES))
             .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            .disable(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT)
             .build();
 
         featureToggleSerialisation(objectMapper);

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/FeeLookupController.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/FeeLookupController.java
@@ -43,6 +43,7 @@ public class FeeLookupController extends BaseController {
 
     private final FeeService feeService;
     private final CaseDataService caseDataService;
+    private final ObjectMapper objectMapper;
 
     @PostMapping(path = "/fee-lookup", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(summary = "Handles looking up Case Fees")
@@ -64,7 +65,6 @@ public class FeeLookupController extends BaseController {
         FeeCaseData feeResponseData = FeeCaseData.builder().build();
         Map<String, Object> mapOfCaseData = caseDetails.getData();
         updateCaseWithFee(mapOfCaseData, feeResponseData, feeResponse);
-        ObjectMapper objectMapper = new ObjectMapper();
         return ResponseEntity.ok(AboutToStartOrSubmitCallbackResponse.builder()
             .data(objectMapper.convertValue(feeResponseData, Map.class)).build());
     }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/PBAPaymentController.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/controllers/PBAPaymentController.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.finrem.caseorchestration.controllers;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -65,6 +66,7 @@ public class PBAPaymentController extends BaseController {
     private final CcdDataStoreService ccdDataStoreService;
     private final PrdOrganisationService prdOrganisationService;
     private final MiamLegacyExemptionsService miamLegacyExemptionsService;
+    private final ObjectMapper objectMapper;
 
     @PostMapping(path = "/pba-payment", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(summary = "Handles PBA Payments for Consented and Contested Journeys")
@@ -186,7 +188,7 @@ public class PBAPaymentController extends BaseController {
 
     private void feeLookup(@RequestHeader(value = AUTHORIZATION_HEADER, required = false) String authToken,
                            @RequestBody CallbackRequest callbackRequest, Map<String, Object> caseData) {
-        ResponseEntity<AboutToStartOrSubmitCallbackResponse> feeResponse = new FeeLookupController(feeService, caseDataService)
+        ResponseEntity<AboutToStartOrSubmitCallbackResponse> feeResponse = new FeeLookupController(feeService, caseDataService, objectMapper)
             .feeLookup(authToken, callbackRequest);
         caseData.put(ORDER_SUMMARY, Objects.requireNonNull(feeResponse.getBody()).getData().get(ORDER_SUMMARY));
         caseData.put(AMOUNT_TO_PAY, Objects.requireNonNull(feeResponse.getBody()).getData().get(AMOUNT_TO_PAY));

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/ReadyForHearingConsentedAboutToStartHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/ReadyForHearingConsentedAboutToStartHandler.java
@@ -1,8 +1,7 @@
 package uk.gov.hmcts.reform.finrem.caseorchestration.handler;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.finrem.caseorchestration.ccd.callback.CallbackType;
 import uk.gov.hmcts.reform.finrem.caseorchestration.controllers.GenericAboutToStartOrSubmitCallbackResponse;
@@ -10,6 +9,7 @@ import uk.gov.hmcts.reform.finrem.caseorchestration.helper.ConsentedHearingHelpe
 import uk.gov.hmcts.reform.finrem.caseorchestration.mapper.FinremCaseDetailsMapper;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.EventType;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CaseType;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.ConsentedHearingDataElement;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.ConsentedHearingDataWrapper;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.FinremCaseData;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.FinremCaseDetails;
@@ -20,10 +20,12 @@ import java.util.List;
 @Service
 public class ReadyForHearingConsentedAboutToStartHandler extends FinremCallbackHandler {
 
+    private final ConsentedHearingHelper consentedHearingHelper;
 
-    @Autowired
-    public ReadyForHearingConsentedAboutToStartHandler(FinremCaseDetailsMapper mapper) {
+    public ReadyForHearingConsentedAboutToStartHandler(FinremCaseDetailsMapper mapper,
+                                                       ConsentedHearingHelper consentedHearingHelper) {
         super(mapper);
+        this.consentedHearingHelper = consentedHearingHelper;
     }
 
     @Override
@@ -36,9 +38,10 @@ public class ReadyForHearingConsentedAboutToStartHandler extends FinremCallbackH
     @Override
     public GenericAboutToStartOrSubmitCallbackResponse<FinremCaseData> handle(FinremCallbackRequest callbackRequest,
                                                                               String userAuthorisation) {
+        CallbackHandlerLogger.aboutToStart(callbackRequest);
+
         FinremCaseDetails caseDetails = callbackRequest.getCaseDetails();
         FinremCaseData caseData = caseDetails.getData();
-        log.info("Received request to invoke event {} for Case ID: {}", EventType.READY_FOR_HEARING, caseDetails.getId());
 
         if (!isHearingDatePresent(caseData)) {
             return GenericAboutToStartOrSubmitCallbackResponse.<FinremCaseData>builder().data(caseData)
@@ -47,13 +50,10 @@ public class ReadyForHearingConsentedAboutToStartHandler extends FinremCallbackH
         return GenericAboutToStartOrSubmitCallbackResponse.<FinremCaseData>builder().data(caseData).build();
     }
 
-    private static boolean isHearingDatePresent(FinremCaseData caseData) {
-
-        ConsentedHearingHelper helper = new ConsentedHearingHelper(new ObjectMapper());
-        ConsentedHearingDataWrapper listForHearings = helper.getHearings(caseData).stream()
-            .filter(hearing -> !hearing.getValue().getHearingDate().isEmpty())
-            .findAny().orElse(null);
-
-        return listForHearings != null;
+    private boolean isHearingDatePresent(FinremCaseData caseData) {
+        return consentedHearingHelper.getHearings(caseData).stream()
+            .map(ConsentedHearingDataWrapper::getValue)
+            .map(ConsentedHearingDataElement::getHearingDate)
+            .anyMatch(StringUtils::isNotBlank);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/ReadyForHearingConsentedAboutToStartHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/ReadyForHearingConsentedAboutToStartHandler.java
@@ -38,7 +38,7 @@ public class ReadyForHearingConsentedAboutToStartHandler extends FinremCallbackH
     @Override
     public GenericAboutToStartOrSubmitCallbackResponse<FinremCaseData> handle(FinremCallbackRequest callbackRequest,
                                                                               String userAuthorisation) {
-        CallbackHandlerLogger.aboutToStart(callbackRequest);
+        log.info(CallbackHandlerLogger.aboutToStart(callbackRequest));
 
         FinremCaseDetails caseDetails = callbackRequest.getCaseDetails();
         FinremCaseData caseData = caseDetails.getData();

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/scheduler/AmendGeneralEmailTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/scheduler/AmendGeneralEmailTask.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.finrem.caseorchestration.scheduler;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -109,7 +108,6 @@ public class AmendGeneralEmailTask extends CsvFileProcessingTask {
     @Override
     protected void executeTask(FinremCaseDetails finremCaseDetails) {
         FinremCaseData caseData = finremCaseDetails.getData();
-        ObjectMapper mapper = new ObjectMapper();
 
         if (caseData.getGeneralEmailWrapper().getGeneralEmailUploadedDocument() != null) {
             caseData.getGeneralEmailWrapper().setGeneralEmailUploadedDocument(null);


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DFR-3845

### Change description

- Disable Jackson feature AUTO_CLOSE_JSON_CONTENT due to its potential to cause corruption of data that is sent to CCD.
- Remove instances in controllers where ObjectMapper is not DI
- Refactor some handler code that doesn't use DI