### PR TITLE
Dfr 4052 postcode validation

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/updatecontactdetails/UpdateContactDetailsAboutToSubmitHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/updatecontactdetails/UpdateContactDetailsAboutToSubmitHandler.java
@@ -8,6 +8,7 @@ import uk.gov.hmcts.reform.finrem.caseorchestration.controllers.GenericAboutToSt
 import uk.gov.hmcts.reform.finrem.caseorchestration.handler.CallbackHandlerLogger;
 import uk.gov.hmcts.reform.finrem.caseorchestration.handler.FinremCallbackHandler;
 import uk.gov.hmcts.reform.finrem.caseorchestration.handler.FinremCallbackRequest;
+import uk.gov.hmcts.reform.finrem.caseorchestration.helper.ContactDetailsValidator;
 import uk.gov.hmcts.reform.finrem.caseorchestration.mapper.FinremCaseDetailsMapper;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.EventType;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CaseDocument;
@@ -16,11 +17,14 @@ import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.FinremCaseData;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.FinremCaseDetails;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.YesOrNo;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.wrapper.ContactDetailsWrapper;
+import uk.gov.hmcts.reform.finrem.caseorchestration.service.InternationalPostalService;
 import uk.gov.hmcts.reform.finrem.caseorchestration.service.OnlineFormDocumentService;
 import uk.gov.hmcts.reform.finrem.caseorchestration.service.UpdateContactDetailsService;
 import uk.gov.hmcts.reform.finrem.caseorchestration.service.noc.nocworkflows.UpdateRepresentationWorkflowService;
 import uk.gov.hmcts.reform.finrem.caseorchestration.utils.refuge.RefugeWrapperUtils;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -32,16 +36,19 @@ public class UpdateContactDetailsAboutToSubmitHandler extends FinremCallbackHand
     private final UpdateContactDetailsService updateContactDetailsService;
     private final OnlineFormDocumentService onlineFormDocumentService;
     private final UpdateRepresentationWorkflowService nocWorkflowService;
+    private final InternationalPostalService internationalPostalService;
 
     public UpdateContactDetailsAboutToSubmitHandler(FinremCaseDetailsMapper finremCaseDetailsMapper,
                                                     UpdateContactDetailsService updateContactDetailsService,
                                                     OnlineFormDocumentService onlineFormDocumentService,
-                                                    UpdateRepresentationWorkflowService nocWorkflowService
+                                                    UpdateRepresentationWorkflowService nocWorkflowService,
+                                                    InternationalPostalService internationalPostalService
     ) {
         super(finremCaseDetailsMapper);
         this.updateContactDetailsService = updateContactDetailsService;
         this.onlineFormDocumentService = onlineFormDocumentService;
         this.nocWorkflowService = nocWorkflowService;
+        this.internationalPostalService = internationalPostalService;
     }
 
     @Override
@@ -91,7 +98,9 @@ public class UpdateContactDetailsAboutToSubmitHandler extends FinremCallbackHand
         }
 
         return GenericAboutToStartOrSubmitCallbackResponse.<FinremCaseData>builder()
-            .data(finremCaseData).build();
+            .data(finremCaseData)
+            .errors(getPostCodeErrors(finremCaseDetails))
+            .build();
     }
 
     private void considerContestedMiniFormA(FinremCaseDetails finremCaseDetails,
@@ -112,5 +121,27 @@ public class UpdateContactDetailsAboutToSubmitHandler extends FinremCallbackHand
             CaseDocument document = onlineFormDocumentService.generateContestedMiniForm(userAuthorisation, finremCaseDetails);
             finremCaseDetails.getData().setMiniFormA(document);
         }
+    }
+
+    /*
+     * Repeat mid-event validation to protect Users navigating with browser controls.
+     * @param finremCaseDetails case details
+     * @return list of errors
+     */
+    private List<String> getPostCodeErrors(FinremCaseDetails finremCaseDetails) {
+        FinremCaseData finremCaseData = finremCaseDetails.getData();
+        List<String> errors = new ArrayList<>();
+        errors.addAll(internationalPostalService.validate(finremCaseData));
+        errors.addAll(ContactDetailsValidator.validateCaseDataEmailAddresses(finremCaseData));
+
+        if (CaseType.CONSENTED.equals(finremCaseDetails.getCaseType())) {
+            errors.addAll(ContactDetailsValidator.validatePostcodesByRepresentation(finremCaseDetails));
+        }
+
+        if (CaseType.CONTESTED.equals(finremCaseDetails.getCaseType())) {
+            errors.addAll(ContactDetailsValidator.validateCaseDataAddresses(finremCaseData));
+        }
+
+        return errors;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/updatecontactdetails/UpdateContactDetailsConsentedMidHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/updatecontactdetails/UpdateContactDetailsConsentedMidHandler.java
@@ -40,7 +40,6 @@ public class UpdateContactDetailsConsentedMidHandler extends FinremCallbackHandl
     @Override
     public GenericAboutToStartOrSubmitCallbackResponse<FinremCaseData> handle(FinremCallbackRequest callbackRequest,
                                                                               String userAuthorisation) {
-
         log.info(CallbackHandlerLogger.midEvent(callbackRequest));
 
         FinremCaseDetails finremCaseDetails = callbackRequest.getCaseDetails();

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/updatecontactdetails/UpdateContactDetailsConsentedMidHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/updatecontactdetails/UpdateContactDetailsConsentedMidHandler.java
@@ -40,6 +40,7 @@ public class UpdateContactDetailsConsentedMidHandler extends FinremCallbackHandl
     @Override
     public GenericAboutToStartOrSubmitCallbackResponse<FinremCaseData> handle(FinremCallbackRequest callbackRequest,
                                                                               String userAuthorisation) {
+
         log.info(CallbackHandlerLogger.midEvent(callbackRequest));
 
         FinremCaseDetails finremCaseDetails = callbackRequest.getCaseDetails();
@@ -47,7 +48,7 @@ public class UpdateContactDetailsConsentedMidHandler extends FinremCallbackHandl
 
         List<String> errors = new ArrayList<>();
         errors.addAll(internationalPostalService.validate(finremCaseData));
-        errors.addAll(ContactDetailsValidator.validateCaseDataAddresses(finremCaseData));
+        errors.addAll(ContactDetailsValidator.validatePostcodesByRepresentation(finremCaseDetails));
         errors.addAll(ContactDetailsValidator.validateCaseDataEmailAddresses(finremCaseData));
 
         return GenericAboutToStartOrSubmitCallbackResponse.<FinremCaseData>builder().data(finremCaseData).errors(errors).build();

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/helper/ContactDetailsValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/helper/ContactDetailsValidator.java
@@ -21,6 +21,8 @@ public class ContactDetailsValidator {
     static final String APPLICANT_SOLICITOR_POSTCODE_ERROR = "Postcode field is required for applicant solicitor address.";
     static final String RESPONDENT_SOLICITOR_POSTCODE_ERROR = "Postcode field is required for respondent solicitor address.";
     static final String INVALID_EMAIL_ADDRESS_ERROR_MESSAGE = "%s is not a valid Email address.";
+    static final String INVALID_VALIDATE_POSTCODE_METHOD_MESSAGE = "%s. Method validatePostcodesByRepresentation is only for "
+        + "updating contact details on consented cases. Use validateCaseDataAddresses whenever possible.";
 
     private ContactDetailsValidator() {
     }
@@ -69,9 +71,9 @@ public class ContactDetailsValidator {
 
         if (CaseType.CONTESTED.equals(finremCaseDetails.getCaseType())) {
             throw new IllegalArgumentException(
-                String.format("{}.validatePostcodesByRepresentation is only for consented cases",
-                finremCaseDetails.getCaseIdAsString()));
+                format(INVALID_VALIDATE_POSTCODE_METHOD_MESSAGE, finremCaseDetails.getCaseIdAsString()));
         }
+
         FinremCaseData finremCaseData = finremCaseDetails.getData();
 
         List<String> errors = new ArrayList<>();

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/helper/ContactDetailsValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/helper/ContactDetailsValidator.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.finrem.caseorchestration.helper;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.Address;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CaseType;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.FinremCaseData;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.FinremCaseDetails;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.YesOrNo;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.wrapper.ContactDetailsWrapper;
 
@@ -50,6 +51,43 @@ public class ContactDetailsValidator {
         checkForEmptyApplicantPostcode(wrapper, errors);
         checkForEmptyRespondentSolicitorPostcode(caseData, wrapper, errors);
         checkForEmptyRespondentPostcode(wrapper, errors);
+
+        return errors;
+    }
+
+    /**
+     * Checks EITHER a party, or their representative, for missing or empty postcode fields.
+     * Used by the consented "Update contact details" event, which hides addresses depending on representation.
+     * If a party is represented, only the representative address is shown to the admin.
+     * If a party is unrepresented, only the party address is shown to the admin.
+     * This method only validates the address that is shown to the admin.
+     * This also stops validation failing for older case data that is already stored with errors (such as applicantAddress = {}).
+     * @param finremCaseDetails the {@link FinremCaseDetails} containing contact details to validate
+     * @return a list of validation error messages for any missing or invalid postcode fields
+     */
+    public static List<String> validatePostcodesByRepresentation(FinremCaseDetails finremCaseDetails) {
+
+        if (CaseType.CONTESTED.equals(finremCaseDetails.getCaseType())) {
+            throw new IllegalArgumentException(
+                String.format("{}.validatePostcodesByRepresentation is only for consented cases",
+                finremCaseDetails.getCaseIdAsString()));
+        }
+        FinremCaseData finremCaseData = finremCaseDetails.getData();
+
+        List<String> errors = new ArrayList<>();
+        ContactDetailsWrapper wrapper = finremCaseData.getContactDetailsWrapper();
+
+        if (YesOrNo.YES.equals(wrapper.getApplicantRepresented())) {
+            ContactDetailsValidator.checkForEmptyApplicantSolicitorPostcode(finremCaseData, wrapper, errors);
+        } else {
+            ContactDetailsValidator.checkForEmptyApplicantPostcode(wrapper, errors);
+        }
+
+        if (YesOrNo.YES.equals(wrapper.getConsentedRespondentRepresented())) {
+            ContactDetailsValidator.checkForEmptyRespondentSolicitorPostcode(finremCaseData, wrapper, errors);
+        } else {
+            ContactDetailsValidator.checkForEmptyRespondentPostcode(wrapper, errors);
+        }
 
         return errors;
     }

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/updatecontactdetails/UpdateContactDetailsConsentedMidHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/updatecontactdetails/UpdateContactDetailsConsentedMidHandlerTest.java
@@ -80,7 +80,7 @@ class UpdateContactDetailsConsentedMidHandlerTest {
             FinremCallbackRequestFactory.create(Long.valueOf(CASE_ID), CONSENTED, UPDATE_CONTACT_DETAILS, caseData);
 
         try (MockedStatic<ContactDetailsValidator> contactValidatorMock = mockStatic(ContactDetailsValidator.class)) {
-            contactValidatorMock.when(() -> ContactDetailsValidator.validateCaseDataAddresses(caseData))
+            contactValidatorMock.when(() -> ContactDetailsValidator.validatePostcodesByRepresentation(callbackRequest.getCaseDetails()))
                 .thenReturn(new ArrayList<>(addressErrors));
             contactValidatorMock.when(() -> ContactDetailsValidator.validateCaseDataEmailAddresses(caseData))
                 .thenReturn(new ArrayList<>(emailErrors));

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/helper/ContactDetailsValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/helper/ContactDetailsValidatorTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.Address;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CaseType;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.FinremCaseData;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.FinremCaseDetails;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.YesOrNo;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.wrapper.ContactDetailsWrapper;
 
@@ -16,6 +17,7 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.helper.ContactDetailsValidator.APPLICANT_POSTCODE_ERROR;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.helper.ContactDetailsValidator.APPLICANT_SOLICITOR_POSTCODE_ERROR;
 import static uk.gov.hmcts.reform.finrem.caseorchestration.helper.ContactDetailsValidator.RESPONDENT_POSTCODE_ERROR;
@@ -55,56 +57,11 @@ class ContactDetailsValidatorTest {
     }
 
     private static Stream<Object[]> provideCaseDataWithInvalidPostcodes() {
+        return Stream.concat(provideContestedCaseDataWithInvalidPostcodes(), provideConsentedCaseDataWithInvalidPostcodes());
+    }
+
+    private static Stream<Object[]> provideContestedCaseDataWithInvalidPostcodes() {
         return Stream.of(
-            new Object[] {
-                createConsentedCaseData(null, new PostCodeModifier("SW1A 1AA"), "E1 6AN", new PostCodeModifier("EC1A 1BB"), YesOrNo.YES, null),
-                APPLICANT_SOLICITOR_POSTCODE_ERROR },
-            new Object[] {
-                createConsentedCaseData("SW1A 1AA", null, "E1 6AN", "EC1A 1BB", null, null),
-                APPLICANT_POSTCODE_ERROR },
-            new Object[] {
-                createConsentedCaseData("SW1A 1AA", new PostCodeModifier(null, false), "E1 6AN", new PostCodeModifier("EC1A 1BB"), null, null),
-                APPLICANT_POSTCODE_ERROR },
-            new Object[] {
-                createConsentedCaseData("SW1A 1AA", new PostCodeModifier("", false), "E1 6AN", new PostCodeModifier("EC1A 1BB"), null, null),
-                APPLICANT_POSTCODE_ERROR },
-            new Object[] {
-                createConsentedCaseData("SW1A 1AA", new PostCodeModifier(" ", false), "E1 6AN", new PostCodeModifier("EC1A 1BB"), null, null),
-                APPLICANT_POSTCODE_ERROR },
-            new Object[] {
-                createConsentedCaseData("SW1A 1AA", new PostCodeModifier(null, true), "E1 6AN", new PostCodeModifier("EC1A 1BB"), null, null),
-                null },
-            new Object[] {
-                createConsentedCaseData("SW1A 1AA", new PostCodeModifier("", true), "E1 6AN", new PostCodeModifier("EC1A 1BB"), null, null),
-                null },
-            new Object[] {
-                createConsentedCaseData("SW1A 1AA", new PostCodeModifier(" ", true), "E1 6AN", new PostCodeModifier("EC1A 1BB"), null, null),
-                null },
-            new Object[] {
-                createConsentedCaseData("SW1A 1AA", new PostCodeModifier("E1 6AN"), null, new PostCodeModifier("EC1A 1BB"), null, YesOrNo.YES),
-                RESPONDENT_SOLICITOR_POSTCODE_ERROR },
-            new Object[] {
-                createConsentedCaseData("SW1A 1AA", new PostCodeModifier("E1 6AN"), null, new PostCodeModifier("EC1A 1BB"), null, YesOrNo.YES),
-                RESPONDENT_SOLICITOR_POSTCODE_ERROR },
-            new Object[] {
-                createConsentedCaseData("SW1A 1AA", new PostCodeModifier("E1 6AN"), "EC1A 1BB", new PostCodeModifier(null), null, null),
-                RESPONDENT_POSTCODE_ERROR },
-            new Object[] {
-                createConsentedCaseData("SW1A 1AA", new PostCodeModifier("E1 6AN"), "EC1A 1BB", new PostCodeModifier(""), null, null),
-                RESPONDENT_POSTCODE_ERROR },
-            new Object[] {
-                createConsentedCaseData("SW1A 1AA", new PostCodeModifier("E1 6AN"), "EC1A 1BB", new PostCodeModifier(" "), null, null),
-                RESPONDENT_POSTCODE_ERROR },
-            new Object[] {
-                createConsentedCaseData("SW1A 1AA", new PostCodeModifier("E1 6AN"), "EC1A 1BB", new PostCodeModifier("", true), null, null),
-                null },
-            new Object[] {
-                createConsentedCaseData("SW1A 1AA", new PostCodeModifier("E1 6AN"), "EC1A 1BB", new PostCodeModifier(" ", true), null, null),
-                null },
-            new Object[] {
-                createConsentedCaseData("SW1A 1AA", new PostCodeModifier("E1 6AN"), "EC1A 1BB", new PostCodeModifier(null, true), null, null),
-                null },
-            // Contested
             new Object[] {
                 createContestedCaseData(null, new PostCodeModifier("SW1A 1AA"), "E1 6AN", new PostCodeModifier("EC1A 1BB"), YesOrNo.YES, null),
                 APPLICANT_SOLICITOR_POSTCODE_ERROR },
@@ -156,6 +113,59 @@ class ContactDetailsValidatorTest {
         );
     }
 
+    private static Stream<Object[]> provideConsentedCaseDataWithInvalidPostcodes() {
+        return Stream.of(
+            new Object[] {
+                createConsentedCaseData(null, new PostCodeModifier("SW1A 1AA"), "E1 6AN", new PostCodeModifier("EC1A 1BB"), YesOrNo.YES, null),
+                APPLICANT_SOLICITOR_POSTCODE_ERROR },
+            new Object[] {
+                createConsentedCaseData("SW1A 1AA", null, "E1 6AN", "EC1A 1BB", null, null),
+                APPLICANT_POSTCODE_ERROR },
+            new Object[] {
+                createConsentedCaseData("SW1A 1AA", new PostCodeModifier(null, false), "E1 6AN", new PostCodeModifier("EC1A 1BB"), null, null),
+                APPLICANT_POSTCODE_ERROR },
+            new Object[] {
+                createConsentedCaseData("SW1A 1AA", new PostCodeModifier("", false), "E1 6AN", new PostCodeModifier("EC1A 1BB"), null, null),
+                APPLICANT_POSTCODE_ERROR },
+            new Object[] {
+                createConsentedCaseData("SW1A 1AA", new PostCodeModifier(" ", false), "E1 6AN", new PostCodeModifier("EC1A 1BB"), null, null),
+                APPLICANT_POSTCODE_ERROR },
+            new Object[] {
+                createConsentedCaseData("SW1A 1AA", new PostCodeModifier(null, true), "E1 6AN", new PostCodeModifier("EC1A 1BB"), null, null),
+                null },
+            new Object[] {
+                createConsentedCaseData("SW1A 1AA", new PostCodeModifier("", true), "E1 6AN", new PostCodeModifier("EC1A 1BB"), null, null),
+                null },
+            new Object[] {
+                createConsentedCaseData("SW1A 1AA", new PostCodeModifier(" ", true), "E1 6AN", new PostCodeModifier("EC1A 1BB"), null, null),
+                null },
+            new Object[] {
+                createConsentedCaseData("SW1A 1AA", new PostCodeModifier("E1 6AN"), null, new PostCodeModifier("EC1A 1BB"), null, YesOrNo.YES),
+                RESPONDENT_SOLICITOR_POSTCODE_ERROR },
+            new Object[] {
+                createConsentedCaseData("SW1A 1AA", new PostCodeModifier("E1 6AN"), null, new PostCodeModifier("EC1A 1BB"), null, YesOrNo.YES),
+                RESPONDENT_SOLICITOR_POSTCODE_ERROR },
+            new Object[] {
+                createConsentedCaseData("SW1A 1AA", new PostCodeModifier("E1 6AN"), "EC1A 1BB", new PostCodeModifier(null), null, null),
+                RESPONDENT_POSTCODE_ERROR },
+            new Object[] {
+                createConsentedCaseData("SW1A 1AA", new PostCodeModifier("E1 6AN"), "EC1A 1BB", new PostCodeModifier(""), null, null),
+                RESPONDENT_POSTCODE_ERROR },
+            new Object[] {
+                createConsentedCaseData("SW1A 1AA", new PostCodeModifier("E1 6AN"), "EC1A 1BB", new PostCodeModifier(" "), null, null),
+                RESPONDENT_POSTCODE_ERROR },
+            new Object[] {
+                createConsentedCaseData("SW1A 1AA", new PostCodeModifier("E1 6AN"), "EC1A 1BB", new PostCodeModifier("", true), null, null),
+                null },
+            new Object[] {
+                createConsentedCaseData("SW1A 1AA", new PostCodeModifier("E1 6AN"), "EC1A 1BB", new PostCodeModifier(" ", true), null, null),
+                null },
+            new Object[] {
+                createConsentedCaseData("SW1A 1AA", new PostCodeModifier("E1 6AN"), "EC1A 1BB", new PostCodeModifier(null, true), null, null),
+                null }
+        );
+    }
+
     @Test
     void shouldReturnNoErrorsForValidCaseData() {
         FinremCaseData caseData = createConsentedCaseData("SW1A 1AA", "E1 6AN", "EC1A 1BB", "B1 1BB", null, null);
@@ -194,6 +204,33 @@ class ContactDetailsValidatorTest {
         List<String> errors = ContactDetailsValidator.validateCaseDataAddresses(caseData);
         assertThat(errors).isEmpty();
     }
+
+    @ParameterizedTest
+    @MethodSource("provideConsentedCaseDataWithInvalidPostcodes")
+    void shouldValidatePostcodesByRepresentationAndReturnExpectedErrors(FinremCaseData caseData, String expectedError) {
+        FinremCaseDetails finremCaseDetails = FinremCaseDetails.builder().data(caseData).build();
+        List<String> errors = ContactDetailsValidator.validatePostcodesByRepresentation(finremCaseDetails);
+        if (expectedError != null) {
+            assertThat(errors).containsOnly(expectedError);
+        } else {
+            assertThat(errors).isEmpty();
+        }
+    }
+
+    @Test
+    void shouldValidatePostcodesByRepresentationUsingCorrectMethods() {
+
+//        ContactDetailsValidator.validatePostcodesByRepresentation(FinremCaseData.builder().contactDetailsWrapper().bul.build());
+
+    }
+
+    @Test
+    void givenContestedCase_whenValidatePostcodesByRepresentation_thenExceptionRaised() {
+        assertThrows(IllegalArgumentException.class, () ->
+            ContactDetailsValidator.validatePostcodesByRepresentation(FinremCaseDetails.builder().caseType(CaseType.CONTESTED).build()));
+    }
+
+
 
     private static FinremCaseData createContestedCaseData(String applicantSolicitorPostcode, String applicantPostcode,
                                                           String respondentSolicitorPostcode, String respondentPostcode,


### PR DESCRIPTION
### Jira link

[DFR-4052](https://tools.hmcts.net/jira/browse/DFR-4052)

The Jira ticket is to fix an issue where Update Contact Details fails for a consented case.

The event fails because:

* an empty address has been stored for the represented applicant.  
* this event hides fields from the admin, so the admin can't add a postcode to pass validation.

Data like this is no longer being created.  Details in Jira ticket.

### Change description

Update contact details has a specific mid handler for consented cases.  This change:

* gives that mid handler it's own validation method, only validates what the admin can see
* adds postcode validation to about-to-submit so browser controls won't circumvent navigation

The test:

* reuses existing Provider methods, but splits into consented and contested case types.
* makes sure that the new method is only used for consented cases.

Github has made the ContactDetailsValidatorTest tough to read with diffs.  The actual changes aren't extensive.  

### Testing done

* Manual
* Unit

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [X] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [X] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
