### PR TITLE
DFR-3915: Add emailReplyToId field for gov.uk notify requests

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/notification/NotificationRequest.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/notification/NotificationRequest.java
@@ -65,4 +65,5 @@ public class NotificationRequest {
     private String judgeFeedback;
     @JsonProperty("documentName")
     private String documentName;
+    private String emailReplyToId;
 }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/notifications/domain/EmailToSend.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/notifications/domain/EmailToSend.java
@@ -10,4 +10,5 @@ public final class EmailToSend {
     String templateId;
     Map<String, Object> templateFields;
     String referenceId;
+    String emailReplyToId;
 }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/notifications/service/EmailService.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/notifications/service/EmailService.java
@@ -73,7 +73,7 @@ public class EmailService {
     public void sendConfirmationEmail(NotificationRequest notificationRequest, EmailTemplateNames template) {
         Map<String, Object> templateVars = buildTemplateVars(notificationRequest, template.name());
         EmailToSend emailToSend = generateEmail(notificationRequest.getNotificationEmail(), template.name(),
-            templateVars);
+            templateVars, notificationRequest.getEmailReplyToId());
         log.info("Sending confirmation email on Case ID : {} using template: {}", notificationRequest.getCaseReferenceNumber(), template.name());
         sendEmail(emailToSend, "send Confirmation email for " + template.name());
     }
@@ -182,12 +182,11 @@ public class EmailService {
         templateVars.put("documentName", notificationRequest.getDocumentName());
     }
 
-    protected EmailToSend generateEmail(String destinationAddress,
-                                      String templateName,
-                                      Map<String, Object> templateVars) {
+    protected EmailToSend generateEmail(String destinationAddress, String templateName,
+                                        Map<String, Object> templateVars, String emailReplyToId) {
         String referenceId = UUID.randomUUID().toString();
         String templateId = emailTemplates.get(templateName);
-        return new EmailToSend(destinationAddress, templateId, templateVars, referenceId);
+        return new EmailToSend(destinationAddress, templateId, templateVars, referenceId, emailReplyToId);
     }
 
     private void sendEmail(EmailToSend emailToSend, String emailDescription) {
@@ -199,7 +198,8 @@ public class EmailService {
                 templateId,
                 emailToSend.getEmailAddress(),
                 emailToSend.getTemplateFields(),
-                referenceId
+                referenceId,
+                emailToSend.getEmailReplyToId()
             );
             log.info("Sending email success. Reference ID: {}", referenceId);
         } catch (NotificationClientException e) {

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/notifications/service/LocalEmailService.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/notifications/service/LocalEmailService.java
@@ -36,7 +36,7 @@ public class LocalEmailService extends EmailService {
     public void sendConfirmationEmail(NotificationRequest notificationRequest, EmailTemplateNames template) {
         Map<String, Object> templateVars = buildTemplateVars(notificationRequest, template.name());
         EmailToSend emailToSend = generateEmail(notificationRequest.getNotificationEmail(), template.name(),
-                templateVars);
+                templateVars, notificationRequest.getEmailReplyToId());
         log.info("Creating a preview email for Case ID : {} using template: {}", notificationRequest.getCaseReferenceNumber(), template.name());
         previewEmail(emailToSend, "send Confirmation email for " + template.name());
     }

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/notifications/domain/EmailToSendTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/notifications/domain/EmailToSendTest.java
@@ -17,7 +17,7 @@ public class EmailToSendTest {
         templateVars = new HashMap<>();
         templateVars.put("abc", "123");
         emailToSend = new EmailToSend("test@test.com", "12345",
-                templateVars, "referenceId");
+                templateVars, "referenceId", "666");
     }
 
     @Test
@@ -26,5 +26,6 @@ public class EmailToSendTest {
         assertEquals("12345", emailToSend.getTemplateId());
         assertEquals("referenceId", emailToSend.getReferenceId());
         assertEquals(templateVars, emailToSend.getTemplateFields());
+        assertEquals("666", emailToSend.getEmailReplyToId());
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/notifications/domain/NotificationRequestTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/notifications/domain/NotificationRequestTest.java
@@ -3,6 +3,8 @@ package uk.gov.hmcts.reform.finrem.caseorchestration.notifications.domain;
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.notification.NotificationRequest;
 
+import java.util.UUID;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.notifications.NotificationConstants.PHONE_OPENING_HOURS;
@@ -14,12 +16,13 @@ class NotificationRequestTest {
 
     @Test
     void shouldGetHwfNotificationRequestData() {
+        String emailReplyToId = UUID.randomUUID().toString();
         underTest = new NotificationRequest("123456",
             "45623", "D123", "Padmaja", "test@test.com",
             "nottingham", CONTESTED, "body", PHONE_OPENING_HOURS, "consent",
             "Consent",
             "rejectedReason", "app", "res", "1234567890", "", "", "", "", null, null,
-            "2024-01-01", "judgeName", "2024-01-01", "Feedback by Mr. judge", "ABC.doc");
+            "2024-01-01", "judgeName", "2024-01-01", "Feedback by Mr. judge", "ABC.doc", emailReplyToId);
         assertEquals("123456", underTest.getCaseReferenceNumber());
         assertEquals("45623", underTest.getSolicitorReferenceNumber());
         assertEquals("D123", underTest.getDivorceCaseNumber());
@@ -38,6 +41,7 @@ class NotificationRequestTest {
         assertEquals("2024-01-01", underTest.getOldestDraftOrderDate());
         assertEquals("Feedback by Mr. judge", underTest.getJudgeFeedback());
         assertEquals("ABC.doc", underTest.getDocumentName());
+        assertEquals(emailReplyToId, underTest.getEmailReplyToId());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/notifications/service/EmailServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/notifications/service/EmailServiceTest.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.notifications.NotificationConstants.PHONE_OPENING_HOURS;
@@ -141,7 +142,7 @@ public class EmailServiceTest {
             eq(emailTemplates.get(FR_HWF_SUCCESSFUL.name())),
             eq(TEST_SOLICITOR_EMAIL),
             eq(returnedTemplateVars),
-            anyString());
+            anyString(), isNull());
     }
 
     @Test
@@ -162,7 +163,7 @@ public class EmailServiceTest {
             eq(emailTemplates.get(FR_CONTESTED_HWF_SUCCESSFUL.name())),
             eq(TEST_SOLICITOR_EMAIL),
             eq(returnedTemplateVars),
-            anyString());
+            anyString(), isNull());
     }
 
     @Test
@@ -184,7 +185,7 @@ public class EmailServiceTest {
             eq(emailTemplates.get(FR_CONTESTED_HWF_SUCCESSFUL.name())),
             eq(TEST_SOLICITOR_EMAIL),
             eq(returnedTemplateVars),
-            anyString());
+            anyString(), isNull());
     }
 
     @Test
@@ -216,7 +217,7 @@ public class EmailServiceTest {
             eq(emailTemplates.get(FR_ASSIGNED_TO_JUDGE.name())),
             eq(TEST_SOLICITOR_EMAIL),
             eq(returnedTemplateVars),
-            anyString());
+            anyString(), isNull());
     }
 
     @Test
@@ -238,7 +239,7 @@ public class EmailServiceTest {
             eq(emailTemplates.get(FR_CONTESTED_PREPARE_FOR_HEARING.name())),
             eq(TEST_SOLICITOR_EMAIL),
             eq(returnedTemplateVars),
-            anyString());
+            anyString(), isNull());
     }
 
     @Test
@@ -261,7 +262,7 @@ public class EmailServiceTest {
             eq(emailTemplates.get(FR_CONTESTED_PREPARE_FOR_HEARING_INTERVENER_SOL.name())),
             eq(TEST_SOLICITOR_EMAIL),
             eq(returnedTemplateVars),
-            anyString());
+            anyString(), isNull());
     }
 
     @Test
@@ -292,7 +293,7 @@ public class EmailServiceTest {
             eq(emailTemplates.get(FR_CONSENT_ORDER_MADE.name())),
             eq(TEST_SOLICITOR_EMAIL),
             eq(returnedTemplateVars),
-            anyString());
+            anyString(), isNull());
     }
 
     @Test
@@ -312,7 +313,7 @@ public class EmailServiceTest {
             eq(emailTemplates.get(FR_CONSENT_ORDER_MADE.name())),
             eq(TEST_SOLICITOR_EMAIL),
             eq(returnedTemplateVars),
-            anyString());
+            anyString(), isNull());
     }
 
     @Test
@@ -344,7 +345,7 @@ public class EmailServiceTest {
             eq(emailTemplates.get(FR_CONSENT_ORDER_NOT_APPROVED.name())),
             eq(TEST_SOLICITOR_EMAIL),
             eq(returnedTemplateVars),
-            anyString());
+            anyString(), isNull());
     }
 
     @Test
@@ -363,7 +364,7 @@ public class EmailServiceTest {
             eq(emailTemplates.get(FR_CONSENT_ORDER_NOT_APPROVED_SENT.name())),
             eq(TEST_SOLICITOR_EMAIL),
             eq(returnedTemplateVars),
-            anyString());
+            anyString(), isNull());
     }
 
     @Test
@@ -393,7 +394,7 @@ public class EmailServiceTest {
             eq(emailTemplates.get(FR_CONSENT_ORDER_AVAILABLE.name())),
             eq(TEST_SOLICITOR_EMAIL),
             eq(returnedTemplateVars),
-            anyString());
+            anyString(), isNull());
     }
 
     @Test
@@ -411,7 +412,7 @@ public class EmailServiceTest {
             eq(emailTemplates.get(FR_CONTESTED_GENERAL_APPLICATION_REFER_TO_JUDGE.name())),
             eq(TEST_SOLICITOR_EMAIL),
             eq(returnedTemplateVars),
-            anyString());
+            anyString(), isNull());
     }
 
     @Test
@@ -730,7 +731,7 @@ public class EmailServiceTest {
             eq(emailTemplates.get(FR_CONTESTED_DRAFT_ORDER_REVIEW_OVERDUE.name())),
             eq("recipient@test.com"),
             templateFieldsArgumentCaptor.capture(),
-            anyString());
+            anyString(), isNull());
 
         Map<String, Object> actualTemplateFields = templateFieldsArgumentCaptor.getValue();
         expectedTemplateFields.forEach((k, v) -> assertEquals(v, actualTemplateFields.get(k)));
@@ -769,7 +770,7 @@ public class EmailServiceTest {
             eq(emailTemplates.get(FR_CONTESTED_DRAFT_ORDER_OR_PSA_REFUSED.name())),
             eq("recipient@test.com"),
             templateFieldsArgumentCaptor.capture(),
-            anyString());
+            anyString(), isNull());
 
         Map<String, Object> actualTemplateFields = templateFieldsArgumentCaptor.getValue();
         expectedTemplateFields.forEach((k, v) -> assertEquals(v, actualTemplateFields.get(k)));


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DFR-3915

### Change description

Add emailReplyToId field that can be used to hold the reply-to UUID for identifying what reply-to email address gov.uk notify should use when sending emails

Note this PR is not populating this field; it is just adding it and will be populated in a later PR.
It will just set the value to null which will not break current email sending functionality. This field is optional:
https://docs.notifications.service.gov.uk/java.html#emailreplytoid-optional

See https://github.com/alphagov/notifications-java-client/blob/e537917e0b22161c52dc6dd36a31951be4b3cd1a/src/main/java/uk/gov/service/notify/NotificationClient.java#L169

### Testing done

Local testing to ensure emails are still sent when emailReplyToId = null

