### PR TITLE
DFR-3915: Add NotificationRequestBuilder

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/config/CourtDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/config/CourtDetails.java
@@ -14,4 +14,5 @@ public class CourtDetails {
     private String courtAddress;
     private String phoneNumber;
     private String email;
+    private String emailReplyToId;
 }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/helper/ConsentedApplicationHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/helper/ConsentedApplicationHelper.java
@@ -59,7 +59,7 @@ public class ConsentedApplicationHelper {
         }
     }
 
-    public Boolean isVariationOrder(final FinremCaseData caseData) {
+    public boolean isVariationOrder(final FinremCaseData caseData) {
         List<NatureApplication> natureOfApplicationList = caseData.getNatureApplicationWrapper().getNatureOfApplication2();
         log.info("Nature list {}", natureOfApplicationList);
         return (!CollectionUtils.isEmpty(natureOfApplicationList)

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/mapper/notificationrequest/AbstractNotificationRequestMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/mapper/notificationrequest/AbstractNotificationRequestMapper.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.reform.finrem.caseorchestration.mapper.notificationrequest;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+class AbstractNotificationRequestMapper {
+
+    private final NotificationRequestBuilderFactory builderFactory;
+
+    /**
+     * Creates a new instance of {@link NotificationRequestBuilder} to build
+     * {@link uk.gov.hmcts.reform.finrem.caseorchestration.model.notification.NotificationRequest}.
+     * @return a new instance of {@link NotificationRequestBuilder}
+     */
+    protected NotificationRequestBuilder notificationRequestBuilder() {
+        return builderFactory.newInstance();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/mapper/notificationrequest/NotificationRequestBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/mapper/notificationrequest/NotificationRequestBuilder.java
@@ -92,7 +92,7 @@ public class NotificationRequestBuilder {
             setConsentedDefaults(caseData);
         }
 
-        if (caseDetails.getData().isContestedApplication()) {
+        if (caseData.isContestedApplication()) {
             setContestedDefaults(caseDetails);
         }
 

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/mapper/notificationrequest/NotificationRequestBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/mapper/notificationrequest/NotificationRequestBuilder.java
@@ -1,0 +1,347 @@
+package uk.gov.hmcts.reform.finrem.caseorchestration.mapper.notificationrequest;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.finrem.caseorchestration.config.CourtDetailsConfiguration;
+import uk.gov.hmcts.reform.finrem.caseorchestration.helper.ConsentedApplicationHelper;
+import uk.gov.hmcts.reform.finrem.caseorchestration.helper.CourtHelper;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CaseType;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.FinremCaseData;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.FinremCaseDetails;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.notification.NotificationRequest;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.wrapper.SolicitorCaseDataKeysWrapper;
+import uk.gov.hmcts.reform.finrem.caseorchestration.notifications.service.EmailService;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.CTSC_OPENING_HOURS;
+
+@Component
+@Scope(value = "prototype")
+@RequiredArgsConstructor
+public class NotificationRequestBuilder {
+
+    private final CourtDetailsConfiguration courtDetailsConfiguration;
+    private final ConsentedApplicationHelper consentedApplicationHelper;
+
+    private String caseReferenceNumber;
+    private String solicitorReferenceNumber;
+    private String divorceCaseNumber;
+    private String name;
+    private String notificationEmail;
+    private String selectedCourt;
+    private String caseType;
+    private String generalEmailBody;
+    private String phoneOpeningHours;
+    private String caseOrderType;
+    private String camelCaseOrderType;
+    private String generalApplicationRejectionReason;
+    private String applicantName;
+    private String respondentName;
+    private String barristerReferenceNumber;
+    private String hearingType;
+    private String intervenerSolicitorReferenceNumber;
+    private String intervenerFullName;
+    private String intervenerSolicitorFirm;
+    private byte[] documentContents;
+    private Boolean isNotDigital;
+    private String hearingDate;
+    private String judgeName;
+    private String oldestDraftOrderDate;
+    private String judgeFeedback;
+    private String documentName;
+    private String contactCourtName;
+    private String contactCourtEmail;
+    private String emailReplyToId;
+
+    /**
+     * Sets default values for the NotificationRequestBuilder based on the provided case details.
+     * This method sets the following fields:
+     * <ul>
+     * <li>applicantName</li>
+     * <li>camelCaseOrderType</li>
+     * <li>caseOrderType</li>
+     * <li>caseReferenceNumber</li>
+     * <li>caseType</li>
+     * <li>contactCourtName</li>
+     * <li>contactCourtEmail</li>
+     * <li>divorceCaseNumber</li>
+     * <li>emailReplyToId</li>
+     * <li>phoneOpeningHours</li>
+     * <li>respondentName</li>
+     * <li>selectedCourt</li>
+     * </ul>
+     *
+     * @param caseDetails the case details
+     * @return the NotificationRequestBuilder instance with default values set
+     */
+    public NotificationRequestBuilder withCaseDefaults(FinremCaseDetails caseDetails) {
+        FinremCaseData caseData = caseDetails.getData();
+
+        caseReferenceNumber = String.valueOf(caseDetails.getId());
+        applicantName = caseData.getFullApplicantName();
+        caseType = CaseType.CONTESTED.equals(caseDetails.getCaseType()) ? EmailService.CONTESTED : EmailService.CONSENTED;
+        divorceCaseNumber = caseData.getDivorceCaseNumber();
+        phoneOpeningHours = CTSC_OPENING_HOURS;
+        addSelectedCourtDetails(caseData);
+
+        if (caseData.isConsentedApplication()) {
+            setConsentedDefaults(caseData);
+        }
+
+        if (caseDetails.getData().isContestedApplication()) {
+            setContestedDefaults(caseDetails);
+        }
+
+        return this;
+    }
+
+    private void addSelectedCourtDetails(FinremCaseData caseData) {
+        Optional.ofNullable(caseData.getSelectedAllocatedCourt())
+            .map(courtDetailsConfiguration.getCourts()::get)
+            .ifPresent(court -> {
+                contactCourtName = court.getCourtName();
+                contactCourtEmail = court.getEmail();
+                emailReplyToId = court.getEmailReplyToId();
+            });
+    }
+
+    private void setContestedDefaults(FinremCaseDetails caseDetails) {
+        respondentName = caseDetails.getData().getRespondentFullName();
+        selectedCourt = CourtHelper.getSelectedFrc(caseDetails);
+    }
+
+    private void setConsentedDefaults(FinremCaseData caseData) {
+        respondentName = caseData.getFullRespondentNameConsented();
+
+        if (consentedApplicationHelper.isVariationOrder(caseData)) {
+            caseOrderType = "variation";
+        } else {
+            caseOrderType = "consent";
+        }
+        camelCaseOrderType = StringUtils.capitalize(caseOrderType);
+    }
+
+    /**
+     * Sets the notification email destination to the court's email based on the selected allocated court in the case details.
+     *
+     * @param caseDetails the case details
+     * @return the NotificationRequestBuilder instance
+     */
+    public NotificationRequestBuilder withCourtAsEmailDestination(FinremCaseDetails caseDetails) {
+        String selectedAllocatedCourt = caseDetails.getData().getSelectedAllocatedCourt();
+        notificationEmail = courtDetailsConfiguration.getCourts().get(selectedAllocatedCourt).getEmail();
+
+        return this;
+    }
+
+    /**
+     * Sets solicitor-related fields in the NotificationRequestBuilder using the provided solicitor case data.
+     * This method sets the following fields:
+     * <ul>
+     * <li>isNotDigital</li>
+     * <li>name</li>
+     * <li>notificationEmail</li>
+     * <li>solicitorReferenceNumber</li>
+     * </ul>
+     *
+     * @param solicitorCaseData the solicitor case data wrapper
+     * @return the NotificationRequestBuilder instance with solicitor data set
+     */
+    public NotificationRequestBuilder withSolicitorCaseData(SolicitorCaseDataKeysWrapper solicitorCaseData) {
+        solicitorReferenceNumber = Objects.toString(solicitorCaseData.getSolicitorReferenceKey(), "");
+        name = Objects.toString(solicitorCaseData.getSolicitorNameKey(), "");
+        notificationEmail = Objects.toString(solicitorCaseData.getSolicitorEmailKey(), "");
+        isNotDigital = solicitorCaseData.getSolicitorIsNotDigitalKey();
+
+        return this;
+    }
+
+    /**
+     * Builds a NotificationRequest object using the values set in the builder.
+     *
+     * @return a NotificationRequest
+     */
+    public NotificationRequest build() {
+        NotificationRequest notificationRequest = new NotificationRequest();
+        notificationRequest.setCaseReferenceNumber(caseReferenceNumber);
+        notificationRequest.setSolicitorReferenceNumber(solicitorReferenceNumber);
+        notificationRequest.setDivorceCaseNumber(divorceCaseNumber);
+        notificationRequest.setName(name);
+        notificationRequest.setNotificationEmail(notificationEmail);
+        notificationRequest.setSelectedCourt(selectedCourt);
+        notificationRequest.setCaseType(caseType);
+        notificationRequest.setGeneralEmailBody(generalEmailBody);
+        notificationRequest.setPhoneOpeningHours(phoneOpeningHours);
+        notificationRequest.setCaseOrderType(caseOrderType);
+        notificationRequest.setCamelCaseOrderType(camelCaseOrderType);
+        notificationRequest.setGeneralApplicationRejectionReason(generalApplicationRejectionReason);
+        notificationRequest.setApplicantName(applicantName);
+        notificationRequest.setRespondentName(respondentName);
+        notificationRequest.setBarristerReferenceNumber(barristerReferenceNumber);
+        notificationRequest.setHearingType(hearingType);
+        notificationRequest.setIntervenerSolicitorReferenceNumber(intervenerSolicitorReferenceNumber);
+        notificationRequest.setIntervenerFullName(intervenerFullName);
+        notificationRequest.setIntervenerSolicitorFirm(intervenerSolicitorFirm);
+        notificationRequest.setDocumentContents(documentContents);
+        notificationRequest.setIsNotDigital(isNotDigital);
+        notificationRequest.setHearingDate(hearingDate);
+        notificationRequest.setJudgeName(judgeName);
+        notificationRequest.setOldestDraftOrderDate(oldestDraftOrderDate);
+        notificationRequest.setJudgeFeedback(judgeFeedback);
+        notificationRequest.setDocumentName(documentName);
+        notificationRequest.setContactCourtName(contactCourtName);
+        notificationRequest.setContactCourtEmail(contactCourtEmail);
+        notificationRequest.setEmailReplyToId(emailReplyToId);
+
+        return notificationRequest;
+    }
+
+    public NotificationRequestBuilder caseReferenceNumber(String caseReferenceNumber) {
+        this.caseReferenceNumber = caseReferenceNumber;
+        return this;
+    }
+
+    public NotificationRequestBuilder solicitorReferenceNumber(String solicitorReferenceNumber) {
+        this.solicitorReferenceNumber = solicitorReferenceNumber;
+        return this;
+    }
+
+    public NotificationRequestBuilder divorceCaseNumber(String divorceCaseNumber) {
+        this.divorceCaseNumber = divorceCaseNumber;
+        return this;
+    }
+
+    public NotificationRequestBuilder name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public NotificationRequestBuilder notificationEmail(String notificationEmail) {
+        this.notificationEmail = notificationEmail;
+        return this;
+    }
+
+    public NotificationRequestBuilder selectedCourt(String selectedCourt) {
+        this.selectedCourt = selectedCourt;
+        return this;
+    }
+
+    public NotificationRequestBuilder caseType(String caseType) {
+        this.caseType = caseType;
+        return this;
+    }
+
+    public NotificationRequestBuilder generalEmailBody(String generalEmailBody) {
+        this.generalEmailBody = generalEmailBody;
+        return this;
+    }
+
+    public NotificationRequestBuilder phoneOpeningHours(String phoneOpeningHours) {
+        this.phoneOpeningHours = phoneOpeningHours;
+        return this;
+    }
+
+    public NotificationRequestBuilder caseOrderType(String caseOrderType) {
+        this.caseOrderType = caseOrderType;
+        return this;
+    }
+
+    public NotificationRequestBuilder camelCaseOrderType(String camelCaseOrderType) {
+        this.camelCaseOrderType = camelCaseOrderType;
+        return this;
+    }
+
+    public NotificationRequestBuilder generalApplicationRejectionReason(String generalApplicationRejectionReason) {
+        this.generalApplicationRejectionReason = generalApplicationRejectionReason;
+        return this;
+    }
+
+    public NotificationRequestBuilder applicantName(String applicantName) {
+        this.applicantName = applicantName;
+        return this;
+    }
+
+    public NotificationRequestBuilder respondentName(String respondentName) {
+        this.respondentName = respondentName;
+        return this;
+    }
+
+    public NotificationRequestBuilder barristerReferenceNumber(String barristerReferenceNumber) {
+        this.barristerReferenceNumber = barristerReferenceNumber;
+        return this;
+    }
+
+    public NotificationRequestBuilder hearingType(String hearingType) {
+        this.hearingType = hearingType;
+        return this;
+    }
+
+    public NotificationRequestBuilder intervenerSolicitorReferenceNumber(String intervenerSolicitorReferenceNumber) {
+        this.intervenerSolicitorReferenceNumber = intervenerSolicitorReferenceNumber;
+        return this;
+    }
+
+    public NotificationRequestBuilder intervenerFullName(String intervenerFullName) {
+        this.intervenerFullName = intervenerFullName;
+        return this;
+    }
+
+    public NotificationRequestBuilder intervenerSolicitorFirm(String intervenerSolicitorFirm) {
+        this.intervenerSolicitorFirm = intervenerSolicitorFirm;
+        return this;
+    }
+
+    public NotificationRequestBuilder documentContents(byte[] documentContents) {
+        this.documentContents = documentContents;
+        return this;
+    }
+
+    public NotificationRequestBuilder isNotDigital(Boolean isNotDigital) {
+        this.isNotDigital = isNotDigital;
+        return this;
+    }
+
+    public NotificationRequestBuilder hearingDate(String hearingDate) {
+        this.hearingDate = hearingDate;
+        return this;
+    }
+
+    public NotificationRequestBuilder judgeName(String judgeName) {
+        this.judgeName = judgeName;
+        return this;
+    }
+
+    public NotificationRequestBuilder oldestDraftOrderDate(String oldestDraftOrderDate) {
+        this.oldestDraftOrderDate = oldestDraftOrderDate;
+        return this;
+    }
+
+    public NotificationRequestBuilder judgeFeedback(String judgeFeedback) {
+        this.judgeFeedback = judgeFeedback;
+        return this;
+    }
+
+    public NotificationRequestBuilder documentName(String documentName) {
+        this.documentName = documentName;
+        return this;
+    }
+
+    public NotificationRequestBuilder contactCourtName(String contactCourtName) {
+        this.contactCourtName = contactCourtName;
+        return this;
+    }
+
+    public NotificationRequestBuilder contactCourtEmail(String contactCourtEmail) {
+        this.contactCourtEmail = contactCourtEmail;
+        return this;
+    }
+
+    public NotificationRequestBuilder emailReplyToId(String emailReplyToId) {
+        this.emailReplyToId = emailReplyToId;
+        return this;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/mapper/notificationrequest/NotificationRequestBuilderFactory.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/mapper/notificationrequest/NotificationRequestBuilderFactory.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.finrem.caseorchestration.mapper.notificationrequest;
 
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.stereotype.Service;

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/mapper/notificationrequest/NotificationRequestBuilderFactory.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/mapper/notificationrequest/NotificationRequestBuilderFactory.java
@@ -1,0 +1,23 @@
+package uk.gov.hmcts.reform.finrem.caseorchestration.mapper.notificationrequest;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationRequestBuilderFactory {
+
+    private final ObjectProvider<NotificationRequestBuilder> builderProvider;
+
+    /**
+     * Creates a new instance of {@link NotificationRequestBuilder} to build
+     * {@link uk.gov.hmcts.reform.finrem.caseorchestration.model.notification.NotificationRequest}.
+     * This method is used to ensure that each NotificationRequest can be built independently without side effects.
+     * @return a new instance of {@link NotificationRequestBuilder}
+     */
+    public NotificationRequestBuilder newInstance() {
+        return builderProvider.getObject();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/notification/NotificationRequest.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/notification/NotificationRequest.java
@@ -65,5 +65,7 @@ public class NotificationRequest {
     private String judgeFeedback;
     @JsonProperty("documentName")
     private String documentName;
+    private String contactCourtName;
+    private String contactCourtEmail;
     private String emailReplyToId;
 }

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/mapper/CourtDetailsMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/mapper/CourtDetailsMapperTest.java
@@ -238,7 +238,8 @@ class CourtDetailsMapperTest {
         // Mocking the court details map
         when(courtDetailsConfiguration.getCourts()).thenReturn(Map.of(
             "FR_s_CFCList_2", new CourtDetails("Croydon County Court And Family Court",
-                "Croydon County Court, Altyre Road, Croydon, CR9 5AB", "0300 123 5577", "FRCLondon@justice.gov.uk")
+                "Croydon County Court, Altyre Road, Croydon, CR9 5AB", "0300 123 5577",
+                "FRCLondon@justice.gov.uk", "42b18e70-18e8-4290-bb85-9c5254548345")
         ));
 
         // Setting up the test data
@@ -263,6 +264,7 @@ class CourtDetailsMapperTest {
         assertEquals("Croydon County Court, Altyre Road, Croydon, CR9 5AB", courtDetails.getCourtAddress());
         assertEquals("FRCLondon@justice.gov.uk", courtDetails.getEmail());
         assertEquals("0300 123 5577", courtDetails.getPhoneNumber());
+        assertEquals("42b18e70-18e8-4290-bb85-9c5254548345", courtDetails.getEmailReplyToId());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/mapper/notificationrequest/NotificationRequestBuilderFactoryTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/mapper/notificationrequest/NotificationRequestBuilderFactoryTest.java
@@ -7,7 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-class NotificationsRequestBuilderFactoryTest {
+class NotificationRequestBuilderFactoryTest {
 
     @Test
     void testNewInstance() {

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/mapper/notificationrequest/NotificationRequestBuilderFactoryTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/mapper/notificationrequest/NotificationRequestBuilderFactoryTest.java
@@ -1,0 +1,23 @@
+package uk.gov.hmcts.reform.finrem.caseorchestration.mapper.notificationrequest;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class NotificationsRequestBuilderFactoryTest {
+
+    @Test
+    void testNewInstance() {
+        @SuppressWarnings("unchecked")
+        ObjectProvider<NotificationRequestBuilder> builderProvider = mock(ObjectProvider.class);
+        when(builderProvider.getObject()).thenReturn(mock(NotificationRequestBuilder.class));
+        NotificationRequestBuilderFactory factory = new NotificationRequestBuilderFactory(builderProvider);
+
+        NotificationRequestBuilder builder = factory.newInstance();
+
+        assertThat(builder).isInstanceOf(NotificationRequestBuilder.class);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/mapper/notificationrequest/NotificationRequestBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/mapper/notificationrequest/NotificationRequestBuilderTest.java
@@ -1,0 +1,272 @@
+package uk.gov.hmcts.reform.finrem.caseorchestration.mapper.notificationrequest;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.finrem.caseorchestration.config.CourtDetails;
+import uk.gov.hmcts.reform.finrem.caseorchestration.config.CourtDetailsConfiguration;
+import uk.gov.hmcts.reform.finrem.caseorchestration.helper.ConsentedApplicationHelper;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CaseType;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.FinremCaseData;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.FinremCaseDetails;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.NorthWalesCourt;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.Region;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.wrapper.AllocatedRegionWrapper;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.wrapper.ContactDetailsWrapper;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.wrapper.DefaultCourtListWrapper;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.wrapper.RegionWrapper;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.notification.NotificationRequest;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.wrapper.SolicitorCaseDataKeysWrapper;
+import uk.gov.hmcts.reform.finrem.caseorchestration.notifications.service.EmailService;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.OrchestrationConstants.CTSC_OPENING_HOURS;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CCDConfigConstant.CAERNARFON;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.RegionWalesFrc.NORTH_WALES;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationRequestBuilderTest {
+
+    @InjectMocks
+    private NotificationRequestBuilder builder;
+    @Mock
+    private CourtDetailsConfiguration courtDetailsConfiguration;
+    @Mock
+    private ConsentedApplicationHelper consentedApplicationHelper;
+
+    @Test
+    void givenConsentedCase_whenWithCaseDefaults_thenCaseDetailsPopulated() {
+        mockCourtDetailsConfiguration();
+        mockConsentedVariationOrder(false);
+        FinremCaseDetails caseDetails = createConsentedCase();
+
+        NotificationRequest notificationRequest = builder
+            .withCaseDefaults(caseDetails)
+            .build();
+
+        assertThat(notificationRequest.getApplicantName()).isEqualTo("Doris Duck");
+        assertThat(notificationRequest.getCamelCaseOrderType()).isEqualTo("Consent");
+        assertThat(notificationRequest.getCaseOrderType()).isEqualTo("consent");
+        assertThat(notificationRequest.getCaseReferenceNumber()).isEqualTo("3456865498462385");
+        assertThat(notificationRequest.getCaseType()).isEqualTo(EmailService.CONSENTED);
+        assertThat(notificationRequest.getContactCourtName()).isEqualTo("Test Court");
+        assertThat(notificationRequest.getContactCourtEmail()).isEqualTo("test.court@test.com");
+        assertThat(notificationRequest.getDivorceCaseNumber()).isEqualTo("3657-4535-2355-7545");
+        assertThat(notificationRequest.getEmailReplyToId()).isEqualTo("3f6a1cd4-812a-48d6-8fd9-067bf4884fd2");
+        assertThat(notificationRequest.getPhoneOpeningHours()).isEqualTo(CTSC_OPENING_HOURS);
+        assertThat(notificationRequest.getRespondentName()).isEqualTo("Davey Duck");
+        assertThat(notificationRequest.getSelectedCourt()).isNull();
+    }
+
+    @Test
+    void givenConsentedVariationOrderCase_whenWithCaseDefaults_thenCaseDetailsPopulated() {
+        mockCourtDetailsConfiguration();
+        mockConsentedVariationOrder(true);
+        FinremCaseDetails caseDetails = createConsentedCase();
+
+        NotificationRequest notificationRequest = builder
+            .withCaseDefaults(caseDetails)
+            .build();
+
+        assertThat(notificationRequest.getApplicantName()).isEqualTo("Doris Duck");
+        assertThat(notificationRequest.getCamelCaseOrderType()).isEqualTo("Variation");
+        assertThat(notificationRequest.getCaseOrderType()).isEqualTo("variation");
+        assertThat(notificationRequest.getCaseReferenceNumber()).isEqualTo("3456865498462385");
+        assertThat(notificationRequest.getCaseType()).isEqualTo(EmailService.CONSENTED);
+        assertThat(notificationRequest.getContactCourtName()).isEqualTo("Test Court");
+        assertThat(notificationRequest.getContactCourtEmail()).isEqualTo("test.court@test.com");
+        assertThat(notificationRequest.getDivorceCaseNumber()).isEqualTo("3657-4535-2355-7545");
+        assertThat(notificationRequest.getEmailReplyToId()).isEqualTo("3f6a1cd4-812a-48d6-8fd9-067bf4884fd2");
+        assertThat(notificationRequest.getPhoneOpeningHours()).isEqualTo(CTSC_OPENING_HOURS);
+        assertThat(notificationRequest.getRespondentName()).isEqualTo("Davey Duck");
+        assertThat(notificationRequest.getSelectedCourt()).isNull();
+    }
+
+    @Test
+    void givenContestedCase_whenWithDefaults_thenCaseDetailsPopulated() {
+        mockCourtDetailsConfiguration();
+        FinremCaseDetails caseDetails = createContestedCase();
+
+        NotificationRequest notificationRequest = builder
+            .withCaseDefaults(caseDetails)
+            .build();
+
+        assertThat(notificationRequest.getApplicantName()).isEqualTo("Doris Duck");
+        assertThat(notificationRequest.getCamelCaseOrderType()).isNull();
+        assertThat(notificationRequest.getCaseOrderType()).isNull();
+        assertThat(notificationRequest.getCaseReferenceNumber()).isEqualTo("3456865498462385");
+        assertThat(notificationRequest.getCaseType()).isEqualTo(EmailService.CONTESTED);
+        assertThat(notificationRequest.getContactCourtName()).isEqualTo("Test Court");
+        assertThat(notificationRequest.getContactCourtEmail()).isEqualTo("test.court@test.com");
+        assertThat(notificationRequest.getDivorceCaseNumber()).isEqualTo("3657-4535-2355-7545");
+        assertThat(notificationRequest.getEmailReplyToId()).isEqualTo("3f6a1cd4-812a-48d6-8fd9-067bf4884fd2");
+        assertThat(notificationRequest.getPhoneOpeningHours()).isEqualTo(CTSC_OPENING_HOURS);
+        assertThat(notificationRequest.getRespondentName()).isEqualTo("Davey Duck");
+        assertThat(notificationRequest.getSelectedCourt()).isEqualTo(NORTH_WALES.getValue());
+    }
+
+    @Test
+    void givenAllPropertiesSet_whenBuild_thenAllPropertiesPopulated() {
+        byte[] documentContents = {1, 2, 3};
+        NotificationRequest notificationRequest = builder
+            .caseReferenceNumber("123456789")
+            .solicitorReferenceNumber("SOL123")
+            .divorceCaseNumber("DIV123")
+            .name("John Doe")
+            .notificationEmail("john.doe@example.com")
+            .selectedCourt("London Court")
+            .caseType("consented")
+            .generalEmailBody("Email body")
+            .phoneOpeningHours("9-5")
+            .caseOrderType("Consent Order")
+            .camelCaseOrderType("ConsentOrder")
+            .generalApplicationRejectionReason("Missing docs")
+            .applicantName("Jane Smith")
+            .respondentName("Richard Roe")
+            .barristerReferenceNumber("BAR123")
+            .hearingType("Directions")
+            .intervenerSolicitorReferenceNumber("INT123")
+            .intervenerFullName("Intervener Name")
+            .intervenerSolicitorFirm("Intervener Firm")
+            .documentContents(documentContents)
+            .isNotDigital(Boolean.TRUE)
+            .hearingDate("2024-06-01")
+            .judgeName("Judge Judy")
+            .oldestDraftOrderDate("2024-05-01")
+            .judgeFeedback("Approved")
+            .documentName("Order.pdf")
+            .contactCourtEmail("test.court@test.net")
+            .contactCourtName("Local Court")
+            .emailReplyToId("909cb736-eab0-46ac-a7f0-d28d89c8950c")
+            .build();
+
+        // Assert all fields are non-null
+        String[] fieldNames = Arrays.stream(NotificationRequest.class.getDeclaredFields())
+            .map(Field::getName)
+            .toArray(String[]::new);
+
+        assertThat(notificationRequest)
+            .extracting(fieldNames)
+            .doesNotContainNull();
+
+        // For array fields, check content equality
+        assertThat(notificationRequest.getDocumentContents()).isEqualTo(documentContents);
+    }
+
+    @Test
+    void givenSolicitorData_whenWithSolicitorCaseData_thenSolicitorDetailsPopulated() {
+        SolicitorCaseDataKeysWrapper solicitorCaseData = SolicitorCaseDataKeysWrapper.builder()
+            .solicitorEmailKey("sol@test.com")
+            .solicitorNameKey("Stella Artois")
+            .solicitorReferenceKey("DGEE34343")
+            .solicitorIsNotDigitalKey(true)
+            .build();
+
+        NotificationRequest notificationRequest = builder
+            .withSolicitorCaseData(solicitorCaseData)
+            .build();
+
+        assertThat(notificationRequest.getName()).isEqualTo("Stella Artois");
+        assertThat(notificationRequest.getNotificationEmail()).isEqualTo("sol@test.com");
+        assertThat(notificationRequest.getSolicitorReferenceNumber()).isEqualTo("DGEE34343");
+        assertThat(notificationRequest.getIsNotDigital()).isTrue();
+    }
+
+    @Test
+    void givenMissingSolicitorData_whenWithSolicitorCaseData_thenSolicitorDetailsNotPopulated() {
+        SolicitorCaseDataKeysWrapper solicitorCaseData = SolicitorCaseDataKeysWrapper.builder()
+            .build();
+
+        NotificationRequest notificationRequest = builder
+            .withSolicitorCaseData(solicitorCaseData)
+            .build();
+
+        assertThat(notificationRequest.getName()).isEmpty();
+        assertThat(notificationRequest.getNotificationEmail()).isEmpty();
+        assertThat(notificationRequest.getSolicitorReferenceNumber()).isEmpty();
+        assertThat(notificationRequest.getIsNotDigital()).isNull();
+    }
+
+    @Test
+    void givenCase_whenWithCourtAsEmailDestination_thenNotificationEmailPopulated() {
+        mockCourtDetailsConfiguration();
+        FinremCaseDetails caseDetails = createContestedCase();
+
+        NotificationRequest notificationRequest = builder
+            .withCourtAsEmailDestination(caseDetails)
+            .build();
+
+        assertThat(notificationRequest.getNotificationEmail()).isEqualTo("test.court@test.com");
+    }
+
+    private FinremCaseDetails createConsentedCase() {
+        FinremCaseData caseData = FinremCaseData.builder()
+            .regionWrapper(createRegionWrapper())
+            .contactDetailsWrapper(ContactDetailsWrapper.builder()
+                .applicantFmName("Doris")
+                .applicantLname("Duck")
+                .appRespondentFmName("Davey")
+                .appRespondentLName("Duck")
+                .build())
+            .ccdCaseType(CaseType.CONSENTED)
+            .divorceCaseNumber("3657-4535-2355-7545")
+            .build();
+        return FinremCaseDetails.builder()
+            .id(3456865498462385L)
+            .caseType(CaseType.CONSENTED)
+            .data(caseData)
+            .build();
+    }
+
+    private FinremCaseDetails createContestedCase() {
+        FinremCaseData caseData = FinremCaseData.builder()
+            .regionWrapper(createRegionWrapper())
+            .contactDetailsWrapper(ContactDetailsWrapper.builder()
+                .applicantFmName("Doris")
+                .applicantLname("Duck")
+                .respondentFmName("Davey")
+                .respondentLname("Duck")
+                .build())
+            .ccdCaseType(CaseType.CONTESTED)
+            .divorceCaseNumber("3657-4535-2355-7545")
+            .build();
+        return FinremCaseDetails.builder()
+            .id(3456865498462385L)
+            .caseType(CaseType.CONTESTED)
+            .data(caseData)
+            .build();
+    }
+
+    private RegionWrapper createRegionWrapper() {
+        return RegionWrapper.builder()
+            .allocatedRegionWrapper(AllocatedRegionWrapper.builder()
+                .regionList(Region.WALES)
+                .walesFrcList(NORTH_WALES)
+                .courtListWrapper(DefaultCourtListWrapper.builder()
+                    .northWalesCourtList(NorthWalesCourt.CAERNARFON)
+                    .build())
+                .build())
+            .build();
+    }
+
+    private void mockCourtDetailsConfiguration() {
+        CourtDetails courtDetails = CourtDetails.builder()
+            .courtName("Test Court")
+            .email("test.court@test.com")
+            .emailReplyToId("3f6a1cd4-812a-48d6-8fd9-067bf4884fd2")
+            .build();
+        when(courtDetailsConfiguration.getCourts()).thenReturn(Map.of(CAERNARFON, courtDetails));
+    }
+
+    private void mockConsentedVariationOrder(boolean variationOrder) {
+        when(consentedApplicationHelper.isVariationOrder(any(FinremCaseData.class))).thenReturn(variationOrder);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/notifications/domain/NotificationRequestTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/notifications/domain/NotificationRequestTest.java
@@ -22,7 +22,8 @@ class NotificationRequestTest {
             "nottingham", CONTESTED, "body", PHONE_OPENING_HOURS, "consent",
             "Consent",
             "rejectedReason", "app", "res", "1234567890", "", "", "", "", null, null,
-            "2024-01-01", "judgeName", "2024-01-01", "Feedback by Mr. judge", "ABC.doc", emailReplyToId);
+            "2024-01-01", "judgeName", "2024-01-01", "Feedback by Mr. judge", "ABC.doc",
+            "A Court Name", "test@test.com", emailReplyToId);
         assertEquals("123456", underTest.getCaseReferenceNumber());
         assertEquals("45623", underTest.getSolicitorReferenceNumber());
         assertEquals("D123", underTest.getDivorceCaseNumber());
@@ -41,6 +42,8 @@ class NotificationRequestTest {
         assertEquals("2024-01-01", underTest.getOldestDraftOrderDate());
         assertEquals("Feedback by Mr. judge", underTest.getJudgeFeedback());
         assertEquals("ABC.doc", underTest.getDocumentName());
+        assertEquals("A Court Name", underTest.getContactCourtName());
+        assertEquals("test@test.com", underTest.getContactCourtEmail());
         assertEquals(emailReplyToId, underTest.getEmailReplyToId());
     }
 


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DFR-3915

### Change description

This PR does not change any functionality.

- Add NotificationRequestBuilder that enables NotificationRequest objects to be created using Spring beans.
- The builder needs to be created as a Spring prototype bean so that it can store state whilst the NotificationRequest is being built.
- NotificationRequestBuilderFactory is used to create builder instances.
- Add in fields to CourtDetails and NotificationRequest that will be used in subsequent PR to populate email data

### Testing done

Tested that emails still send
