### PR TITLE
DFR-4132 fix typo for manageHearingHCFormCTemplate

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/config/DocumentConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/config/DocumentConfiguration.java
@@ -102,7 +102,7 @@ public class DocumentConfiguration {
     @Getter(AccessLevel.NONE)
     private String manageHearingFormCTemplate;
     @Getter(AccessLevel.NONE)
-    private String manageHearingHCFromCTemplate;
+    private String manageHearingHCFormCTemplate;
     private String manageHearingExpressFormCTemplate;
     @Getter(AccessLevel.NONE)
     private String manageHearingFastTrackFormCTemplate;
@@ -164,7 +164,7 @@ public class DocumentConfiguration {
     }
 
     public String getFormCStandardTemplate(FinremCaseDetails caseDetails) {
-        return isHighCourtSelected(caseDetails) ? manageHearingHCFromCTemplate : manageHearingFormCTemplate;
+        return isHighCourtSelected(caseDetails) ? manageHearingHCFormCTemplate : manageHearingFormCTemplate;
     }
 
     public String getFormCFastTrackTemplate(CaseDetails caseDetails) {


### PR DESCRIPTION
### Jira link
[DFR-4132](https://tools.hmcts.net/jira/browse/DFR-4132)

### Change description
- Not directly related to the bug.
- Found a typo on manage hearings High Court Form C template. No template would be generated in this scenario. 
- Updated to correct template name.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behaviour remains the same.
-->

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [ ] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
