### PR TITLE
DFR-3915: Refactor general email notification requests

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/mapper/notificationrequest/FinremNotificationRequestMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/mapper/notificationrequest/FinremNotificationRequestMapper.java
@@ -195,6 +195,16 @@ public class FinremNotificationRequestMapper {
             .build();
     }
 
+    /**
+     * Builds a {@link NotificationRequest} for sending a general email notification.
+     * @param caseDetails the case details
+     * @return the populated notification request
+     */
+    public NotificationRequest getNotificationRequestForGeneralEmail(FinremCaseDetails caseDetails) {
+        SolicitorCaseDataKeysWrapper caseDataKeysWrapper = getApplicantSolicitorCaseData(caseDetails.getData());
+        return buildNotificationRequest(caseDetails, caseDataKeysWrapper);
+    }
+
     private void setCaseOrderType(NotificationRequest notificationRequest, FinremCaseData caseData) {
         if (Boolean.TRUE.equals(consentedApplicationHelper.isVariationOrder(caseData))) {
             notificationRequest.setCaseOrderType("variation");

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/NotificationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/NotificationService.java
@@ -36,7 +36,6 @@ import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigCo
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.CONSENTED_SOLICITOR_NAME;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.CONTESTED_SOLICITOR_EMAIL;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.CONTESTED_SOLICITOR_NAME;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.GENERAL_EMAIL_RECIPIENT;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.RESP_SOLICITOR_EMAIL;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.RESP_SOLICITOR_NOTIFICATIONS_EMAIL_CONSENT;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.TRANSFER_COURTS_EMAIL;
@@ -654,23 +653,6 @@ public class NotificationService {
         emailService.sendConfirmationEmail(notificationRequest, FR_CONTESTED_DRAFT_ORDER);
     }
 
-    /**
-     * No Return.
-     *
-     * <p>Please use @{@link #sendConsentGeneralEmail(FinremCaseDetails, String)}</p>
-     *
-     * @param caseDetails instance of CaseDetails
-     * @deprecated Use {@link CaseDetails caseDetails}
-     */
-    @Deprecated(since = "15-june-2023")
-    public void sendConsentGeneralEmail(CaseDetails caseDetails) {
-        NotificationRequest notificationRequest = notificationRequestMapper.getNotificationRequestForApplicantSolicitor(caseDetails);
-        notificationRequest.setNotificationEmail(Objects.toString(caseDetails.getData().get(GENERAL_EMAIL_RECIPIENT)));
-        log.info("Received request for notification email for consented general email for Case ID: {}",
-            caseDetails.getId());
-        emailService.sendConfirmationEmail(notificationRequest, FR_CONSENT_GENERAL_EMAIL);
-    }
-
     public void sendConsentGeneralEmail(FinremCaseDetails caseDetails, String auth) {
         NotificationRequest notificationRequest = finremNotificationRequestMapper.getNotificationRequestForApplicantSolicitor(caseDetails);
         notificationRequest.setNotificationEmail(caseDetails.getData().getGeneralEmailWrapper().getGeneralEmailRecipient());
@@ -688,23 +670,6 @@ public class NotificationService {
             return true;
         }
         return false;
-    }
-
-    /**
-     * No Return.
-     *
-     * <p>Please use @{@link #sendContestedGeneralEmail(FinremCaseDetails, String)}</p>
-     *
-     * @param caseDetails instance of CaseDetails
-     * @deprecated Use {@link CaseDetails caseDetails}
-     */
-    @Deprecated(since = "15-june-2023")
-    public void sendContestedGeneralEmail(CaseDetails caseDetails) {
-        NotificationRequest notificationRequest = notificationRequestMapper.getNotificationRequestForApplicantSolicitor(caseDetails);
-        notificationRequest.setNotificationEmail(Objects.toString(caseDetails.getData().get(GENERAL_EMAIL_RECIPIENT)));
-        log.info("Received request for notification email for contested general email for Case ID: {}",
-            caseDetails.getId());
-        emailService.sendConfirmationEmail(notificationRequest, FR_CONTESTED_GENERAL_EMAIL);
     }
 
     public void sendContestedGeneralEmail(FinremCaseDetails caseDetails, String auth) {

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/mapper/notificationrequest/FinremNotificationRequestMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/mapper/notificationrequest/FinremNotificationRequestMapperTest.java
@@ -69,7 +69,7 @@ class FinremNotificationRequestMapperTest {
     private final FinremCaseDetails contestedFinremCaseDetails = getContestedFinremCaseDetails();
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         // Register the JavaTimeModule for Java 8 Date/Time support
         mapper.registerModule(new JavaTimeModule());
     }
@@ -380,6 +380,37 @@ class FinremNotificationRequestMapperTest {
         assertEquals("Victoria Goodman", notificationRequest.getApplicantName());
         assertEquals("David Goodman", notificationRequest.getRespondentName());
         assertEquals(CTSC_OPENING_HOURS, notificationRequest.getPhoneOpeningHours());
+    }
+
+    @Test
+    void givenContestedCaseData_whenGeneralEmail_thenBuildNotificationRequest() {
+        NotificationRequest notificationRequest = notificationRequestMapper.getNotificationRequestForGeneralEmail(contestedFinremCaseDetails);
+
+        assertEquals("12345", notificationRequest.getCaseReferenceNumber());
+        assertEquals(TEST_SOLICITOR_REFERENCE, notificationRequest.getSolicitorReferenceNumber());
+        assertEquals(TEST_DIVORCE_CASE_NUMBER, notificationRequest.getDivorceCaseNumber());
+        assertEquals(TEST_SOLICITOR_NAME, notificationRequest.getName());
+        assertEquals(TEST_SOLICITOR_EMAIL, notificationRequest.getNotificationEmail());
+        assertEquals("contested", notificationRequest.getCaseType());
+        assertEquals("nottingham", notificationRequest.getSelectedCourt());
+        assertEquals("David Goodman", notificationRequest.getRespondentName());
+        assertEquals("Victoria Goodman", notificationRequest.getApplicantName());
+    }
+
+    @Test
+    void givenConsentedCaseData_whenGeneralEmail_thenBuildNotificationRequest() {
+        NotificationRequest notificationRequest = notificationRequestMapper.getNotificationRequestForGeneralEmail(consentedFinremCaseDetails);
+
+        assertEquals("12345", notificationRequest.getCaseReferenceNumber());
+        assertEquals(TEST_SOLICITOR_REFERENCE, notificationRequest.getSolicitorReferenceNumber());
+        assertEquals(TEST_DIVORCE_CASE_NUMBER, notificationRequest.getDivorceCaseNumber());
+        assertEquals(TEST_SOLICITOR_NAME, notificationRequest.getName());
+        assertEquals(TEST_SOLICITOR_EMAIL, notificationRequest.getNotificationEmail());
+        assertEquals("consented", notificationRequest.getCaseType());
+        assertEquals("consent", notificationRequest.getCaseOrderType());
+        assertEquals("Consent", notificationRequest.getCamelCaseOrderType());
+        assertEquals("David Goodman", notificationRequest.getRespondentName());
+        assertEquals("Victoria Goodman", notificationRequest.getApplicantName());
     }
 
     @SneakyThrows

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/FinremNotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/FinremNotificationServiceTest.java
@@ -45,6 +45,7 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -412,9 +413,11 @@ class FinremNotificationServiceTest {
 
     @Test
     void sendGeneralEmailConsented() {
+        when(finremNotificationRequestMapper.getNotificationRequestForGeneralEmail(consentedFinremCaseDetails)).thenReturn(mock(NotificationRequest.class));
+
         notificationService.sendConsentGeneralEmail(consentedFinremCaseDetails, anyString());
 
-        verify(finremNotificationRequestMapper).getNotificationRequestForApplicantSolicitor(consentedFinremCaseDetails);
+        verify(finremNotificationRequestMapper).getNotificationRequestForGeneralEmail(consentedFinremCaseDetails);
         verify(emailService).sendConfirmationEmail(any(), eq(FR_CONSENT_GENERAL_EMAIL));
     }
 
@@ -424,9 +427,11 @@ class FinremNotificationServiceTest {
         defaultFinremCaseData.getGeneralEmailWrapper()
             .setGeneralEmailUploadedDocument(CaseDocument.builder().documentBinaryUrl("binaryUrl").build());
         FinremCaseDetails caseDetails = getConsentedFinremCaseDetails(defaultFinremCaseData);
+        when(finremNotificationRequestMapper.getNotificationRequestForGeneralEmail(caseDetails)).thenReturn(mock(NotificationRequest.class));
+
         notificationService.sendConsentGeneralEmail(caseDetails, anyString());
 
-        verify(finremNotificationRequestMapper).getNotificationRequestForApplicantSolicitor(caseDetails);
+        verify(finremNotificationRequestMapper).getNotificationRequestForGeneralEmail(caseDetails);
         verify(emailService).sendConfirmationEmail(any(), eq(FR_CONSENT_GENERAL_EMAIL_ATTACHMENT));
     }
 
@@ -436,21 +441,23 @@ class FinremNotificationServiceTest {
         defaultFinremCaseData.getGeneralEmailWrapper()
             .setGeneralEmailUploadedDocument(CaseDocument.builder().documentBinaryUrl("binaryUrl").build());
         FinremCaseDetails caseDetails = getConsentedFinremCaseDetails(defaultFinremCaseData);
+        when(finremNotificationRequestMapper.getNotificationRequestForGeneralEmail(caseDetails)).thenReturn(mock(NotificationRequest.class));
         doThrow(HttpClientErrorException.class)
             .when(evidenceManagementDownloadService).getByteArray(any(CaseDocument.class), anyString());
 
         assertThatThrownBy(() -> notificationService.sendConsentGeneralEmail(caseDetails, AUTH_TOKEN))
             .isInstanceOf(HttpClientErrorException.class);
 
-        verify(finremNotificationRequestMapper).getNotificationRequestForApplicantSolicitor(caseDetails);
+        verify(finremNotificationRequestMapper).getNotificationRequestForGeneralEmail(caseDetails);
         verify(emailService, never()).sendConfirmationEmail(any(), eq(FR_CONSENT_GENERAL_EMAIL));
     }
 
     @Test
     void sendGeneralEmailContested() {
+        when(finremNotificationRequestMapper.getNotificationRequestForGeneralEmail(contestedFinremCaseDetails)).thenReturn(mock(NotificationRequest.class));
         notificationService.sendContestedGeneralEmail(contestedFinremCaseDetails, anyString());
 
-        verify(finremNotificationRequestMapper).getNotificationRequestForApplicantSolicitor(contestedFinremCaseDetails);
+        verify(finremNotificationRequestMapper).getNotificationRequestForGeneralEmail(contestedFinremCaseDetails);
         verify(emailService).sendConfirmationEmail(any(), eq(FR_CONTESTED_GENERAL_EMAIL));
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/FinremNotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/FinremNotificationServiceTest.java
@@ -413,7 +413,8 @@ class FinremNotificationServiceTest {
 
     @Test
     void sendGeneralEmailConsented() {
-        when(finremNotificationRequestMapper.getNotificationRequestForGeneralEmail(consentedFinremCaseDetails)).thenReturn(mock(NotificationRequest.class));
+        when(finremNotificationRequestMapper.getNotificationRequestForGeneralEmail(consentedFinremCaseDetails))
+            .thenReturn(mock(NotificationRequest.class));
 
         notificationService.sendConsentGeneralEmail(consentedFinremCaseDetails, anyString());
 
@@ -427,7 +428,8 @@ class FinremNotificationServiceTest {
         defaultFinremCaseData.getGeneralEmailWrapper()
             .setGeneralEmailUploadedDocument(CaseDocument.builder().documentBinaryUrl("binaryUrl").build());
         FinremCaseDetails caseDetails = getConsentedFinremCaseDetails(defaultFinremCaseData);
-        when(finremNotificationRequestMapper.getNotificationRequestForGeneralEmail(caseDetails)).thenReturn(mock(NotificationRequest.class));
+        when(finremNotificationRequestMapper.getNotificationRequestForGeneralEmail(caseDetails))
+            .thenReturn(mock(NotificationRequest.class));
 
         notificationService.sendConsentGeneralEmail(caseDetails, anyString());
 
@@ -441,7 +443,8 @@ class FinremNotificationServiceTest {
         defaultFinremCaseData.getGeneralEmailWrapper()
             .setGeneralEmailUploadedDocument(CaseDocument.builder().documentBinaryUrl("binaryUrl").build());
         FinremCaseDetails caseDetails = getConsentedFinremCaseDetails(defaultFinremCaseData);
-        when(finremNotificationRequestMapper.getNotificationRequestForGeneralEmail(caseDetails)).thenReturn(mock(NotificationRequest.class));
+        when(finremNotificationRequestMapper.getNotificationRequestForGeneralEmail(caseDetails))
+            .thenReturn(mock(NotificationRequest.class));
         doThrow(HttpClientErrorException.class)
             .when(evidenceManagementDownloadService).getByteArray(any(CaseDocument.class), anyString());
 
@@ -454,7 +457,8 @@ class FinremNotificationServiceTest {
 
     @Test
     void sendGeneralEmailContested() {
-        when(finremNotificationRequestMapper.getNotificationRequestForGeneralEmail(contestedFinremCaseDetails)).thenReturn(mock(NotificationRequest.class));
+        when(finremNotificationRequestMapper.getNotificationRequestForGeneralEmail(contestedFinremCaseDetails))
+            .thenReturn(mock(NotificationRequest.class));
         notificationService.sendContestedGeneralEmail(contestedFinremCaseDetails, anyString());
 
         verify(finremNotificationRequestMapper).getNotificationRequestForGeneralEmail(contestedFinremCaseDetails);

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/NotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/NotificationServiceTest.java
@@ -76,6 +76,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.YES_VALUE;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.TestConstants.AUTH_TOKEN;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.TestConstants.TEST_DIVORCE_CASE_NUMBER;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.TestConstants.TEST_JUDGE_EMAIL;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.TestConstants.TEST_RESP_SOLICITOR_EMAIL;
@@ -1075,9 +1076,11 @@ class NotificationServiceTest {
     @Test
     void shouldSendGeneralEmailWithAttachmentConsented() {
         FinremCaseDetails finremCaseDetails = getFinremCaseDetails(CaseType.CONSENTED);
-        notificationService.sendConsentGeneralEmail(finremCaseDetails, anyString());
+        when(finremNotificationRequestMapper.getNotificationRequestForGeneralEmail(finremCaseDetails)).thenReturn(notificationRequest);
 
-        verify(finremNotificationRequestMapper).getNotificationRequestForApplicantSolicitor(finremCaseDetails);
+        notificationService.sendConsentGeneralEmail(finremCaseDetails, AUTH_TOKEN);
+
+        verify(finremNotificationRequestMapper).getNotificationRequestForGeneralEmail(finremCaseDetails);
         verify(evidenceManagementDownloadService).getByteArray(any(CaseDocument.class), anyString());
         verify(emailService).sendConfirmationEmail(notificationRequest, FR_CONSENT_GENERAL_EMAIL_ATTACHMENT);
     }
@@ -1085,9 +1088,11 @@ class NotificationServiceTest {
     @Test
     void shouldSendGeneralEmailWithAttachmentContested() {
         FinremCaseDetails finremCaseDetails = getFinremCaseDetails(CaseType.CONTESTED);
-        notificationService.sendContestedGeneralEmail(finremCaseDetails, anyString());
+        when(finremNotificationRequestMapper.getNotificationRequestForGeneralEmail(finremCaseDetails)).thenReturn(notificationRequest);
 
-        verify(finremNotificationRequestMapper).getNotificationRequestForApplicantSolicitor(finremCaseDetails);
+        notificationService.sendContestedGeneralEmail(finremCaseDetails, AUTH_TOKEN);
+
+        verify(finremNotificationRequestMapper).getNotificationRequestForGeneralEmail(finremCaseDetails);
         verify(evidenceManagementDownloadService).getByteArray(any(CaseDocument.class), anyString());
         verify(emailService).sendConfirmationEmail(notificationRequest, FR_CONTESTED_GENERAL_EMAIL_ATTACHMENT);
     }

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/NotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/NotificationServiceTest.java
@@ -116,7 +116,6 @@ import static uk.gov.hmcts.reform.finrem.caseorchestration.notifications.domain.
 import static uk.gov.hmcts.reform.finrem.caseorchestration.notifications.domain.EmailTemplateNames.FR_CONSENTED_LIST_FOR_HEARING;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.notifications.domain.EmailTemplateNames.FR_CONSENTED_NOC_CASEWORKER;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.notifications.domain.EmailTemplateNames.FR_CONSENTED_NOTICE_OF_CHANGE;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.notifications.domain.EmailTemplateNames.FR_CONSENT_GENERAL_EMAIL;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.notifications.domain.EmailTemplateNames.FR_CONSENT_GENERAL_EMAIL_ATTACHMENT;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.notifications.domain.EmailTemplateNames.FR_CONSENT_ORDER_AVAILABLE;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.notifications.domain.EmailTemplateNames.FR_CONSENT_ORDER_AVAILABLE_CTSC;
@@ -132,7 +131,6 @@ import static uk.gov.hmcts.reform.finrem.caseorchestration.notifications.domain.
 import static uk.gov.hmcts.reform.finrem.caseorchestration.notifications.domain.EmailTemplateNames.FR_CONTESTED_DRAFT_ORDER_READY_FOR_REVIEW_JUDGE;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.notifications.domain.EmailTemplateNames.FR_CONTESTED_DRAFT_ORDER_REVIEW_OVERDUE;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.notifications.domain.EmailTemplateNames.FR_CONTESTED_GENERAL_APPLICATION_OUTCOME;
-import static uk.gov.hmcts.reform.finrem.caseorchestration.notifications.domain.EmailTemplateNames.FR_CONTESTED_GENERAL_EMAIL;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.notifications.domain.EmailTemplateNames.FR_CONTESTED_GENERAL_EMAIL_ATTACHMENT;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.notifications.domain.EmailTemplateNames.FR_CONTESTED_GENERAL_ORDER;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.notifications.domain.EmailTemplateNames.FR_CONTESTED_GENERAL_ORDER_CONSENT;
@@ -507,24 +505,6 @@ class NotificationServiceTest {
 
         verify(notificationRequestMapper).getNotificationRequestForApplicantSolicitor(callbackRequest.getCaseDetails());
         verify(emailService).sendConfirmationEmail(notificationRequest, FR_CONTESTED_HWF_SUCCESSFUL);
-    }
-
-    @Test
-    void sendGeneralEmailConsented() {
-        CallbackRequest callbackRequest = getConsentedCallbackRequest();
-        notificationService.sendConsentGeneralEmail(callbackRequest.getCaseDetails());
-
-        verify(notificationRequestMapper).getNotificationRequestForApplicantSolicitor(callbackRequest.getCaseDetails());
-        verify(emailService).sendConfirmationEmail(notificationRequest, FR_CONSENT_GENERAL_EMAIL);
-    }
-
-    @Test
-    void sendGeneralEmailContested() {
-        CallbackRequest callbackRequest = getConsentedCallbackRequest();
-        notificationService.sendContestedGeneralEmail(callbackRequest.getCaseDetails());
-
-        verify(notificationRequestMapper).getNotificationRequestForApplicantSolicitor(callbackRequest.getCaseDetails());
-        verify(emailService).sendConfirmationEmail(notificationRequest, FR_CONTESTED_GENERAL_EMAIL);
     }
 
     @Test


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DFR-3915

### Change description

Refactor building general email notification requests.

- Created a separate method for creating the general email notification request - this is a copy of the existing generic method used. By creating a distinct method for general email this can then be subsequently enhanced without impacting other notification requests.
- Refactor NotificationService send contested/consented email by moving common code into a separate method (sendGeneralEmail)