### PR TITLE
DFR-3836: Handle email failures

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/notifications/service/EmailService.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/notifications/service/EmailService.java
@@ -28,6 +28,7 @@ import static org.apache.commons.lang3.ObjectUtils.isEmpty;
 public class EmailService {
 
     protected final EmailClient emailClient;
+    private final NotificationClientExceptionResolver notificationClientExceptionResolver;
 
     @Value("#{${uk.gov.notify.email.templates}}")
     private Map<String, String> emailTemplates;
@@ -213,6 +214,7 @@ public class EmailService {
             log.info("Sending email success. Reference ID: {}", referenceId);
         } catch (NotificationClientException e) {
             log.warn("Failed to send email. Reference ID: {}. Reason:", referenceId, e);
+            notificationClientExceptionResolver.resolve(e);
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/notifications/service/LocalEmailService.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/notifications/service/LocalEmailService.java
@@ -20,8 +20,8 @@ import java.util.Map;
 public class LocalEmailService extends EmailService {
 
     @Autowired
-    public LocalEmailService(EmailClient emailClient) {
-        super(emailClient);
+    public LocalEmailService(EmailClient emailClient, NotificationClientExceptionResolver exceptionResolver) {
+        super(emailClient, exceptionResolver);
     }
 
     /**

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/notifications/service/NotificationClientExceptionResolver.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/notifications/service/NotificationClientExceptionResolver.java
@@ -1,0 +1,27 @@
+package uk.gov.hmcts.reform.finrem.caseorchestration.notifications.service;
+
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.finrem.caseorchestration.notifications.service.exceptions.InvalidEmailAddressException;
+import uk.gov.hmcts.reform.finrem.caseorchestration.notifications.service.exceptions.SendEmailException;
+import uk.gov.service.notify.NotificationClientException;
+
+@Service
+public class NotificationClientExceptionResolver {
+
+    /**
+     * Resolves NotificationClientException to more specific exceptions.
+     *
+     * @param exception the NotificationClientException to resolve
+     */
+    public void resolve(NotificationClientException exception) {
+        if (isInvalidEmailError(exception)) {
+            throw new InvalidEmailAddressException(exception);
+        } else {
+            throw new SendEmailException(exception);
+        }
+    }
+
+    private boolean isInvalidEmailError(NotificationClientException exception) {
+        return exception.getHttpResult() == 400 && exception.getMessage().contains("email_address Not a valid email address");
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/notifications/service/exceptions/InvalidEmailAddressException.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/notifications/service/exceptions/InvalidEmailAddressException.java
@@ -1,0 +1,9 @@
+package uk.gov.hmcts.reform.finrem.caseorchestration.notifications.service.exceptions;
+
+import uk.gov.service.notify.NotificationClientException;
+
+public class InvalidEmailAddressException extends RuntimeException {
+    public InvalidEmailAddressException(NotificationClientException exception) {
+        super(exception);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/notifications/service/exceptions/SendEmailException.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/notifications/service/exceptions/SendEmailException.java
@@ -1,0 +1,9 @@
+package uk.gov.hmcts.reform.finrem.caseorchestration.notifications.service.exceptions;
+
+import uk.gov.service.notify.NotificationClientException;
+
+public class SendEmailException extends RuntimeException {
+    public SendEmailException(NotificationClientException exception) {
+        super(exception);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/notifications/service/EmailServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/notifications/service/EmailServiceTest.java
@@ -19,6 +19,8 @@ import uk.gov.hmcts.reform.finrem.caseorchestration.CaseOrchestrationApplication
 import uk.gov.hmcts.reform.finrem.caseorchestration.integrationtest.IntegrationTest;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.notification.NotificationRequest;
 import uk.gov.hmcts.reform.finrem.caseorchestration.notifications.client.EmailClient;
+import uk.gov.hmcts.reform.finrem.caseorchestration.notifications.service.exceptions.InvalidEmailAddressException;
+import uk.gov.hmcts.reform.finrem.caseorchestration.notifications.service.exceptions.SendEmailException;
 import uk.gov.service.notify.NotificationClientException;
 
 import java.util.Map;
@@ -26,7 +28,9 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -795,6 +799,24 @@ public class EmailServiceTest {
 
         Map<String, Object> actualTemplateFields = templateFieldsArgumentCaptor.getValue();
         expectedTemplateFields.forEach((k, v) -> assertEquals(v, actualTemplateFields.get(k)));
+    }
+
+    @Test
+    public void givenInvalidEmail_whenSendEmail_thenExceptionThrown() throws NotificationClientException {
+        doThrow(new NotificationClientException("email_address Not a valid email address"))
+            .when(mockClient).sendEmail(any(), any(), any(), any(), any());
+
+        assertThrows(InvalidEmailAddressException.class,
+            () -> emailService.sendConfirmationEmail(notificationRequest, FR_HWF_SUCCESSFUL));
+    }
+
+    @Test
+    public void givenSendEmailError_whenSendEmail_thenExceptionThrown() throws NotificationClientException {
+        doThrow(new NotificationClientException("Internal Server Error"))
+            .when(mockClient).sendEmail(any(), any(), any(), any(), any());
+
+        assertThrows(SendEmailException.class,
+            () -> emailService.sendConfirmationEmail(notificationRequest, FR_HWF_SUCCESSFUL));
     }
 
     private void assertContestedTemplateVariablesAreAbsent(Map<String, Object> returnedTemplateVars) {

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/notifications/service/NotificationClientExceptionResolverTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/notifications/service/NotificationClientExceptionResolverTest.java
@@ -1,0 +1,56 @@
+package uk.gov.hmcts.reform.finrem.caseorchestration.notifications.service;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.finrem.caseorchestration.notifications.service.exceptions.InvalidEmailAddressException;
+import uk.gov.hmcts.reform.finrem.caseorchestration.notifications.service.exceptions.SendEmailException;
+import uk.gov.service.notify.NotificationClientException;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class NotificationClientExceptionResolverTest {
+
+    @Test
+    void givenInvalidEmailError_whenResolve_thenThrowInvalidEmailAddressException() {
+        NotificationClientException exception = mock(NotificationClientException.class);
+        when(exception.getHttpResult()).thenReturn(400);
+
+        String message = """
+            {
+                "errors" : [ {
+                "error" : "ValidationError",
+                    "message" : "email_address Not a valid email address"
+            } ],
+                "status_code" : 400
+            }
+            """;
+        when(exception.getMessage()).thenReturn(message);
+
+        NotificationClientExceptionResolver resolver = new NotificationClientExceptionResolver();
+        assertThatThrownBy(() -> resolver.resolve(exception))
+            .isInstanceOf(InvalidEmailAddressException.class);
+    }
+
+    @Test
+    void given400Error_whenResolve_thenThrowSendEmailException() {
+        NotificationClientException exception = mock(NotificationClientException.class);
+        when(exception.getHttpResult()).thenReturn(400);
+        when(exception.getMessage()).thenReturn("Cannot send to this recipient using a team-only API key");
+
+        NotificationClientExceptionResolver resolver = new NotificationClientExceptionResolver();
+        assertThatThrownBy(() -> resolver.resolve(exception))
+            .isInstanceOf(SendEmailException.class);
+    }
+
+    @Test
+    void given500Error_whenResolve_thenThrowSendEmailException() {
+        NotificationClientException exception = mock(NotificationClientException.class);
+        when(exception.getHttpResult()).thenReturn(500);
+        when(exception.getMessage()).thenReturn("Internal server error");
+
+        NotificationClientExceptionResolver resolver = new NotificationClientExceptionResolver();
+        assertThatThrownBy(() -> resolver.resolve(exception))
+            .isInstanceOf(SendEmailException.class);
+    }
+}


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DFR-3836

### Change description

- When gov.uk notify fails to send an email and the NotificationClient throws a NotificationClientException then these are currently ignored.
- Add code to handle the exception and provide a suitable message to the user in the Create General Email event.
