### PR TITLE
DFR-4113: New test to check hearing corres posted when new hearing type added

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/helper/managehearings/HearingCorrespondenceHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/helper/managehearings/HearingCorrespondenceHelper.java
@@ -148,6 +148,7 @@ public class HearingCorrespondenceHelper {
             HearingType.MENTION,
             HearingType.PERMISSION_TO_APPEAL,
             HearingType.APPEAL_HEARING,
+            HearingType.APPLICATION_HEARING,
             HearingType.RETRIAL_HEARING,
             HearingType.PTR
         );

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/helper/managehearings/HearingCorrespondenceHelperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/helper/managehearings/HearingCorrespondenceHelperTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -354,6 +355,24 @@ class HearingCorrespondenceHelperTest {
                 finremCaseDetails(ManageHearingsAction.ADD_HEARING), Hearing.builder().hearingType(HearingType.FDR).build()
             )
         );
+    }
+
+    /**
+     * Test fails if both methods return false.  This would mean no correspondence is sent for a hearing.
+     * Either shouldPostAllHearingDocuments or shouldPostHearingNoticeOnly must return true.
+     * If the test fails, it's likely that a new HearingType has been added and the logic in one of the methods
+     * needs updating.
+     */
+    @ParameterizedTest
+    @EnumSource(HearingType.class)
+    void shouldAlwaysPostSomeHearingCorrespondence(HearingType hearingType) {
+        // Arrange. The hearing uses the parameterised hearing type.
+        FinremCaseDetails finremCaseDetails = finremCaseDetails(ManageHearingsAction.ADD_HEARING);
+        Hearing hearing = Hearing.builder().hearingType(hearingType).build();
+
+        // Assert that at least one of the methods returns true.
+        assertTrue(helper.shouldPostAllHearingDocuments(finremCaseDetails, hearing)
+            || helper.shouldPostHearingNoticeOnly(finremCaseDetails, hearing));
     }
 
     private static FinremCaseDetails finremCaseDetails(ManageHearingsAction action) {


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DFR-4113


### Change description

Unit test to check that either

* shouldPostAllHearingDocuments or
* shouldPostHearingNoticeOnly

Returns true for each hearing type enum

### Testing done

Test run

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [X] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [X] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
