### PR TITLE
Update Spring Boot to v3.5.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'checkstyle'
     id 'jacoco'
     id 'org.sonarqube' version '6.2.0.5505'
-    id 'org.springframework.boot' version '3.4.5'
+    id 'org.springframework.boot' version '3.5.3'
     id 'com.github.ben-manes.versions' version '0.52.0'
     id 'uk.gov.hmcts.java' version '0.12.66'
     id 'au.com.dius.pact' version '4.6.17'
@@ -43,12 +43,12 @@ def versions = [
         jacksonDatabind      : '2.19.1',
         retry                : '1.3.4',
         snakeyaml            : '2.4',
-        loadbalancer         : '4.2.1'
+        loadbalancer         : '4.3.0'
 ]
 
 project.ext {
     pactVersion = getCheckedOutGitCommitHash()
-    springCloudBomVersion = "2024.0.1"
+    springCloudBomVersion = "2025.0.0"
     restAssuredBomVersion = "5.5.5"
 }
 


### PR DESCRIPTION
### Change description

Update Spring Boot to v3.5.3
This also requires an update to Spring Cloud Dependencies
