### PR TITLE
duplicate payment error should prevent case submission

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/casesubmission/CaseSubmissionAboutToSubmitHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/casesubmission/CaseSubmissionAboutToSubmitHandler.java
@@ -30,6 +30,8 @@ import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ConsentedStatus
 @Slf4j
 public class CaseSubmissionAboutToSubmitHandler extends FinremCallbackHandler {
 
+    private static final String PAYMENT_FAILURE_MESSAGE = "Payment failed. Please review your account.";
+
     private final FeeService feeService;
     private final PBAPaymentServiceAdapter pbaPaymentService;
 
@@ -69,13 +71,14 @@ public class CaseSubmissionAboutToSubmitHandler extends FinremCallbackHandler {
             PaymentResponse paymentResponse = pbaPaymentService.makePayment(userAuthorisation, caseDetails);
             if (paymentResponse.isDuplicatePayment()) {
                 // No payment reference is supplied with a duplicate payment response
-                log.error("Case ID: {} - Duplicate payment", caseDetails.getId());
+                log.info("Case ID: {} - Duplicate payment", caseDetails.getId());
+                errors.add(PAYMENT_FAILURE_MESSAGE);
             } else if (paymentResponse.isPaymentSuccess()) {
                 log.info("Case ID: {} - Payment successful", caseDetails.getId());
                 caseData.getPaymentDetailsWrapper().setPbaPaymentReference(paymentResponse.getReference());
             } else {
                 log.info("Case ID: {} - Payment failed", caseDetails.getId());
-                errors.add(paymentResponse.getError());
+                errors.add(PAYMENT_FAILURE_MESSAGE);
             }
         }
 

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/payments/client/PBAPaymentClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/payments/client/PBAPaymentClient.java
@@ -2,11 +2,9 @@ package uk.gov.hmcts.reform.finrem.caseorchestration.service.payments.client;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
@@ -97,19 +95,8 @@ public class PBAPaymentClient {
     }
 
     private PaymentResponse get400ErrorResponse(HttpClientErrorException e) {
-        if (isDuplicatePaymentException(e)) {
-            return PaymentResponse.builder()
-                .error(PaymentResponse.DUPLICATE_PAYMENT_MESSAGE)
-                .build();
-        } else {
-            return PaymentResponse.builder()
-                .error("Payment failed. Please review your account.")
-                .build();
-        }
-    }
-
-    private boolean isDuplicatePaymentException(HttpClientErrorException e) {
-        return e.getStatusCode() == HttpStatus.BAD_REQUEST
-            && StringUtils.contains(e.getResponseBodyAsString(), PaymentResponse.DUPLICATE_PAYMENT_MESSAGE);
+        return PaymentResponse.builder()
+            .error(e.getResponseBodyAsString())
+            .build();
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/payments/SetUpUtils.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/payments/SetUpUtils.java
@@ -2,11 +2,11 @@ package uk.gov.hmcts.reform.finrem.caseorchestration.service.payments;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import feign.FeignException;
 import feign.Response;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ApplicationType;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CaseType;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.fee.FeeResponse;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.pba.payment.FeeRequest;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.pba.payment.PaymentRequest;
@@ -22,13 +22,13 @@ import uk.gov.hmcts.reform.finrem.caseorchestration.service.payments.model.pba.v
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ApplicationType.CONSENTED;
-
 
 public class SetUpUtils {
 
@@ -45,10 +45,8 @@ public class SetUpUtils {
     public static final String FEE_VERSION = "v1";
 
     public static final String PBA_NUMBER = "PBA0222";
-    public static final String CONSENTED_CASE_TYPE = "FinancialRemedyMVP2";
-    public static final String CONTESTED_CASE_TYPE = "FinancialRemedyContested";
 
-    private static ObjectMapper objectMapper = new ObjectMapper();
+    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     public static FeignException feignError() {
         Response response = Response.builder().status(STATUS_CODE).headers(ImmutableMap.of()).build();
@@ -60,7 +58,7 @@ public class SetUpUtils {
     }
 
     public static String pbaAccount() {
-        PBAAccount pbaAccount = PBAAccount.builder().accountList(ImmutableList.of(PBA_NUMBER)).build();
+        PBAAccount pbaAccount = PBAAccount.builder().accountList(List.of(PBA_NUMBER)).build();
         return objectToJson(pbaAccount);
     }
 
@@ -105,7 +103,7 @@ public class SetUpUtils {
         return PaymentResponse.builder()
             .status(PAYMENT_SUCCESS_STATUS)
             .reference(PAYMENT_REF)
-            .statusHistories(ImmutableList.of()).build();
+            .statusHistories(List.of()).build();
     }
 
     public static PaymentResponse paymentDuplicateError() {
@@ -133,7 +131,7 @@ public class SetUpUtils {
         return PaymentResponse.builder()
             .status(PAYMENT_FAILED_STATUS)
             .reference(PAYMENT_REF)
-            .statusHistories(ImmutableList.of(paymentStatusHistory())).build();
+            .statusHistories(List.of(paymentStatusHistory())).build();
     }
 
     public static String paymentResponseErrorToString() {
@@ -193,7 +191,7 @@ public class SetUpUtils {
             .build();
         return PaymentRequest.builder()
             .accountNumber(ACCOUNT_NUMBER)
-            .caseType(CONSENTED_CASE_TYPE)
+            .caseType(CaseType.CONSENTED.getCcdType())
             .ccdCaseNumber("ED12345")
             .customerReference("SOL1")
             .organisationName("ORG SOL1")

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/payments/client/PBAPaymentClientTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/payments/client/PBAPaymentClientTest.java
@@ -68,14 +68,16 @@ public class PBAPaymentClientTest extends PaymentsBaseServiceTest {
 
     @Test
     public void makePaymentWithCaseTypeReceivesClientError() {
+        String paymentResponseBody = paymentResponseErrorToString();
         mockServer.expect(requestTo(URI))
             .andExpect(method(HttpMethod.POST))
             .andRespond(withUnauthorizedRequest()
-                .body(paymentResponseErrorToString()).contentType(APPLICATION_JSON));
+                .body(paymentResponseBody).contentType(APPLICATION_JSON));
 
         PaymentResponse paymentResponse = pbaPaymentClient.makePaymentWithCaseType(AUTH_TOKEN, paymentRequestWithCaseType());
 
         assertThat(paymentResponse.isPaymentSuccess(), is(false));
+        assertThat(paymentResponse.getError(), is(paymentResponseBody));
     }
 
     @Test


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DFR-3889

### Change description

A "duplicate payment" response from payments api is currently ignored and the Case Submission event is allowed to submit.
However, in scenarios where the initial payment caused an error this behaviour will cause a case to be submitted without payment.
Therefore, a duplicate payment response should prevent a case being submitted. The consequence of this is that if the initial request was valid then the user will have to redo Case Submission and take manual steps to recover the duplicate payment.

### Testing done

- Tested valid PBA account submits case
- Tested invalid PBA account never submits case
- Tested duplicate payment never submits case
- Tested invalid PBA account followed by a valid PBA submits case
