### PR TITLE
DFR-3915: Add emailReplyToId config

### DIFF
--- a/src/main/resources/json/court-details.json
+++ b/src/main/resources/json/court-details.json
@@ -955,7 +955,6 @@
     "courtName": "Central Family Court",
     "courtAddress": "Central Family Court, First Avenue House, 42-49 High Holborn, London WC1V 6NP",
     "phoneNumber": "0300 123 5577",
-    "email": "FRCLondon@Justice.gov.uk",
-    "emailReplyToId": "ef8dbd1d-9fa2-4277-8b6e-111bcee3c9b9"
+    "email": "cfc.fru@justice.gov.uk"
   }
 }

--- a/src/main/resources/json/court-details.json
+++ b/src/main/resources/json/court-details.json
@@ -3,121 +3,141 @@
     "courtName": "Bromley County Court And Family Court",
     "courtAddress": "Bromley County Court, College Road, Bromley, BR1 3PX",
     "phoneNumber": "0300 123 5577",
-    "email": "FRCLondon@justice.gov.uk"
+    "email": "FRCLondon@justice.gov.uk",
+    "emailReplyToId": "ef8dbd1d-9fa2-4277-8b6e-111bcee3c9b9"
   },
   "FR_s_CFCList_2": {
     "courtName": "Croydon County Court And Family Court",
     "courtAddress": "Croydon County Court, Altyre Road, Croydon, CR9 5AB",
     "phoneNumber": "0300 123 5577",
-    "email": "FRCLondon@justice.gov.uk"
+    "email": "FRCLondon@justice.gov.uk",
+    "emailReplyToId": "ef8dbd1d-9fa2-4277-8b6e-111bcee3c9b9"
   },
   "FR_s_CFCList_3": {
     "courtName": "Edmonton County Court And Family Court",
     "courtAddress": "Edmonton County Court, 59 Fore Street, Edmonton, N18 2TN",
     "phoneNumber": "0300 123 5577",
-    "email": "FRCLondon@justice.gov.uk"
+    "email": "FRCLondon@justice.gov.uk",
+    "emailReplyToId": "ef8dbd1d-9fa2-4277-8b6e-111bcee3c9b9"
   },
   "FR_s_CFCList_4": {
     "courtName": "Kingston-Upon-Thames County Court And Family Court",
     "courtAddress": "Kingston upon Thames County Court, St James Road, Kingston-upon-Thames, KT1 2AD",
     "phoneNumber": "0300 123 5577",
-    "email": "FRCLondon@justice.gov.uk"
+    "email": "FRCLondon@justice.gov.uk",
+    "emailReplyToId": "ef8dbd1d-9fa2-4277-8b6e-111bcee3c9b9"
   },
   "FR_s_CFCList_5": {
     "courtName": "Romford County And Family Court",
     "courtAddress": "Romford County Court, 2a Oaklands Avenue, Romford, RM1 4DP",
     "phoneNumber": "0300 123 5577",
-    "email": "FRCLondon@justice.gov.uk"
+    "email": "FRCLondon@justice.gov.uk",
+    "emailReplyToId": "ef8dbd1d-9fa2-4277-8b6e-111bcee3c9b9"
   },
   "FR_s_CFCList_6": {
     "courtName": "Barnet Civil And Family Courts Centre",
     "courtAddress": "Barnet County Court, St Marys Court, Regents Park Road, Finchley Central, London, N3 1BQ",
     "phoneNumber": "0300 123 5577",
-    "email": "FRCLondon@justice.gov.uk"
+    "email": "FRCLondon@justice.gov.uk",
+    "emailReplyToId": "ef8dbd1d-9fa2-4277-8b6e-111bcee3c9b9"
   },
   "FR_s_CFCList_8": {
     "courtName": "Brentford County And Family Court",
     "courtAddress": "Brentford County Court, Alexandra Road, High Street, Brentford, TW8 0JJ",
     "phoneNumber": "0300 123 5577",
-    "email": "FRCLondon@justice.gov.uk"
+    "email": "FRCLondon@justice.gov.uk",
+    "emailReplyToId": "ef8dbd1d-9fa2-4277-8b6e-111bcee3c9b9"
   },
   "FR_s_CFCList_9": {
     "courtName": "Central Family Court",
     "courtAddress": "Central Family Court, First Avenue House, 42-49 High Holborn, London WC1V 6NP",
     "phoneNumber": "0300 123 5577",
-    "email": "FRCLondon@justice.gov.uk"
+    "email": "FRCLondon@justice.gov.uk",
+    "emailReplyToId": "ef8dbd1d-9fa2-4277-8b6e-111bcee3c9b9"
   },
   "FR_s_CFCList_11": {
     "courtName": "East London Family Court",
     "courtAddress": "East London Family Court, 6th and 7th Floor, 11 Westferry Circus, London, E14 4HD",
     "phoneNumber": "0300 123 5577",
-    "email": "FRCLondon@justice.gov.uk"
+    "email": "FRCLondon@justice.gov.uk",
+    "emailReplyToId": "ef8dbd1d-9fa2-4277-8b6e-111bcee3c9b9"
   },
   "FR_s_CFCList_14": {
     "courtName": "Uxbridge County Court And Family Court",
     "courtAddress": "Uxbridge County Court, 501 Uxbridge Road, Hayes, UB4 8HL",
     "phoneNumber": "0300 123 5577",
-    "email": "FRCLondon@justice.gov.uk"
+    "email": "FRCLondon@justice.gov.uk",
+    "emailReplyToId": "ef8dbd1d-9fa2-4277-8b6e-111bcee3c9b9"
   },
   "FR_s_CFCList_16": {
     "courtName": "Willesden Family Court",
     "courtAddress": "Willesden County Court, 9 Acton Lane, Harlesden, NW10 8SB",
     "phoneNumber": "0300 123 5577",
-    "email": "FRCLondon@justice.gov.uk"
+    "email": "FRCLondon@justice.gov.uk",
+    "emailReplyToId": "ef8dbd1d-9fa2-4277-8b6e-111bcee3c9b9"
   },
   "FR_s_CFCList_17": {
     "courtName": "The Royal Courts of Justice",
     "courtAddress": "The Royal Courts of Justice, Strand, London, WC2A 2LL",
     "phoneNumber": "0207 421 8594",
-    "email": "FRCLondon@justice.gov.uk"
+    "email": "FRCLondon@justice.gov.uk",
+    "emailReplyToId": "ef8dbd1d-9fa2-4277-8b6e-111bcee3c9b9"
   },
   "FR_s_NottinghamList_1": {
     "courtName": "Nottingham County Court And Family Court",
     "courtAddress": "60 Canal Street, Nottingham NG1 7EJ",
     "phoneNumber": "0300 123 5577",
-    "email": "FRCNottingham@justice.gov.uk"
+    "email": "FRCNottingham@justice.gov.uk",
+    "emailReplyToId": "5c727fb0-4618-4e78-ab4d-387a2ce0b728"
   },
   "FR_s_NottinghamList_2": {
     "courtName": "Derby Combined Court Centre",
     "courtAddress": "Morledge, Derby DE1 2XE",
     "phoneNumber": "0300 123 5577",
-    "email": "FRCNottingham@justice.gov.uk"
+    "email": "FRCNottingham@justice.gov.uk",
+    "emailReplyToId": "5c727fb0-4618-4e78-ab4d-387a2ce0b728"
   },
   "FR_s_NottinghamList_3": {
     "courtName": "Leicester County Court And Family Court",
     "courtAddress": "90 Wellington Street, Leicester LE1 6HG",
     "phoneNumber": "0300 123 5577",
-    "email": "FRCNottingham@justice.gov.uk"
+    "email": "FRCNottingham@justice.gov.uk",
+    "emailReplyToId": "5c727fb0-4618-4e78-ab4d-387a2ce0b728"
   },
   "FR_s_NottinghamList_4": {
     "courtName": "Lincoln County Court And Family Court",
     "courtAddress": "360 High Street, Lincoln LN5 7PS",
     "phoneNumber": "0300 123 5577",
-    "email": "FRCNottingham@justice.gov.uk"
+    "email": "FRCNottingham@justice.gov.uk",
+    "emailReplyToId": "5c727fb0-4618-4e78-ab4d-387a2ce0b728"
   },
   "FR_s_NottinghamList_5": {
     "courtName": "Northampton Crown, County And Family Court",
     "courtAddress": "85 - 87 Ladys Lane, Northampton NN1 3HQ",
     "phoneNumber": "0300 123 5577",
-    "email": "FRCNottingham@justice.gov.uk"
+    "email": "FRCNottingham@justice.gov.uk",
+    "emailReplyToId": "5c727fb0-4618-4e78-ab4d-387a2ce0b728"
   },
   "FR_s_NottinghamList_6": {
     "courtName": "Chesterfield County Court",
     "courtAddress": "Tapton Lane, Chesterfield S41 7TW",
     "phoneNumber": "0300 123 5577",
-    "email": "FRCNottingham@justice.gov.uk"
+    "email": "FRCNottingham@justice.gov.uk",
+    "emailReplyToId": "5c727fb0-4618-4e78-ab4d-387a2ce0b728"
   },
   "FR_s_NottinghamList_7": {
     "courtName": "Mansfield Magistrates And County Court",
     "courtAddress": "Rosemary Street, Mansfield NG19 6EE",
     "phoneNumber": "0300 123 5577",
-    "email": "FRCNottingham@justice.gov.uk"
+    "email": "FRCNottingham@justice.gov.uk",
+    "emailReplyToId": "5c727fb0-4618-4e78-ab4d-387a2ce0b728"
   },
   "FR_s_NottinghamList_8": {
     "courtName": "Boston County Court And Family Court",
     "courtAddress": "55 Norfolk Street, Boston PE21 6PE",
     "phoneNumber": "0300 123 5577",
-    "email": "FRCNottingham@justice.gov.uk"
+    "email": "FRCNottingham@justice.gov.uk",
+    "emailReplyToId": "5c727fb0-4618-4e78-ab4d-387a2ce0b728"
   },
   "FR_birmingham_hc_list_1": {
     "courtName": "Birmingham Civil And Family Justice Centre",
@@ -130,97 +150,113 @@
     "courtName": "Coventry Combined Court Centre",
     "courtAddress": "140 Much Park Street, Coventry, CV1 2SN",
     "phoneNumber": "0300 123 5577",
-    "email": "FRCBirmingham@justice.gov.uk"
+    "email": "FRCBirmingham@justice.gov.uk",
+    "emailReplyToId": "22a13617-b938-433e-a2d3-6390354f8c4d"
   },
   "FR_birmingham_hc_list_3": {
     "courtName": "Telford County Court And Family Court",
     "courtAddress": "Telford Justice Centre, Telford Square, Malinsgate, Telford, TF3 4HX",
     "phoneNumber": "0300 123 5577",
-    "email": "FRCBirmingham@justice.gov.uk"
+    "email": "FRCBirmingham@justice.gov.uk",
+    "emailReplyToId": "22a13617-b938-433e-a2d3-6390354f8c4d"
   },
   "FR_birmingham_hc_list_4": {
     "courtName": "Wolverhampton Combined Court Centre",
     "courtAddress": "Pipers Row, Wolverhampton, WV1 3LQ",
     "phoneNumber": "0300 123 5577",
-    "email": "FRCBirmingham@justice.gov.uk"
+    "email": "FRCBirmingham@justice.gov.uk",
+    "emailReplyToId": "22a13617-b938-433e-a2d3-6390354f8c4d"
   },
   "FR_birmingham_hc_list_5": {
     "courtName": "Dudley County Court And Family Court",
     "courtAddress": "The Inhedge, Dudley, DY1 1RY",
     "phoneNumber": "0300 123 5577",
-    "email": "FRCBirmingham@justice.gov.uk"
+    "email": "FRCBirmingham@justice.gov.uk",
+    "emailReplyToId": "22a13617-b938-433e-a2d3-6390354f8c4d"
   },
   "FR_birmingham_hc_list_6": {
     "courtName": "Walsall County And Family Court",
     "courtAddress": "Bridge House, Bridge Street, Walsall, WS1 1JQ",
     "phoneNumber": "0300 123 5577",
-    "email": "FRCBirmingham@justice.gov.uk"
+    "email": "FRCBirmingham@justice.gov.uk",
+    "emailReplyToId": "22a13617-b938-433e-a2d3-6390354f8c4d"
   },
   "FR_birmingham_hc_list_7": {
     "courtName": "Stoke On Trent Combined Court",
     "courtAddress": "Bethesda Street, Hanley, Stoke-on-Trent, ST1 3BP",
     "phoneNumber": "0300 123 5577",
-    "email": "FRCBirmingham@justice.gov.uk"
+    "email": "FRCBirmingham@justice.gov.uk",
+    "emailReplyToId": "22a13617-b938-433e-a2d3-6390354f8c4d"
   },
   "FR_birmingham_hc_list_8": {
     "courtName": "Worcester Combined Court",
     "courtAddress": "The Shirehall, Foregate, Worcester, WR1 1EQ",
     "phoneNumber": "0300 123 5577",
-    "email": "FRCBirmingham@justice.gov.uk"
+    "email": "FRCBirmingham@justice.gov.uk",
+    "emailReplyToId": "22a13617-b938-433e-a2d3-6390354f8c4d"
   },
   "FR_birmingham_hc_list_9": {
     "courtName": "Stafford Combined Court",
     "courtAddress": "Victoria Square, Stafford, ST16 2QQ",
     "phoneNumber": "0300 123 5577",
-    "email": "FRCBirmingham@justice.gov.uk"
+    "email": "FRCBirmingham@justice.gov.uk",
+    "emailReplyToId": "22a13617-b938-433e-a2d3-6390354f8c4d"
   },
   "FR_birmingham_hc_list_10": {
     "courtName": "Hereford County Court And Family Court",
     "courtAddress": "The Court House, Bath Street, Hereford, HR1 2HE",
     "phoneNumber": "0300 123 5577",
-    "email": "FRCBirmingham@justice.gov.uk"
+    "email": "FRCBirmingham@justice.gov.uk",
+    "emailReplyToId": "22a13617-b938-433e-a2d3-6390354f8c4d"
   },
   "FR_cleaveland_hc_list_1": {
     "courtName": "Newcastle Civil and Family Courts and Tribunals Centre",
     "courtAddress": "Barras Bridge, Newcastle upon Tyne, NE18QF",
     "phoneNumber": "0300 123 5577",
-    "email": "Family.newcastle.countycourt@justice.gov.uk"
+    "email": "Family.newcastle.countycourt@justice.gov.uk",
+    "emailReplyToId": "88906b91-2295-4887-8ffc-848f2c84171e"
   },
   "FR_cleaveland_hc_list_2": {
     "courtName": "Durham Justice Centre",
     "courtAddress": "Green Lane, Old Elvet, Durham, DH1 3RG",
     "phoneNumber": "0300 123 5577",
-    "email": "Family.newcastle.countycourt@justice.gov.uk"
+    "email": "Family.newcastle.countycourt@justice.gov.uk",
+    "emailReplyToId": "88906b91-2295-4887-8ffc-848f2c84171e"
   },
   "FR_cleaveland_hc_list_3": {
     "courtName": "Sunderland County And Family Court",
     "courtAddress": "Gillbridge Avenue, Sunderland, SR1 3AP",
     "phoneNumber": "0300 123 5577",
-    "email": "Family.newcastle.countycourt@justice.gov.uk"
+    "email": "Family.newcastle.countycourt@justice.gov.uk",
+    "emailReplyToId": "88906b91-2295-4887-8ffc-848f2c84171e"
   },
   "FR_cleaveland_hc_list_4": {
     "courtName": "Middlesbrough County Court at Teesside Combined Court",
     "courtAddress": "The Law Courts, Russell Street, Middlesbrough, TS1 2AE",
     "phoneNumber": "0300 123 5577",
-    "email": "Family.newcastle.countycourt@justice.gov.uk"
+    "email": "Family.newcastle.countycourt@justice.gov.uk",
+    "emailReplyToId": "88906b91-2295-4887-8ffc-848f2c84171e"
   },
   "FR_cleaveland_hc_list_5": {
     "courtName": "Gateshead County Court and Family Court",
     "courtAddress": "Gateshead Law Courts, Warwick Street, Gateshead, NE8 1DT",
     "phoneNumber": "0300 123 5577",
-    "email": "Family.newcastle.countycourt@justice.gov.uk"
+    "email": "Family.newcastle.countycourt@justice.gov.uk",
+    "emailReplyToId": "88906b91-2295-4887-8ffc-848f2c84171e"
   },
   "FR_cleaveland_hc_list_6": {
     "courtName": "South Shields County Court and Family Court",
     "courtAddress": "Millbank, Secretan Way, Tyne and Wear, South Shields, NE33 1RG",
     "phoneNumber": "0300 123 5577",
-    "email": "Family.newcastle.countycourt@justice.gov.uk"
+    "email": "Family.newcastle.countycourt@justice.gov.uk",
+    "emailReplyToId": "88906b91-2295-4887-8ffc-848f2c84171e"
   },
   "FR_cleaveland_hc_list_7": {
     "courtName": "North Shields County Court and Family Court",
     "courtAddress": "Kings Court, Earl Grey Way, Royal Quays, North Shields, NE29 6AR",
     "phoneNumber": "0300 123 5577",
-    "email": "Family.newcastle.countycourt@justice.gov.uk"
+    "email": "Family.newcastle.countycourt@justice.gov.uk",
+    "emailReplyToId": "88906b91-2295-4887-8ffc-848f2c84171e"
   },
   "FR_cleaveland_hc_list_8": {
     "courtName": "Darlington County Court and Family Court",
@@ -233,361 +269,421 @@
     "courtName": "Darlington Magistrates Court",
     "courtAddress": "Parkgate, Darlington, DL1 1RU",
     "phoneNumber": "01642 340000",
-    "email": "family.middlesbrough.countycourt@justice.gov.uk"
+    "email": "family.middlesbrough.countycourt@justice.gov.uk",
+    "emailReplyToId": "543e8a6e-35eb-43cc-9c10-9848d4bef106"
   },
   "FR_humber_hc_list_1": {
     "courtName": "Sheffield Family Hearing Centre",
     "courtAddress": "The Law Courts, 50 West Bar, Sheffield, S3 8PH",
     "phoneNumber": "0300 123 5577",
-    "email": "FRCSheffield@justice.gov.uk"
+    "email": "FRCSheffield@justice.gov.uk",
+    "emailReplyToId": "3036ec66-e305-40b3-a0ce-de3d5ecfba16"
   },
   "FR_humber_hc_list_2": {
     "courtName": "Kingston-upon-Hull Combined Court Centre",
     "courtAddress": "Lowgate, Kingston-upon-Hull, HU1 2EZ",
     "phoneNumber": "0300 123 5577",
-    "email": "Hull.private.filing@Justice.gov.uk"
+    "email": "Hull.private.filing@Justice.gov.uk",
+    "emailReplyToId": "5555188f-724c-40fd-aa55-92f5ba019d70"
   },
   "FR_humber_hc_list_3": {
     "courtName": "Doncaster Justice Centre North",
     "courtAddress": "College Road, Doncaster, DN1 3HT",
     "phoneNumber": "0300 123 5577",
-    "email": "family.doncaster.countycourt@justice.gov.uk"
+    "email": "family.doncaster.countycourt@justice.gov.uk",
+    "emailReplyToId": "10199921-9e19-4f37-b43b-3ff8b6f642d1"
   },
   "FR_humber_hc_list_4": {
     "courtName": "Great Grimsby Combined Court Centre",
     "courtAddress": "Town Hall Square, Grimsby, DN31 1HX",
     "phoneNumber": "0300 123 5577",
-    "email": "family.grimsby.countycourt@justice.gov.uk"
+    "email": "family.grimsby.countycourt@justice.gov.uk",
+    "emailReplyToId": "62004e99-3b2d-423b-a556-2186f9995033"
   },
   "FR_humber_hc_list_5": {
     "courtName": "Barnsley Law Courts",
     "courtAddress": "The Court House, Westgate, Barnsley, S70 2DW",
     "phoneNumber": "0300 123 5577",
-    "email": "family.barnsley.countycourt@justice.gov.uk"
+    "email": "family.barnsley.countycourt@justice.gov.uk",
+    "emailReplyToId": "2ba9a295-91da-4a55-9588-78b5b03209b5"
   },
   "FR_liverpool_hc_list_1": {
     "courtName": "Liverpool Civil And Family Court",
     "courtAddress": "35 Vernon Street, Liverpool, L2 2BX",
     "phoneNumber": "0300 123 5577",
-    "email": "FRCLiverpool@Justice.gov.uk"
+    "email": "FRCLiverpool@Justice.gov.uk",
+    "emailReplyToId": "696714a7-e509-4da7-b94a-3a39600faafb"
   },
   "FR_liverpool_hc_list_2": {
     "courtName": "Chester Civil And Family Justice Centre",
     "courtAddress": "Trident House, Little St John Street, Chester, CH1 1SN",
     "phoneNumber": "0300 123 5577",
-    "email": "family.chester.countycourt@justice.gov.uk"
+    "email": "family.chester.countycourt@justice.gov.uk",
+    "emailReplyToId": "ce82c08c-0198-4b84-b0b6-5bbf85374cb0"
   },
   "FR_liverpool_hc_list_3": {
     "courtName": "Crewe County Court And Family Court",
     "courtAddress": "The Law Courts, Civic Centre, Crewe, CW1 2DP",
     "phoneNumber": "0300 123 5577",
-    "email": "FRCLiverpool@Justice.gov.uk"
+    "email": "FRCLiverpool@Justice.gov.uk",
+    "emailReplyToId": "696714a7-e509-4da7-b94a-3a39600faafb"
   },
   "FR_liverpool_hc_list_4": {
     "courtName": "St. Helens County Court And Family Court",
     "courtAddress": "St Helens Courthouse, Corporation Street, St Helens, WA10 1SZ",
     "phoneNumber": "0300 123 5577",
-    "email": "FRCLiverpool@Justice.gov.uk"
+    "email": "FRCLiverpool@Justice.gov.uk",
+    "emailReplyToId": "696714a7-e509-4da7-b94a-3a39600faafb"
   },
   "FR_liverpool_hc_list_5": {
     "courtName": "Birkenhead County Court And Family Court",
     "courtAddress": "76 Hamilton Street, Birkenhead, CH41 5EN",
     "phoneNumber": "0300 123 5577",
-    "email": "family.birkenhead.countycourt@justice.gov.uk"
+    "email": "family.birkenhead.countycourt@justice.gov.uk",
+    "emailReplyToId": "78c5690e-d3f1-4e56-9a8a-d75d48190255"
   },
   "FR_manchester_hc_list_1": {
     "courtName": "Manchester County And Family Court",
     "courtAddress": "1 Bridge Street West, Manchester, M60 9DJ",
     "phoneNumber": "0300 123 5577",
-    "email": "manchesterdivorce@justice.gov.uk"
+    "email": "manchesterdivorce@justice.gov.uk",
+    "emailReplyToId": "e6a6a705-2c86-4241-8c8a-702676b9f82b"
   },
   "FR_manchester_hc_list_2": {
     "courtName": "Stockport County Court And Family Court",
     "courtAddress": "The Courthouse, Edward Street, Stockport, SK1 3NF",
     "phoneNumber": "0300 123 5577",
-    "email": "Stockportfamily@Justice.gov.uk"
+    "email": "Stockportfamily@Justice.gov.uk",
+    "emailReplyToId": "55d228ed-cb20-40ff-b3a0-e616fbd3d821"
   },
   "FR_manchester_hc_list_3": {
     "courtName": "Wigan County Court And Family Court",
     "courtAddress": "Wigan and Leigh Courthouse, Darlington Street, Wigan, WN1 1DW",
     "phoneNumber": "0300 123 5577",
-    "email": "wiganfamily@justice.gov.uk"
+    "email": "wiganfamily@justice.gov.uk",
+    "emailReplyToId": "eafd7d24-b224-471b-9cf8-a4536ed146a0"
   },
   "FR_newport_hc_list_1": {
     "courtName": "Newport Civil and Family Court",
     "courtAddress": "Clarence House, Clarence Place, Newport, NP19 7AA",
     "phoneNumber": "0300 123 5577",
-    "email": "FRCNewport@justice.gov.uk"
+    "email": "FRCNewport@justice.gov.uk",
+    "emailReplyToId": "c03171fe-99dd-44cc-82a8-92a93d2fef12"
   },
   "FR_newport_hc_list_2": {
     "courtName": "Cardiff Civil & Family Justice Centre",
     "courtAddress": "2 Park Street, Cardiff, CF10 1ET",
     "phoneNumber": "0300 123 5577",
-    "email": "family.cardiff.countycourt@justice.gov.uk"
+    "email": "family.cardiff.countycourt@justice.gov.uk",
+    "emailReplyToId": "1f9ee1e2-8e08-4df6-afa8-1ef2a5c5d708"
   },
   "FR_newport_hc_list_3": {
     "courtName": "Merthyr Tydfil Combined Court Centre",
     "courtAddress": "The Law Courts, Glebeland Place, Merthyr Tydfil, CF47 8BH",
     "phoneNumber": "0300 123 5577",
-    "email": "family.merthyrtydfil.countycourt@justice.gov.uk"
+    "email": "family.merthyrtydfil.countycourt@justice.gov.uk",
+    "emailReplyToId": "95932987-38d1-4181-a000-b80fa68ffd2f"
   },
   "FR_newport_hc_list_4": {
     "courtName": "Pontypridd County and Family Court",
     "courtAddress": "The Courthouse, Courthouse Street, Pontypridd, CF37 1JR",
     "phoneNumber": "0300 123 5577",
-    "email": "Family.pontypridd.countycourt@justice.gov.uk"
+    "email": "Family.pontypridd.countycourt@justice.gov.uk",
+    "emailReplyToId": "7ed5f4b0-714b-4dbd-9bba-72881e4b0dc2"
   },
   "FR_newport_hc_list_5": {
     "courtName": "Blackwood Civil and Family Court",
     "courtAddress": "8 Hall Street, Blackwood, NP12 1NY",
     "phoneNumber": "0300 123 5577",
-    "email": "blackwood.family@justice.gov.uk"
+    "email": "blackwood.family@justice.gov.uk",
+    "emailReplyToId": "c5bfaa06-ccf6-43c4-9185-69bed530b616"
   },
   "FR_kent_surrey_hc_list_1": {
     "courtName": "Canterbury Family Court Hearing Centre",
     "courtAddress": "The Law Courts, Chaucer Road, Canterbury, CT1 1ZA",
     "phoneNumber": "0300 123 5577",
-    "email": "Family.canterbury.countycourt@justice.gov.uk"
+    "email": "Family.canterbury.countycourt@justice.gov.uk",
+    "emailReplyToId": "6e422e35-c6b0-4440-9ba7-91eee7a2018b"
   },
   "FR_kent_surrey_hc_list_2": {
     "courtName": "Maidstone Combined Court Centre",
     "courtAddress": "The Law Courts, Barker Road, Maidstone, ME16 8EQ",
     "phoneNumber": "0300 123 5577",
-    "email": "FRCKSS@justice.gov.uk"
+    "email": "FRCKSS@justice.gov.uk",
+    "emailReplyToId": "3ad5044f-af5f-43c1-8e90-0c561df26119"
   },
   "FR_kent_surrey_hc_list_3": {
     "courtName": "Dartford County Court And Family Court",
     "courtAddress": "Home Gardens, Dartford, DA1 1DX",
     "phoneNumber": "0300 123 5577",
-    "email": "family.dartford.countycourt@justice.gov.uk"
+    "email": "family.dartford.countycourt@justice.gov.uk",
+    "emailReplyToId": "ab724f7d-2990-4ef6-88be-f29c2adbaaa1"
   },
   "FR_kent_surrey_hc_list_4": {
     "courtName": "Medway County Court And Family Court",
     "courtAddress": "Gun Wharf, Dock Road, Chatham, Kent, ME4 4AR",
     "phoneNumber": "0300 123 5577",
-    "email": "FRCKSS@justice.gov.uk"
+    "email": "FRCKSS@justice.gov.uk",
+    "emailReplyToId": "3ad5044f-af5f-43c1-8e90-0c561df26119"
   },
   "FR_kent_surrey_hc_list_5": {
     "courtName": "Guildford County Court And Family Court",
     "courtAddress": "The Law Courts, Mary Road, Guildford, GU1 4PS",
     "phoneNumber": "0300 123 5577",
-    "email": "surreyfamily@Justice.gov.uk"
+    "email": "surreyfamily@Justice.gov.uk",
+    "emailReplyToId": "8ca3cf68-c695-40fc-994c-229399ee5662"
   },
   "FR_kent_surrey_hc_list_6": {
     "courtName": "Staines County Court And Family Court",
     "courtAddress": "Knowle Green, Staines, TW18 1XH",
     "phoneNumber": "0300 123 5577",
-    "email": "surreyfamily@Justice.gov.uk"
+    "email": "surreyfamily@Justice.gov.uk",
+    "emailReplyToId": "8ca3cf68-c695-40fc-994c-229399ee5662"
   },
   "FR_kent_surrey_hc_list_7": {
     "courtName": "Brighton County And Family Court",
     "courtAddress": "William Street, Brighton, BN2 0RF",
     "phoneNumber": "0300 123 5577",
-    "email": "sussexfamily@Justice.gov.uk"
+    "email": "sussexfamily@Justice.gov.uk",
+    "emailReplyToId": "5d28fd14-0095-4cbb-a734-f67eaf302d15"
   },
   "FR_kent_surrey_hc_list_8": {
     "courtName": "Worthing County Court And Family Court",
     "courtAddress": "The Law Courts, Christchurch Road, Worthing, BN11 1JD",
     "phoneNumber": "0300 123 5577",
-    "email": "worthingfamily@justice.gov.uk"
+    "email": "worthingfamily@justice.gov.uk",
+    "emailReplyToId": "0b458090-cfd6-4d6c-9a75-782341711a0f"
   },
   "FR_kent_surrey_hc_list_9": {
     "courtName": "Hastings County Court And Family Court Hearing Centre",
     "courtAddress": "The Law Courts, Bohemia Road, Hastings, TN34 1QX",
     "phoneNumber": "0300 123 5577",
-    "email": "hastingsfamily@justice.gov.uk"
+    "email": "hastingsfamily@justice.gov.uk",
+    "emailReplyToId": "7c85f1be-0824-4e5a-a34c-a1e171e404ed"
   },
   "FR_kent_surrey_hc_list_10": {
     "courtName": "Horsham County Court And Family Court",
     "courtAddress": "The Law Courts, Hurst Road, Horsham, RH12 2ET",
     "phoneNumber": "0300 123 5577",
-    "email": "sussexfamily@Justice.gov.uk"
+    "email": "sussexfamily@Justice.gov.uk",
+    "emailReplyToId": "5d28fd14-0095-4cbb-a734-f67eaf302d15"
   },
   "FR_kent_surrey_hc_list_11": {
     "courtName": "Thanet Family Court Hearing Centre",
     "courtAddress": "2nd Floor, The Courthouse, Cecil Square, Margate, Kent CT9 1RL",
     "phoneNumber": "01227 819200",
-    "email": "Family.canterbury.countycourt@justice.gov.uk"
+    "email": "Family.canterbury.countycourt@justice.gov.uk",
+    "emailReplyToId": "6e422e35-c6b0-4440-9ba7-91eee7a2018b"
   },
   "FR_swansea_hc_list_1": {
     "courtName": "Swansea Civil & Family Justice Centre",
     "courtAddress": "Carvella House, Quay West, Quay Parade, Swansea, SA1 1SD",
     "phoneNumber": "0300 123 5577",
-    "email": "FRCswansea@justice.gov.uk"
+    "email": "FRCswansea@justice.gov.uk",
+    "emailReplyToId": "7b214aa4-b7c0-4de6-9916-52428c246a3a"
   },
   "FR_swansea_hc_list_2": {
     "courtName": "Aberystwyth Justice Centre",
     "courtAddress": "Y Lanfa, Trefechan, Aberystwyth, SY23 1AS",
     "phoneNumber": "0300 123 5577",
-    "email": "family.aberystwyth.countycourt@justice.gov.uk"
+    "email": "family.aberystwyth.countycourt@justice.gov.uk",
+    "emailReplyToId": "9a1a67f8-9495-4511-9e9f-13738900e89f"
   },
   "FR_swansea_hc_list_3": {
     "courtName": "Haverfordwest County & Family Court",
     "courtAddress": "Penffynnon, Hawthorn Rise, Haverfordwest, SA61 2AX",
     "phoneNumber": "0300 123 5577",
-    "email": "family.haverfordwest.countycourt@justice.gov.uk"
+    "email": "family.haverfordwest.countycourt@justice.gov.uk",
+    "emailReplyToId": "b7290279-0305-42d6-a515-e998eff9f6bf"
   },
   "FR_swansea_hc_list_4": {
     "courtName": "Carmarthen County and Family Court",
     "courtAddress": "County Court, 2nd Floor Court Buildings, Town Hall Square, Llanelli, SA15 3AL",
     "phoneNumber": "0300 123 5577",
-    "email": "family.llanelli.countycourt@justice.gov.uk"
+    "email": "family.llanelli.countycourt@justice.gov.uk",
+    "emailReplyToId": "bf69f2f2-eddd-41db-9c14-131097bbc793"
   },
   "FR_swansea_hc_list_5": {
     "courtName": "Llanelli Law Courts",
     "courtAddress": "Town Hall Square, Llanelli, SA15 3AW",
     "phoneNumber": "0300 123 5577",
-    "email": "family.llanelli.countycourt@justice.gov.uk"
+    "email": "family.llanelli.countycourt@justice.gov.uk",
+    "emailReplyToId": "bf69f2f2-eddd-41db-9c14-131097bbc793"
   },
   "FR_swansea_hc_list_6": {
     "courtName": "Port Talbot Justice Centre",
     "courtAddress": "Harbourside Road, Port Talbot, SA13 1SB",
     "phoneNumber": "0300 123 5577",
-    "email": "ptjc.familyteam@justice.gov.uk"
+    "email": "ptjc.familyteam@justice.gov.uk",
+    "emailReplyToId": "d71f15d9-b6ae-4b5d-bc0a-fca6a09cca14"
   },
   "FR_nw_yorkshire_hc_list_1": {
     "courtName": "Harrogate Justice Centre",
     "courtAddress": "The Court House, Victoria Avenue, Harrogate, HG1 1EL",
     "phoneNumber": "0300 123 5577",
-    "email": "enquiries.harrogate.countycourt@Justice.gov.uk"
+    "email": "enquiries.harrogate.countycourt@Justice.gov.uk",
+    "emailReplyToId": "69848f8f-700e-4052-a108-5a38486287b1"
   },
   "FR_nw_yorkshire_hc_list_2": {
     "courtName": "Bradford Combined Court Centre",
     "courtAddress": "Exchange Square, Drake Street, Bradford, BD1 1JA",
     "phoneNumber": "0300 123 5577",
-    "email": "bradfordfamily@justice.gov.uk"
+    "email": "bradfordfamily@justice.gov.uk",
+    "emailReplyToId": "b1ba1849-5e2e-4e49-90ac-a9e7f0f5a03f"
   },
   "FR_nw_yorkshire_hc_list_3": {
     "courtName": "Huddersfield County Court and Family Court",
     "courtAddress": "Queensgate House, Queensgate, Huddersfield, HD1 2RR",
     "phoneNumber": "0300 123 5577",
-    "email": "huddersfieldfamily@justice.gov.uk"
+    "email": "huddersfieldfamily@justice.gov.uk",
+    "emailReplyToId": "95ddde2a-7d4f-4a98-8703-46bdaf10545b"
   },
   "FR_nw_yorkshire_hc_list_4": {
     "courtName": "Wakefield Civil and Family Justice Centre",
     "courtAddress": "1 Mulberry Way, Wakefield, WF1 2QN",
     "phoneNumber": "0300 123 5577",
-    "email": "wakefieldfamily@justice.gov.uk"
+    "email": "wakefieldfamily@justice.gov.uk",
+    "emailReplyToId": "cbaf906e-ce29-4c69-bd8b-219dfdb78095"
   },
   "FR_nw_yorkshire_hc_list_5": {
     "courtName": "York County Court and Family Court",
     "courtAddress": "Piccadilly House, 55 Piccadilly, York, YO1 9WL",
     "phoneNumber": "0300 123 5577",
-    "email": "family.york.countycourt@justice.gov.uk"
+    "email": "family.york.countycourt@justice.gov.uk",
+    "emailReplyToId": "91cf8019-9633-43b7-b854-06d6caf61a77"
   },
   "FR_nw_yorkshire_hc_list_6": {
     "courtName": "Scarborough Justice Centre",
     "courtAddress": "The Law Courts, Northway, Scarborough, YO12 7AE",
     "phoneNumber": "0300 123 5577",
-    "email": "family.scarborough.countycourt@justice.gov.uk"
+    "email": "family.scarborough.countycourt@justice.gov.uk",
+    "emailReplyToId": "2dd834a5-0ef2-4066-bc53-f64941e69b46"
   },
   "FR_nw_yorkshire_hc_list_7": {
     "courtName": "Skipton County Court and Family Court",
     "courtAddress": "The Court House, Otley Street, Skipton, BD23 1RH",
     "phoneNumber": "0300 123 5577",
-    "email": "skipton.cty.cm@justice.gov.uk"
+    "email": "skipton.cty.cm@justice.gov.uk",
+    "emailReplyToId": "61f274c9-13fa-44bd-bb5a-eb5e3b9827e6"
   },
   "FR_nw_yorkshire_hc_list_8": {
     "courtName": "Leeds Combined Court Centre",
     "courtAddress": "The Courthouse, 1 Oxford Row, Leeds, LS1 3BG",
     "phoneNumber": "0300 123 5577",
-    "email": "leedsfamily@justice.gov.uk"
+    "email": "leedsfamily@justice.gov.uk",
+    "emailReplyToId": "1a4ee76a-2e62-469c-b4b7-2edc2d9cb52a"
   },
   "FR_lancashireList_1": {
     "courtName": "Preston Designated Family Court",
     "courtAddress": "Sessions House, Lancaster Road, Preston, PR1 2PD",
     "phoneNumber": "0300 123 5577",
-    "email": "LancashireandCumbriaFRC@justice.gov.uk"
+    "email": "LancashireandCumbriaFRC@justice.gov.uk",
+    "emailReplyToId": "f1fda0b5-43f8-4089-8dc8-dd6ed46b86d5"
   },
   "FR_lancashireList_2": {
     "courtName": "Blackburn Family Court",
     "courtAddress": "64 Victoria Street, Blackburn, BB1 6DL",
     "phoneNumber": "0300 123 5577",
-    "email": "LancashireandCumbriaFRC@justice.gov.uk"
+    "email": "LancashireandCumbriaFRC@justice.gov.uk",
+    "emailReplyToId": "f1fda0b5-43f8-4089-8dc8-dd6ed46b86d5"
   },
   "FR_lancashireList_3": {
     "courtName": "Blackpool Family Court",
     "courtAddress": "The Law Courts, Chapel Street, Blackpool, FY1 5RJ",
     "phoneNumber": "0300 123 5577",
-    "email": "LancashireandCumbriaFRC@justice.gov.uk"
+    "email": "LancashireandCumbriaFRC@justice.gov.uk",
+    "emailReplyToId": "f1fda0b5-43f8-4089-8dc8-dd6ed46b86d5"
   },
   "FR_lancashireList_4": {
     "courtName": "Lancaster Courthouse",
     "courtAddress": "George Street, Lancaster, LA1 1XZ",
     "phoneNumber": "0300 123 5577",
-    "email": "LancashireandCumbriaFRC@justice.gov.uk"
+    "email": "LancashireandCumbriaFRC@justice.gov.uk",
+    "emailReplyToId": "f1fda0b5-43f8-4089-8dc8-dd6ed46b86d5"
   },
   "FR_lancashireList_5": {
     "courtName": "Leyland Family Hearing Centre",
     "courtAddress": "The Family Court, Lancastergate, Leyland, PR25 2EX",
     "phoneNumber": "0300 123 5577",
-    "email": "LancashireandCumbriaFRC@justice.gov.uk"
+    "email": "LancashireandCumbriaFRC@justice.gov.uk",
+    "emailReplyToId": "f1fda0b5-43f8-4089-8dc8-dd6ed46b86d5"
   },
   "FR_lancashireList_6": {
     "courtName": "Reedley Family Hearing Centre",
     "courtAddress": "The Court House, Colne Road (Junction with Swaledale Avenue), Reedley, Burnley, BB10 2LJ",
     "phoneNumber": "0300 123 5577",
-    "email": "LancashireandCumbriaFRC@justice.gov.uk"
+    "email": "LancashireandCumbriaFRC@justice.gov.uk",
+    "emailReplyToId": "f1fda0b5-43f8-4089-8dc8-dd6ed46b86d5"
   },
   "FR_lancashireList_7": {
     "courtName": "Barrow in Furness County and Family Court",
     "courtAddress": "Barrow Law Courts, Abbey Road, Barrow in Furness, LA14 6QX",
     "phoneNumber": "0300 123 5577",
-    "email": "LancashireandCumbriaFRC@justice.gov.uk"
+    "email": "LancashireandCumbriaFRC@justice.gov.uk",
+    "emailReplyToId": "f1fda0b5-43f8-4089-8dc8-dd6ed46b86d5"
   },
   "FR_lancashireList_8": {
     "courtName": "Carlisle Combined Court",
     "courtAddress": "Courts of Justice, Earl Street, Carlisle, CA1 1DJ",
     "phoneNumber": "0300 123 5577",
-    "email": "LancashireandCumbriaFRC@justice.gov.uk"
+    "email": "LancashireandCumbriaFRC@justice.gov.uk",
+    "emailReplyToId": "f1fda0b5-43f8-4089-8dc8-dd6ed46b86d5"
   },
   "FR_lancashireList_9": {
     "courtName": "West Cumbria Courthouse",
     "courtAddress": "Hall Park, Ramsay Brow, Workington, CA14 4AS",
     "phoneNumber": "0300 123 5577",
-    "email": "LancashireandCumbriaFRC@justice.gov.uk"
+    "email": "LancashireandCumbriaFRC@justice.gov.uk",
+    "emailReplyToId": "f1fda0b5-43f8-4089-8dc8-dd6ed46b86d5"
   },
   "FR_bedfordshireList_1": {
     "courtName": "Peterborough Combined Court Centre",
     "courtAddress": "Crown Buildings, Rivergate, Peterborough, PE1 1EJ",
     "phoneNumber": "0300 123 5577",
-    "email": "FRC.NES.BCH@justice.gov.uk"
+    "email": "FRC.NES.BCH@justice.gov.uk",
+    "emailReplyToId": "25dc4238-28f5-4787-af79-372627e94542"
   },
   "FR_bedfordshireList_2": {
     "courtName": "Cambridge County and Family Court",
     "courtAddress": "197 East Road, Cambridge, CB1 1BA",
     "phoneNumber": "0300 123 5577",
-    "email": "FRC.NES.BCH@justice.gov.uk"
+    "email": "FRC.NES.BCH@justice.gov.uk",
+    "emailReplyToId": "25dc4238-28f5-4787-af79-372627e94542"
   },
   "FR_bedfordshireList_3": {
     "courtName": "Bury St Edmunds County Court and Family Court",
     "courtAddress": "2nd Floor, Triton House, St Andrews Street (N), Bury St Edmunds, Suffolk, IP33 1TR",
     "phoneNumber": "0300 123 5577",
-    "email": "Family.Chelmsford.Countycourt@justice.gov.uk"
+    "email": "Family.Chelmsford.Countycourt@justice.gov.uk",
+    "emailReplyToId": "490128f7-d7fd-4f92-80bb-8e58650a02cb"
   },
   "FR_bedfordshireList_4": {
     "courtName": "Norwich Combined Court Centre",
     "courtAddress": "The Law courts, Bishopgate, Norwich, NR3 1UR",
     "phoneNumber": "0300 123 5577",
-    "email": "Family.norwich.countycourt@justice.gov.uk"
+    "email": "Family.norwich.countycourt@justice.gov.uk",
+    "emailReplyToId": "1eaa8086-fbf7-4d86-954a-6e5bb48cfefe"
   },
   "FR_bedfordshireList_5": {
     "courtName": "Ipswich County Court and Family Hearing Centre",
-    "courtAddress": "8 Arcade Street , Ipswich, IP1 1EJ",
+    "courtAddress": "8 Arcade Street, Ipswich, IP1 1EJ",
     "phoneNumber": "0300 123 5577",
-    "email": "Family.Chelmsford.Countycourt@justice.gov.uk"
+    "email": "Family.Chelmsford.Countycourt@justice.gov.uk",
+    "emailReplyToId": "490128f7-d7fd-4f92-80bb-8e58650a02cb"
   },
   "FR_bedfordshireList_6": {
     "courtName": "Chelmsford Justice Centre",
     "courtAddress": "Priory Place, New London Road, Chelmsford, CM2 0PP",
     "phoneNumber": "0300 123 5577",
-    "email": "Family.Chelmsford.Countycourt@justice.gov.uk"
+    "email": "Family.Chelmsford.Countycourt@justice.gov.uk",
+    "emailReplyToId": "490128f7-d7fd-4f92-80bb-8e58650a02cb"
   },
   "FR_bedfordshireList_7": {
     "courtName": "Southend County Court and Family Hearing Centre",
     "courtAddress": "80 Victoria Avenue, Southend-On-Sea, SS2 6EU",
     "phoneNumber": "0300 123 5577",
-    "email": "Family.Chelmsford.Countycourt@justice.gov.uk"
+    "email": "Family.Chelmsford.Countycourt@justice.gov.uk",
+    "emailReplyToId": "490128f7-d7fd-4f92-80bb-8e58650a02cb"
   },
   "FR_bedfordshireList_8": {
     "courtName": "Bedford County Court and Family Hearing Centre",
@@ -600,163 +696,190 @@
     "courtName": "Luton Justice Centre",
     "courtAddress": "Luton Justice Centre, Floors 4&5 Arndale House, The Mall, Luton, LU1 2EN",
     "phoneNumber": "0300 123 5577",
-    "email": "Lutoncountyfamily@Justice.gov.uk"
+    "email": "Lutoncountyfamily@Justice.gov.uk",
+    "emailReplyToId": "ec36ee15-3191-42c6-b0ee-7ce94fd0bf58"
   },
   "FR_bedfordshireList_10": {
     "courtName": "Hertford County Court and Family Hearing Centre",
     "courtAddress": "Shire Hall, Fore Street, Hertford, Hertfordshire, SG14 1BY",
     "phoneNumber": "0300 123 5577",
-    "email": "enquiries.hertford.countycourt@justice.gov.uk"
+    "email": "enquiries.hertford.countycourt@justice.gov.uk",
+    "emailReplyToId": "ce7a4d93-cd18-4aa7-b9e0-e32b264790d0"
   },
   "FR_bedfordshireList_11": {
     "courtName": "Watford County Court and Family Hearing Centre",
     "courtAddress": "10 King Street, Watford, Hertfordshire, WD18 0BW",
     "phoneNumber": "0300 123 5577",
-    "email": "watfordcountyfamily@justice.gov.uk "
+    "email": "watfordcountyfamily@justice.gov.uk",
+    "emailReplyToId": "4328732f-0e90-441d-8f23-40fd7ecb14b3"
   },
   "FR_thamesvalleyList_1": {
     "courtName": "Oxford Combined Court Centre",
     "courtAddress": "St Aldates, Oxford, OX1 1TL",
     "phoneNumber": "0300 123 5577",
-    "email": "FRCThamesValley@justice.gov.uk"
+    "email": "FRCThamesValley@justice.gov.uk",
+    "emailReplyToId": "f6c688f1-4e3d-4046-b27d-a3acf9efbebe"
   },
   "FR_thamesvalleyList_2": {
     "courtName": "Reading County Court and Family Court",
     "courtAddress": "Hearing Centre, 160-163 Friar Street, Reading, RG1 1HE",
     "phoneNumber": "0300 123 5577",
-    "email": "family.reading.countycourt@justice.gov.uk"
+    "email": "family.reading.countycourt@justice.gov.uk",
+    "emailReplyToId": "8a73d88e-9a42-404e-a989-f42a56e0fc3b"
   },
   "FR_thamesvalleyList_3": {
     "courtName": "Milton Keynes County Court and Family Court",
     "courtAddress": "351 Silbury Boulevard, Witon Gate East, Central Milton Keynes, MK9 2DT",
     "phoneNumber": "0300 123 5577",
-    "email": "family.miltonkeynes.countycourt@justice.gov.uk"
+    "email": "family.miltonkeynes.countycourt@justice.gov.uk",
+    "emailReplyToId": "1ff8c96e-ae6e-4e85-a55f-bc263f5111e4"
   },
   "FR_thamesvalleyList_4": {
     "courtName": "Slough County Court",
     "courtAddress": "The Law Courts, Windsor Road, Slough, SL1 2HE",
     "phoneNumber": "0300 123 5577",
-    "email": "family.reading.countycourt@justice.gov.uk"
+    "email": "family.reading.countycourt@justice.gov.uk",
+    "emailReplyToId": "8a73d88e-9a42-404e-a989-f42a56e0fc3b"
   },
   "FR_devonList_1": {
     "courtName": "Plymouth Combined Court",
     "courtAddress": "The Law Courts, 10 Armada Way, Plymouth, PL1 2ER",
     "phoneNumber": "0300 123 5577",
-    "email": "FR.PlymouthHub@justice.gov.uk"
+    "email": "FR.PlymouthHub@justice.gov.uk",
+    "emailReplyToId": "5fb049b7-5ee3-4457-8b76-b2c7611910ec"
   },
   "FR_devonList_2": {
     "courtName": "Exeter Combined Court Centre",
     "courtAddress": "Southernhay Gardens, Exeter, EX1 1UH",
     "phoneNumber": "0300 123 5577",
-    "email": "FR.PlymouthHub@justice.gov.uk"
+    "email": "FR.PlymouthHub@justice.gov.uk",
+    "emailReplyToId": "5fb049b7-5ee3-4457-8b76-b2c7611910ec"
   },
   "FR_devonList_3": {
     "courtName": "Taunton Crown, County and Family Court",
     "courtAddress": "The Shire Hall, Taunton, TA1 4EU",
     "phoneNumber": "0300 123 5577",
-    "email": "FR.PlymouthHub@justice.gov.uk"
+    "email": "FR.PlymouthHub@justice.gov.uk",
+    "emailReplyToId": "5fb049b7-5ee3-4457-8b76-b2c7611910ec"
   },
   "FR_devonList_4": {
     "courtName": "Torquay and Newton Abbot County and Family Court",
     "courtAddress": "The Willows, Nicholson Road, Torquay, TQ2 7AZ",
     "phoneNumber": "0300 123 5577",
-    "email": "FR.PlymouthHub@justice.gov.uk"
+    "email": "FR.PlymouthHub@justice.gov.uk",
+    "emailReplyToId": "5fb049b7-5ee3-4457-8b76-b2c7611910ec"
   },
   "FR_devonList_5": {
     "courtName": "Barnstaple Magistrates, County and Family Court",
     "courtAddress": "Barnstaple Law Courts, North Walk, Barnstaple, EX31 1DU",
     "phoneNumber": "0300 123 5577",
-    "email": "FR.PlymouthHub@justice.gov.uk"
+    "email": "FR.PlymouthHub@justice.gov.uk",
+    "emailReplyToId": "5fb049b7-5ee3-4457-8b76-b2c7611910ec"
   },
   "FR_devonList_6": {
     "courtName": "Truro County Court and Family Court",
     "courtAddress": "Edward Street, Truro, TR1 2PB",
     "phoneNumber": "0300 123 5577",
-    "email": "FR.PlymouthHub@justice.gov.uk"
+    "email": "FR.PlymouthHub@justice.gov.uk",
+    "emailReplyToId": "5fb049b7-5ee3-4457-8b76-b2c7611910ec"
   },
   "FR_devonList_7": {
     "courtName": "Yeovil County, Family and Magistrates Court",
     "courtAddress": "The Law Courts, Petters Way, Yeovil, BA20 1SW",
     "phoneNumber": "0300 123 5577",
-    "email": "FR.PlymouthHub@justice.gov.uk"
+    "email": "FR.PlymouthHub@justice.gov.uk",
+    "emailReplyToId": "5fb049b7-5ee3-4457-8b76-b2c7611910ec"
   },
   "FR_devonList_8": {
     "courtName": "Bodmin County Court and Family Court",
     "courtAddress": "The Law Courts, Launceston Road, Bodmin, PL31 2AL",
     "phoneNumber": "0300 123 5577",
-    "email": "FR.PlymouthHub@justice.gov.uk"
+    "email": "FR.PlymouthHub@justice.gov.uk",
+    "emailReplyToId": "5fb049b7-5ee3-4457-8b76-b2c7611910ec"
   },
   "FR_dorsetList_1": {
     "courtName": "Bournemouth and Poole County Court and Family Court",
     "courtAddress": "Courts of Justice, Deansleigh Road, Bournemouth, BH7 7DS",
     "phoneNumber": "0300 123 5577",
-    "email": "BournemouthFRC.bournemouth.countycourt@justice.gov.uk"
+    "email": "BournemouthFRC.bournemouth.countycourt@justice.gov.uk",
+    "emailReplyToId": "d6b2d0d5-d375-41de-b7ab-0484f4cd5100"
   },
   "FR_dorsetList_2": {
     "courtName": "Weymouth Combined Court",
     "courtAddress": "The Law Courts, Westway Road, Weymouth, DT4 8BS",
     "phoneNumber": "0300 123 5577",
-    "email": "BournemouthFRC.bournemouth.countycourt@justice.gov.uk"
+    "email": "BournemouthFRC.bournemouth.countycourt@justice.gov.uk",
+    "emailReplyToId": "d6b2d0d5-d375-41de-b7ab-0484f4cd5100"
   },
   "FR_dorsetList_3": {
     "courtName": "Winchester Combined Court Centre",
     "courtAddress": "Winchester Combined Court, The Law Courts, Winchester, SO23 9EL",
     "phoneNumber": "0300 123 5577",
-    "email": "BournemouthFRC.bournemouth.countycourt@justice.gov.uk"
+    "email": "BournemouthFRC.bournemouth.countycourt@justice.gov.uk",
+    "emailReplyToId": "d6b2d0d5-d375-41de-b7ab-0484f4cd5100"
   },
   "FR_dorsetList_4": {
     "courtName": "Portsmouth Combined Court Centre",
     "courtAddress": "The Courts of Justice, Winston Churchill Avenue, Portsmouth, PO1 2EB",
     "phoneNumber": "0300 123 5577",
-    "email": "BournemouthFRC.bournemouth.countycourt@justice.gov.uk"
+    "email": "BournemouthFRC.bournemouth.countycourt@justice.gov.uk",
+    "emailReplyToId": "d6b2d0d5-d375-41de-b7ab-0484f4cd5100"
   },
   "FR_dorsetList_5": {
     "courtName": "Southampton Combined Court Centre",
     "courtAddress": "The Courts of Justice, London Road, Southampton SO15 2XQ",
     "phoneNumber": "0300 123 5577",
-    "email": "BournemouthFRC.bournemouth.countycourt@justice.gov.uk"
+    "email": "BournemouthFRC.bournemouth.countycourt@justice.gov.uk",
+    "emailReplyToId": "d6b2d0d5-d375-41de-b7ab-0484f4cd5100"
   },
   "FR_dorsetList_6": {
     "courtName": "Aldershot Justice Centre",
     "courtAddress": "The Court House, Civic Centre, Wellington Avenue, Aldershot, GU11 1NY",
     "phoneNumber": "0300 123 5577",
-    "email": "BournemouthFRC.bournemouth.countycourt@justice.gov.uk"
+    "email": "BournemouthFRC.bournemouth.countycourt@justice.gov.uk",
+    "emailReplyToId": "d6b2d0d5-d375-41de-b7ab-0484f4cd5100"
   },
   "FR_dorsetList_7": {
     "courtName": "Basingstoke County and Family Court",
     "courtAddress": "The Court House, London Road, Basingstoke, RG21 4AB",
     "phoneNumber": "0300 123 5577",
-    "email": "BournemouthFRC.bournemouth.countycourt@justice.gov.uk"
+    "email": "BournemouthFRC.bournemouth.countycourt@justice.gov.uk",
+    "emailReplyToId": "d6b2d0d5-d375-41de-b7ab-0484f4cd5100"
   },
   "FR_dorsetList_8": {
     "courtName": "Newport (Isle of Wight) Combined Court",
     "courtAddress": "The Law Courts, 1 Quay Street, Newport, PO30 5YT",
     "phoneNumber": "0300 123 5577",
-    "email": "BournemouthFRC.bournemouth.countycourt@justice.gov.uk"
+    "email": "BournemouthFRC.bournemouth.countycourt@justice.gov.uk",
+    "emailReplyToId": "d6b2d0d5-d375-41de-b7ab-0484f4cd5100"
   },
   "FR_bristolList_1": {
     "courtName": "Bristol Civil and Family Justice Centre",
     "courtAddress": "2 Redcliff Street, Bristol, BS1 6GR",
     "phoneNumber": "0300 123 5577",
-    "email": "BristolFRC.bristol.countycourt@justice.gov.uk"
+    "email": "BristolFRC.bristol.countycourt@justice.gov.uk",
+    "emailReplyToId": "06eb50b8-dacc-41d7-a688-0d227309435b"
   },
   "FR_bristolList_2": {
     "courtName": "Gloucester and Cheltenham County and Family Court",
     "courtAddress": "Kimbrose Way, Gloucester, GL1 2DE",
     "phoneNumber": "0300 123 5577",
-    "email": "BristolFRC.bristol.countycourt@justice.gov.uk"
+    "email": "BristolFRC.bristol.countycourt@justice.gov.uk",
+    "emailReplyToId": "06eb50b8-dacc-41d7-a688-0d227309435b"
   },
   "FR_bristolList_3": {
     "courtName": "Swindon Combined Court",
     "courtAddress": "The Law Courts, Islington Street, Swindon, SN1 2HG",
     "phoneNumber": "0300 123 5577",
-    "email": "BristolFRC.bristol.countycourt@justice.gov.uk"
+    "email": "BristolFRC.bristol.countycourt@justice.gov.uk",
+    "emailReplyToId": "06eb50b8-dacc-41d7-a688-0d227309435b"
   },
   "FR_bristolList_4": {
     "courtName": "Salisbury Law Courts",
     "courtAddress": "Wilton Road, Salisbury, SP2 7EP",
     "phoneNumber": "0300 123 5577",
-    "email": "BristolFRC.bristol.countycourt@justice.gov.uk"
+    "email": "BristolFRC.bristol.countycourt@justice.gov.uk",
+    "emailReplyToId": "06eb50b8-dacc-41d7-a688-0d227309435b"
   },
   "FR_bristolList_5": {
     "courtName": "Bath Law Courts",
@@ -769,60 +892,70 @@
     "courtName": "Weston Super Mare County and Family Court",
     "courtAddress": "North Somerset Courthouse, The Hedges, St Georges, Weston-Super-Mare, BS22 7BB",
     "phoneNumber": "0300 123 5577",
-    "email": "BristolFRC.bristol.countycourt@justice.gov.uk"
+    "email": "BristolFRC.bristol.countycourt@justice.gov.uk",
+    "emailReplyToId": "06eb50b8-dacc-41d7-a688-0d227309435b"
   },
   "FR_bristolList_7": {
     "courtName": "Bristol Magistrates Court",
     "courtAddress": "Marlborough Street, Bristol, BS1 3NU",
     "phoneNumber": "0300 123 5577",
-    "email": "BristolFRC.bristol.countycourt@justice.gov.uk"
+    "email": "BristolFRC.bristol.countycourt@justice.gov.uk",
+    "emailReplyToId": "06eb50b8-dacc-41d7-a688-0d227309435b"
   },
   "FR_bristolList_8": {
     "courtName": "Swindon Magistrates Court",
     "courtAddress": "Princess Street, Swindon, SN1 2JB",
     "phoneNumber": "0300 123 5577",
-    "email": "BristolFRC.bristol.countycourt@justice.gov.uk"
+    "email": "BristolFRC.bristol.countycourt@justice.gov.uk",
+    "emailReplyToId": "06eb50b8-dacc-41d7-a688-0d227309435b"
   },
   "FR_northwalesList_1": {
     "courtName": "Wrexham County Court and Family Court",
     "courtAddress": "The Law Courts, Bodhyfryd, Wrexham, LL12 7BP",
     "phoneNumber": "0300 123 5577",
-    "email": "FRCWrexham@justice.gov.uk"
+    "email": "FRCWrexham@justice.gov.uk",
+    "emailReplyToId": "4378234f-8123-4079-bc37-fa4311cb9aa9"
   },
   "FR_northwalesList_2": {
     "courtName": "Caernarfon Justice Centre",
     "courtAddress": "Llanberis Road, Caernarfon, LL55 2DF",
     "phoneNumber": "0300 123 5577",
-    "email": "Family.caernarfon.countycourt@justice.gov.uk"
+    "email": "Family.caernarfon.countycourt@justice.gov.uk",
+    "emailReplyToId": "fd40a990-351f-4fcd-824f-6d9bf15bf511"
   },
   "FR_northwalesList_3": {
     "courtName": "Prestatyn Justice Centre",
     "courtAddress": "Victoria Road, Prestatyn, LL19 7TE",
     "phoneNumber": "0300 123 5577",
-    "email": "Family.prestatyn.countycourt@justice.gov.uk"
+    "email": "Family.prestatyn.countycourt@justice.gov.uk",
+    "emailReplyToId": "483646bb-755f-4778-8cc0-9205dce17a90"
   },
   "FR_northwalesList_4": {
     "courtName": "Welshpool Civil and Family Court",
     "courtAddress": "Welshpool Law Courts, 24 Severn Street, Welshpool, Powys, SY21 7UX",
     "phoneNumber": "0300 123 5577",
-    "email": "FRCWrexham@justice.gov.uk"
+    "email": "FRCWrexham@justice.gov.uk",
+    "emailReplyToId": "4378234f-8123-4079-bc37-fa4311cb9aa9"
   },
   "FR_northwalesList_5": {
     "courtName": "Mold County",
     "courtAddress": "Law Courts, Mold, CH7 1AE",
     "phoneNumber": "0300 123 5577",
-    "email": "FRCWrexham@justice.gov.uk"
+    "email": "FRCWrexham@justice.gov.uk",
+    "emailReplyToId": "4378234f-8123-4079-bc37-fa4311cb9aa9"
   },
   "FR_highCourtList_1": {
     "courtName": "High Court Family Division",
     "courtAddress": "High Court Family Division, Queens Building, Royal Courts of Justice, Strand, London, WC2A 2LL",
     "phoneNumber": "020 7947 7551",
-    "email": "rcj.familyhighcourt@justice.gov.uk"
+    "email": "rcj.familyhighcourt@justice.gov.uk",
+    "emailReplyToId": "10655eb2-2382-4ec9-992a-99be8ff0fd54"
   },
   "FR_londonList_1": {
     "courtName": "Central Family Court",
     "courtAddress": "Central Family Court, First Avenue House, 42-49 High Holborn, London WC1V 6NP",
     "phoneNumber": "0300 123 5577",
-    "email": "cfc.fru@justice.gov.uk"
+    "email": "FRCLondon@Justice.gov.uk",
+    "emailReplyToId": "ef8dbd1d-9fa2-4277-8b6e-111bcee3c9b9"
   }
 }


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DFR-3915

### Change description

Add emailReplyToId config. These are the ids that govuk.notify uses to determine which reply-to email address to use.
The only court that has not been updated is Central Family Court - this is awaiting confirmation from service as to what email address to use.
