### PR TITLE
DFR-3915: Move Create General Email handlers into their own package

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/creategeneralemail/GeneralEmailAboutToStartHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/creategeneralemail/GeneralEmailAboutToStartHandler.java
@@ -1,10 +1,12 @@
-package uk.gov.hmcts.reform.finrem.caseorchestration.handler;
+package uk.gov.hmcts.reform.finrem.caseorchestration.handler.creategeneralemail;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.finrem.caseorchestration.ccd.callback.CallbackType;
 import uk.gov.hmcts.reform.finrem.caseorchestration.controllers.GenericAboutToStartOrSubmitCallbackResponse;
+import uk.gov.hmcts.reform.finrem.caseorchestration.handler.FinremCallbackHandler;
+import uk.gov.hmcts.reform.finrem.caseorchestration.handler.FinremCallbackRequest;
 import uk.gov.hmcts.reform.finrem.caseorchestration.mapper.FinremCaseDetailsMapper;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.EventType;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CaseType;

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/creategeneralemail/GeneralEmailAboutToSubmitHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/creategeneralemail/GeneralEmailAboutToSubmitHandler.java
@@ -1,10 +1,12 @@
-package uk.gov.hmcts.reform.finrem.caseorchestration.handler;
+package uk.gov.hmcts.reform.finrem.caseorchestration.handler.creategeneralemail;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.finrem.caseorchestration.ccd.callback.CallbackType;
 import uk.gov.hmcts.reform.finrem.caseorchestration.controllers.GenericAboutToStartOrSubmitCallbackResponse;
+import uk.gov.hmcts.reform.finrem.caseorchestration.handler.FinremCallbackHandler;
+import uk.gov.hmcts.reform.finrem.caseorchestration.handler.FinremCallbackRequest;
 import uk.gov.hmcts.reform.finrem.caseorchestration.mapper.FinremCaseDetailsMapper;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.EventType;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CaseDocument;

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/creategeneralemail/GeneralEmailMidHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/creategeneralemail/GeneralEmailMidHandler.java
@@ -1,10 +1,12 @@
-package uk.gov.hmcts.reform.finrem.caseorchestration.handler;
+package uk.gov.hmcts.reform.finrem.caseorchestration.handler.creategeneralemail;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.finrem.caseorchestration.ccd.callback.CallbackType;
 import uk.gov.hmcts.reform.finrem.caseorchestration.controllers.GenericAboutToStartOrSubmitCallbackResponse;
+import uk.gov.hmcts.reform.finrem.caseorchestration.handler.FinremCallbackHandler;
+import uk.gov.hmcts.reform.finrem.caseorchestration.handler.FinremCallbackRequest;
 import uk.gov.hmcts.reform.finrem.caseorchestration.mapper.FinremCaseDetailsMapper;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.EventType;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CaseDocument;

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/creategeneralemail/GeneralEmailAboutToStartHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/creategeneralemail/GeneralEmailAboutToStartHandlerTest.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.reform.finrem.caseorchestration.handler;
+package uk.gov.hmcts.reform.finrem.caseorchestration.handler.creategeneralemail;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -7,6 +7,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.finrem.caseorchestration.ccd.callback.CallbackType;
 import uk.gov.hmcts.reform.finrem.caseorchestration.controllers.GenericAboutToStartOrSubmitCallbackResponse;
+import uk.gov.hmcts.reform.finrem.caseorchestration.handler.FinremCallbackRequest;
 import uk.gov.hmcts.reform.finrem.caseorchestration.mapper.FinremCaseDetailsMapper;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.EventType;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CaseDocument;

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/creategeneralemail/GeneralEmailAboutToSubmitHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/creategeneralemail/GeneralEmailAboutToSubmitHandlerTest.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.reform.finrem.caseorchestration.handler;
+package uk.gov.hmcts.reform.finrem.caseorchestration.handler.creategeneralemail;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -9,6 +9,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.finrem.caseorchestration.ccd.callback.CallbackType;
 import uk.gov.hmcts.reform.finrem.caseorchestration.controllers.GenericAboutToStartOrSubmitCallbackResponse;
+import uk.gov.hmcts.reform.finrem.caseorchestration.handler.FinremCallbackRequest;
 import uk.gov.hmcts.reform.finrem.caseorchestration.mapper.FinremCaseDetailsMapper;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.EventType;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CaseDocument;
@@ -56,7 +57,7 @@ class GeneralEmailAboutToSubmitHandlerTest {
     private FeatureToggleService featureToggleService;
 
     @BeforeEach
-    public void init() {
+    void init() {
         GeneralEmailDocumentCategoriser categoriser = new GeneralEmailDocumentCategoriser(featureToggleService);
         handler =  new GeneralEmailAboutToSubmitHandler(finremCaseDetailsMapper,
             notificationService,
@@ -140,7 +141,7 @@ class GeneralEmailAboutToSubmitHandlerTest {
     void givenConsentedCallbackRequest_whenHandledForRecipient_thenNotCategorised() {
         FinremCallbackRequest callbackRequest = buildFinremCallbackRequest(true);
         GenericAboutToStartOrSubmitCallbackResponse<FinremCaseData> response = handler.handle(callbackRequest, AUTH_TOKEN);
-        assertNull(response.getData().getGeneralEmailWrapper().getGeneralEmailCollection().get(0)
+        assertNull(response.getData().getGeneralEmailWrapper().getGeneralEmailCollection().getFirst()
                 .getValue().getGeneralEmailUploadedDocument().getCategoryId());
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/creategeneralemail/GeneralEmailMidHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/creategeneralemail/GeneralEmailMidHandlerTest.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.reform.finrem.caseorchestration.handler;
+package uk.gov.hmcts.reform.finrem.caseorchestration.handler.creategeneralemail;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -8,6 +8,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.finrem.caseorchestration.TestSetUpUtils;
 import uk.gov.hmcts.reform.finrem.caseorchestration.controllers.GenericAboutToStartOrSubmitCallbackResponse;
+import uk.gov.hmcts.reform.finrem.caseorchestration.handler.FinremCallbackRequest;
 import uk.gov.hmcts.reform.finrem.caseorchestration.mapper.FinremCaseDetailsMapper;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CaseDocument;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CaseType;


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DFR-3915

### Change description

Move Create General Email handlers into their own package

### Testing done

Tested event still runs locally.
