### PR TITLE
Dfr 4137 mapper resilience

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/mapper/tabdata/managehearings/HearingTabDataMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/mapper/tabdata/managehearings/HearingTabDataMapper.java
@@ -63,8 +63,9 @@ public class HearingTabDataMapper {
         final String courtNameNotAvailable = "Court name not available";
         try {
             return courtDetailsMapper.convertToFrcCourtDetails(court).getCourtName();
-        } catch (IllegalStateException e) {
-            log.error("Caught exception when retrieving court name. '{}' provided instead.", courtNameNotAvailable, e);
+        } catch (IllegalStateException | NullPointerException e) {
+            log.error("Caught an exception when retrieving court name. '{}' provided instead.",
+                courtNameNotAvailable, e);
             return courtNameNotAvailable;
         }
     }
@@ -82,21 +83,15 @@ public class HearingTabDataMapper {
     /**
      * Formats the given hearing date and time into a human-readable string.
      * If the date is {@code null}, returns a default value.
-     * If an exception occurs during formatting, logs the error and returns the default value.
      *
      * @param hearingDate the hearing date to format
      * @param hearingTime the hearing time to append to the date
      * @return a formatted date-time string (e.g., "27 Jun 2025 10:00 AM"), or a default value if the date is null
      */
     public String getFormattedDateTime(LocalDate hearingDate, String hearingTime) {
-        try {
-            return hearingDate != null
-                ? hearingDate.format(DateTimeFormatter.ofPattern("dd MMM yyyy")) + " " + hearingTime
-                : DEFAULT_DATE_TIME;
-        } catch (Exception e) {
-            log.error("Error formatting date and time: {}", e.getMessage());
-            return DEFAULT_DATE_TIME;
-        }
+        return hearingDate != null
+            ? hearingDate.format(DateTimeFormatter.ofPattern("dd MMM yyyy")) + " " + hearingTime
+            : DEFAULT_DATE_TIME;
     }
 
     /**
@@ -162,9 +157,9 @@ public class HearingTabDataMapper {
         UUID hearingId,
         Hearing hearing) {
         try {
-            return mapHearingDocumentsToTabData(hearingDocumentsCollection, hearingId, new Hearing());
-        } catch (Exception e) {
-            log.error("Error mapping hearing documents to tab data: {}", e.getMessage());
+            return mapHearingDocumentsToTabData(hearingDocumentsCollection, hearingId, hearing);
+        } catch (NullPointerException npe) {
+            log.error("NullPointerException mapping hearing documents to tab data.", npe);
             return List.of();
         }
     }

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/mapper/tabdata/managehearings/HearingTabDataMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/mapper/tabdata/managehearings/HearingTabDataMapperTest.java
@@ -153,4 +153,7 @@ class HearingTabDataMapperTest {
         assertEquals(" ", result.getTabAdditionalInformation());
         assertThat(result.getTabHearingDocuments()).isEmpty();
     }
+
+    // todo tests for exceptions
+
 }


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DFR-4136

### Change description

* Wrapped court and document mappers in exception handlers with error loggers.
* Considered date formatter, but couldn't find a realistic way to break it, so left it.
* Added test to cause these methods to fail, then check the logs and handling.

If the Court mapper fails, return a message in the hearing tab.

If the Document Mapper fails, leave the hearings docs empty. User with need to look elsewhere.  We could create a document with the message in the filename if this is a common problem that confused users.

### Testing done

* Manual
* Unit

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [X] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [X] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
