### PR TITLE
DFR-5168: adding orchestrator for Users integration

### DIFF
--- a/docs/idam-user-orchestration.md
+++ b/docs/idam-user-orchestration.md
@@ -1,0 +1,305 @@
+# IDAM User Orchestration API
+
+This API automates the IDAM Postman collection steps for test-user management.
+
+It supports:
+
+- Create one or more users
+- Delete one or more users
+- Update one or more users by deleting each existing account and creating it again
+
+## Base URL
+
+When the service is running locally:
+
+```bash
+http://localhost:9000
+```
+
+All routes are under:
+
+```text
+/case-orchestration/idam/users
+```
+
+## Configuration
+
+Create and update need the IDAM `finrem` client secret to get a client-credentials access token.
+
+Preferred configuration:
+
+```bash
+export FINREM_IDAM_CLIENT_SECRET=<finrem-client-secret>
+```
+
+Optional configuration:
+
+```bash
+export IDAM_TEST_SUPPORT_ENV=aat
+export IDAM_TEST_SUPPORT_SCOPE="profile roles"
+```
+
+Defaults:
+
+| Property | Environment variable | Default |
+|----------|----------------------|---------|
+| `idam.test-support.default-env` | `IDAM_TEST_SUPPORT_ENV` | `aat` |
+| `idam.test-support.client-credentials-scope` | `IDAM_TEST_SUPPORT_SCOPE` | `profile roles` |
+| `idam.client.secret` | `FINREM_IDAM_CLIENT_SECRET` | `DUMMY_SECRET` |
+
+If `FINREM_IDAM_CLIENT_SECRET` is not available, create and update can receive a one-off secret using:
+
+```text
+X-IDAM-Client-Secret: <finrem-client-secret>
+```
+
+Do not put the client secret in the JSON body. This service can log request bodies when local debug body logging is
+enabled.
+
+The application cannot fetch the client secret by itself unless it is already available through the configured
+environment variable or mounted configtree secret.
+
+## Create User
+
+```http
+POST /case-orchestration/idam/users
+Content-Type: application/json
+```
+
+Request:
+
+```json
+{
+  "environment": "aat",
+  "password": "TempPassword123!",
+  "users": [
+    {
+      "email": "staff.admin@example.com",
+      "forename": "Staff",
+      "surname": "Admin",
+      "roleNames": [
+        "staff-admin",
+        "caseworker"
+      ]
+    }
+  ]
+}
+```
+
+`environment` may also be sent as `env`. If omitted, the API uses `IDAM_TEST_SUPPORT_ENV`, defaulting to `aat`.
+The same `password` is used for every user in the request.
+
+Curl:
+
+```bash
+curl -X POST "http://localhost:9000/case-orchestration/idam/users" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "environment": "aat",
+    "password": "TempPassword123!",
+    "users": [
+      {
+        "email": "staff.admin@example.com",
+        "forename": "Staff",
+        "surname": "Admin",
+        "roleNames": ["staff-admin", "caseworker"]
+      }
+    ]
+  }'
+```
+
+With one-off client secret override:
+
+```bash
+curl -X POST "http://localhost:9000/case-orchestration/idam/users" \
+  -H "Content-Type: application/json" \
+  -H "X-IDAM-Client-Secret: <finrem-client-secret>" \
+  -d '{
+    "environment": "aat",
+    "password": "TempPassword123!",
+    "users": [
+      {
+        "email": "staff.admin@example.com",
+        "forename": "Staff",
+        "surname": "Admin",
+        "roleNames": ["staff-admin", "caseworker"]
+      }
+    ]
+  }'
+```
+
+Successful response status: `201 Created`
+
+## Delete User
+
+```http
+DELETE /case-orchestration/idam/users
+Content-Type: application/json
+```
+
+Request:
+
+```json
+{
+  "environment": "aat",
+  "users": [
+    {
+      "email": "staff.admin@example.com"
+    }
+  ]
+}
+```
+
+Curl:
+
+```bash
+curl -X DELETE "http://localhost:9000/case-orchestration/idam/users" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "environment": "aat",
+    "users": [
+      {
+        "email": "staff.admin@example.com"
+      }
+    ]
+  }'
+```
+
+Successful response status: `200 OK`
+
+Delete does not need the client secret. It calls the IDAM testing-support account delete endpoint directly.
+
+## Update User
+
+IDAM does not expose an update step in the Postman collection. This route performs:
+
+1. Delete user by `existingEmail`
+2. Create user with the supplied replacement user data
+
+```http
+PUT /case-orchestration/idam/users
+Content-Type: application/json
+```
+
+Request:
+
+```json
+{
+  "environment": "aat",
+  "password": "NewTempPassword123!",
+  "users": [
+    {
+      "existingEmail": "staff.admin@example.com",
+      "email": "staff.admin@example.com",
+      "forename": "Staff",
+      "surname": "Admin",
+      "roleNames": [
+        "staff-admin",
+        "caseworker"
+      ]
+    }
+  ]
+}
+```
+
+The same `password` is used for every recreated user in the request.
+
+Curl:
+
+```bash
+curl -X PUT "http://localhost:9000/case-orchestration/idam/users" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "environment": "aat",
+    "password": "NewTempPassword123!",
+    "users": [
+      {
+        "existingEmail": "staff.admin@example.com",
+        "email": "staff.admin@example.com",
+        "forename": "Staff",
+        "surname": "Admin",
+        "roleNames": ["staff-admin", "caseworker"]
+      }
+    ]
+  }'
+```
+
+Successful response status: `200 OK`
+
+## Response Shape
+
+Create response example:
+
+```json
+{
+  "operation": "CREATE",
+  "environment": "aat",
+  "users": [
+    {
+      "id": "00000000-0000-0000-0000-000000000000",
+      "email": "staff.admin@example.com",
+      "roleNames": [
+        "staff-admin",
+        "caseworker"
+      ]
+    }
+  ],
+  "steps": [
+    {
+      "name": "GET_CLIENT_CREDENTIALS_TOKEN",
+      "target": "idam-web-public",
+      "statusCode": 200
+    },
+    {
+      "name": "CREATE_USER",
+      "target": "idam-testing-support-api",
+      "statusCode": 201
+    }
+  ]
+}
+```
+
+Delete response example:
+
+```json
+{
+  "operation": "DELETE",
+  "environment": "aat",
+  "users": [
+    {
+      "email": "staff.admin@example.com",
+      "deletedEmail": "staff.admin@example.com"
+    }
+  ],
+  "steps": [
+    {
+      "name": "DELETE_USER",
+      "target": "idam-api",
+      "statusCode": 204
+    }
+  ]
+}
+```
+
+Update response includes a `users` entry for each recreated user. Each entry includes `deletedEmail` and the recreated
+user details.
+
+## Validation
+
+Required fields:
+
+- Create: `password`, `users[].email`, `users[].forename`, `users[].surname`, `users[].roleNames`
+- Delete: `users[].email`
+- Update: `password`, `users[].existingEmail`, `users[].email`, `users[].forename`, `users[].surname`, `users[].roleNames`
+
+`environment` must contain only letters, numbers and hyphens.
+
+## IDAM Endpoints Called
+
+For environment `aat`, the orchestration calls:
+
+| Step | Method | Target |
+|------|--------|--------|
+| Get client credentials token | `POST` | `https://idam-web-public.aat.platform.hmcts.net/o/token` |
+| Create user | `POST` | `https://idam-testing-support-api.aat.platform.hmcts.net/test/idam/users` |
+| Delete user | `DELETE` | `https://idam-api.aat.platform.hmcts.net/testing-support/accounts/{email}` |

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/idam/IdamUserOrchestrationController.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/idam/IdamUserOrchestrationController.java
@@ -1,0 +1,58 @@
+package uk.gov.hmcts.reform.finrem.caseorchestration.idam;
+
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(value = "/case-orchestration/idam/users")
+@Slf4j
+public class IdamUserOrchestrationController {
+
+    public static final String IDAM_CLIENT_SECRET_HEADER = "X-IDAM-Client-Secret";
+
+    private final IdamUserOrchestrationService idamUserOrchestrationService;
+
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(summary = "Create an IDAM test user")
+    public ResponseEntity<IdamUserOrchestrationModels.OrchestrationResponse> createUser(
+        @RequestHeader(value = IDAM_CLIENT_SECRET_HEADER, required = false) String clientSecretOverride,
+        @Valid @RequestBody IdamUserOrchestrationModels.CreateUserRequest request) {
+
+        log.info("Creating {} IDAM test users in {}", request.users().size(), request.environment());
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(idamUserOrchestrationService.createUser(request, clientSecretOverride));
+    }
+
+    @DeleteMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(summary = "Delete an IDAM test user")
+    public ResponseEntity<IdamUserOrchestrationModels.OrchestrationResponse> deleteUser(
+        @Valid @RequestBody IdamUserOrchestrationModels.DeleteUserRequest request) {
+
+        log.info("Deleting {} IDAM test users in {}", request.users().size(), request.environment());
+        return ResponseEntity.ok(idamUserOrchestrationService.deleteUser(request));
+    }
+
+    @PutMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(summary = "Update an IDAM test user by deleting and recreating the account")
+    public ResponseEntity<IdamUserOrchestrationModels.OrchestrationResponse> updateUser(
+        @RequestHeader(value = IDAM_CLIENT_SECRET_HEADER, required = false) String clientSecretOverride,
+        @Valid @RequestBody IdamUserOrchestrationModels.UpdateUserRequest request) {
+
+        log.info("Updating {} IDAM test users in {}", request.users().size(), request.environment());
+        return ResponseEntity.ok(idamUserOrchestrationService.updateUser(request, clientSecretOverride));
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/idam/IdamUserOrchestrationModels.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/idam/IdamUserOrchestrationModels.java
@@ -1,0 +1,90 @@
+package uk.gov.hmcts.reform.finrem.caseorchestration.idam;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+import java.util.List;
+
+public final class IdamUserOrchestrationModels {
+
+    private IdamUserOrchestrationModels() {
+    }
+
+    public record CreateUserRequest(
+        @JsonAlias("env")
+        @Pattern(regexp = "^[a-zA-Z0-9-]+$", message = "environment must contain only letters, numbers and hyphens")
+        String environment,
+        @NotBlank String password,
+        @Valid @NotEmpty List<@NotNull User> users
+    ) {
+    }
+
+    public record DeleteUserRequest(
+        @JsonAlias("env")
+        @Pattern(regexp = "^[a-zA-Z0-9-]+$", message = "environment must contain only letters, numbers and hyphens")
+        String environment,
+        @Valid @NotEmpty List<@NotNull UserToDelete> users
+    ) {
+    }
+
+    public record UpdateUserRequest(
+        @JsonAlias("env")
+        @Pattern(regexp = "^[a-zA-Z0-9-]+$", message = "environment must contain only letters, numbers and hyphens")
+        String environment,
+        @NotBlank String password,
+        @Valid @NotEmpty List<@NotNull UserToUpdate> users
+    ) {
+    }
+
+    public record User(
+        @Email @NotBlank String email,
+        @NotBlank String forename,
+        @NotBlank String surname,
+        @NotEmpty List<@NotBlank String> roleNames
+    ) {
+    }
+
+    public record UserToDelete(
+        @Email @NotBlank String email
+    ) {
+    }
+
+    public record UserToUpdate(
+        @Email @NotBlank String existingEmail,
+        @Email @NotBlank String email,
+        @NotBlank String forename,
+        @NotBlank String surname,
+        @NotEmpty List<@NotBlank String> roleNames
+    ) {
+        User toUser() {
+            return new User(email, forename, surname, roleNames);
+        }
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record OrchestrationResponse(
+        String operation,
+        String environment,
+        List<UserResult> users,
+        List<Step> steps
+    ) {
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record UserResult(
+        String id,
+        String email,
+        String deletedEmail,
+        List<String> roleNames
+    ) {
+    }
+
+    public record Step(String name, String target, int statusCode) {
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/idam/IdamUserOrchestrationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/idam/IdamUserOrchestrationService.java
@@ -1,0 +1,284 @@
+package uk.gov.hmcts.reform.finrem.caseorchestration.idam;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.util.UriComponentsBuilder;
+import uk.gov.hmcts.reform.idam.client.OAuth2Configuration;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+@Service
+public class IdamUserOrchestrationService {
+
+    private static final ParameterizedTypeReference<Map<String, Object>> MAP_RESPONSE =
+        new ParameterizedTypeReference<>() {
+        };
+    private static final String CLIENT_CREDENTIALS_GRANT_TYPE = "client_credentials";
+    private static final String DUMMY_SECRET = "DUMMY_SECRET";
+    private static final String IDAM_API = "idam-api";
+    private static final String IDAM_TESTING_SUPPORT_API = "idam-testing-support-api";
+    private static final String IDAM_WEB_PUBLIC = "idam-web-public";
+    private static final String STEP_CREATE_USER = "CREATE_USER";
+    private static final String STEP_DELETE_USER = "DELETE_USER";
+    private static final String STEP_GET_CLIENT_CREDENTIALS_TOKEN = "GET_CLIENT_CREDENTIALS_TOKEN";
+    private static final Pattern ENVIRONMENT_PATTERN = Pattern.compile("^[a-z0-9-]+$");
+
+    private final RestTemplate restTemplate;
+    private final OAuth2Configuration oauth2Configuration;
+    private final String defaultEnvironment;
+    private final String clientCredentialsScope;
+
+    public IdamUserOrchestrationService(RestTemplate restTemplate,
+                                        OAuth2Configuration oauth2Configuration,
+                                        @Value("${idam.test-support.default-env}") String defaultEnvironment,
+                                        @Value("${idam.test-support.client-credentials-scope}") String clientCredentialsScope) {
+        this.restTemplate = restTemplate;
+        this.oauth2Configuration = oauth2Configuration;
+        this.defaultEnvironment = defaultEnvironment;
+        this.clientCredentialsScope = clientCredentialsScope;
+    }
+
+    public IdamUserOrchestrationModels.OrchestrationResponse createUser(
+        IdamUserOrchestrationModels.CreateUserRequest request,
+        String clientSecretOverride) {
+
+        String environment = resolveEnvironment(request.environment());
+        List<IdamUserOrchestrationModels.Step> steps = new ArrayList<>();
+        String accessToken = getClientCredentialsAccessToken(environment, resolveClientSecret(clientSecretOverride), steps);
+        List<IdamUserOrchestrationModels.UserResult> users = request.users().stream()
+            .map(user -> createdUserResult(createUserInIdam(environment, accessToken, request.password(), user, steps), user, null))
+            .toList();
+
+        return new IdamUserOrchestrationModels.OrchestrationResponse("CREATE", environment, users, steps);
+    }
+
+    public IdamUserOrchestrationModels.OrchestrationResponse deleteUser(
+        IdamUserOrchestrationModels.DeleteUserRequest request) {
+
+        String environment = resolveEnvironment(request.environment());
+        List<IdamUserOrchestrationModels.Step> steps = new ArrayList<>();
+        List<IdamUserOrchestrationModels.UserResult> users = request.users().stream()
+            .map(user -> {
+                deleteUserFromIdam(environment, user.email(), steps);
+                return new IdamUserOrchestrationModels.UserResult(null, user.email(), user.email(), null);
+            })
+            .toList();
+
+        return new IdamUserOrchestrationModels.OrchestrationResponse("DELETE", environment, users, steps);
+    }
+
+    public IdamUserOrchestrationModels.OrchestrationResponse updateUser(
+        IdamUserOrchestrationModels.UpdateUserRequest request,
+        String clientSecretOverride) {
+
+        String environment = resolveEnvironment(request.environment());
+        List<IdamUserOrchestrationModels.Step> steps = new ArrayList<>();
+        String clientSecret = resolveClientSecret(clientSecretOverride);
+
+        request.users().forEach(user -> deleteUserFromIdam(environment, user.existingEmail(), steps));
+        String accessToken = getClientCredentialsAccessToken(environment, clientSecret, steps);
+        List<IdamUserOrchestrationModels.UserResult> users = request.users().stream()
+            .map(user -> createdUserResult(
+                createUserInIdam(environment, accessToken, request.password(), user.toUser(), steps),
+                user.toUser(),
+                user.existingEmail()
+            ))
+            .toList();
+
+        return new IdamUserOrchestrationModels.OrchestrationResponse("UPDATE", environment, users, steps);
+    }
+
+    private Map<String, Object> createUserInIdam(String environment,
+                                                 String accessToken,
+                                                 String password,
+                                                 IdamUserOrchestrationModels.User user,
+                                                 List<IdamUserOrchestrationModels.Step> steps) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setBearerAuth(accessToken);
+
+        ResponseEntity<Map<String, Object>> response = exchangeForMap(
+            STEP_CREATE_USER,
+            buildUri(IDAM_TESTING_SUPPORT_API, environment, "test", "idam", "users"),
+            HttpMethod.POST,
+            new HttpEntity<>(Map.of("password", password, "user", user), headers)
+        );
+
+        requireStatus(response, HttpStatus.CREATED, STEP_CREATE_USER);
+        steps.add(step(STEP_CREATE_USER, IDAM_TESTING_SUPPORT_API, response));
+        return response.getBody();
+    }
+
+    private void deleteUserFromIdam(String environment,
+                                    String email,
+                                    List<IdamUserOrchestrationModels.Step> steps) {
+        ResponseEntity<Void> response = exchangeForVoid(
+            STEP_DELETE_USER,
+            buildUri(IDAM_API, environment, "testing-support", "accounts", email),
+            HttpMethod.DELETE,
+            HttpEntity.EMPTY
+        );
+
+        requireStatus(response, HttpStatus.NO_CONTENT, STEP_DELETE_USER);
+        steps.add(step(STEP_DELETE_USER, IDAM_API, response));
+    }
+
+    private String getClientCredentialsAccessToken(String environment,
+                                                   String clientSecret,
+                                                   List<IdamUserOrchestrationModels.Step> steps) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", CLIENT_CREDENTIALS_GRANT_TYPE);
+        body.add("client_id", oauth2Configuration.getClientId());
+        body.add("client_secret", clientSecret);
+        body.add("scope", clientCredentialsScope);
+
+        ResponseEntity<Map<String, Object>> response = exchangeForMap(
+            STEP_GET_CLIENT_CREDENTIALS_TOKEN,
+            buildUri(IDAM_WEB_PUBLIC, environment, "o", "token"),
+            HttpMethod.POST,
+            new HttpEntity<>(body, headers)
+        );
+
+        requireStatus(response, HttpStatus.OK, STEP_GET_CLIENT_CREDENTIALS_TOKEN);
+        steps.add(step(STEP_GET_CLIENT_CREDENTIALS_TOKEN, IDAM_WEB_PUBLIC, response));
+
+        String accessToken = stringValue(response.getBody(), "access_token");
+        if (StringUtils.isBlank(accessToken)) {
+            throw new ResponseStatusException(
+                HttpStatus.BAD_GATEWAY,
+                "IDAM client credentials token response did not contain an access_token"
+            );
+        }
+
+        return accessToken;
+    }
+
+    private ResponseEntity<Map<String, Object>> exchangeForMap(String step,
+                                                               URI uri,
+                                                               HttpMethod method,
+                                                               HttpEntity<?> entity) {
+        try {
+            return restTemplate.exchange(uri, method, entity, MAP_RESPONSE);
+        } catch (HttpStatusCodeException exception) {
+            throw badGateway(step, exception.getStatusCode().value(), exception);
+        } catch (RestClientException exception) {
+            throw badGateway(step, null, exception);
+        }
+    }
+
+    private ResponseEntity<Void> exchangeForVoid(String step,
+                                                 URI uri,
+                                                 HttpMethod method,
+                                                 HttpEntity<?> entity) {
+        try {
+            return restTemplate.exchange(uri, method, entity, Void.class);
+        } catch (HttpStatusCodeException exception) {
+            throw badGateway(step, exception.getStatusCode().value(), exception);
+        } catch (RestClientException exception) {
+            throw badGateway(step, null, exception);
+        }
+    }
+
+    private ResponseStatusException badGateway(String step, Integer statusCode, RestClientException exception) {
+        String message = statusCode == null
+            ? String.format("IDAM test-user orchestration step %s failed", step)
+            : String.format("IDAM test-user orchestration step %s failed with status %s", step, statusCode);
+        return new ResponseStatusException(HttpStatus.BAD_GATEWAY, message, exception);
+    }
+
+    private void requireStatus(ResponseEntity<?> response, HttpStatus expectedStatus, String step) {
+        if (response.getStatusCode().value() != expectedStatus.value()) {
+            throw new ResponseStatusException(
+                HttpStatus.BAD_GATEWAY,
+                String.format("IDAM test-user orchestration step %s returned %s instead of %s",
+                    step, response.getStatusCode().value(), expectedStatus.value())
+            );
+        }
+    }
+
+    private URI buildUri(String serviceName, String environment, String... pathSegments) {
+        UriComponentsBuilder builder = UriComponentsBuilder.newInstance()
+            .scheme("https")
+            .host(String.format("%s.%s.platform.hmcts.net", serviceName, environment));
+
+        for (String pathSegment : pathSegments) {
+            builder.pathSegment(pathSegment);
+        }
+
+        return builder.build().toUri();
+    }
+
+    private String resolveEnvironment(String requestEnvironment) {
+        String environment = StringUtils.defaultIfBlank(requestEnvironment, defaultEnvironment)
+            .trim()
+            .toLowerCase(Locale.ROOT);
+
+        if (!ENVIRONMENT_PATTERN.matcher(environment).matches()) {
+            throw new ResponseStatusException(
+                HttpStatus.BAD_REQUEST,
+                "environment must contain only letters, numbers and hyphens"
+            );
+        }
+
+        return environment;
+    }
+
+    private String resolveClientSecret(String clientSecretOverride) {
+        String clientSecret = StringUtils.defaultIfBlank(clientSecretOverride, oauth2Configuration.getClientSecret());
+
+        if (StringUtils.isBlank(clientSecret) || DUMMY_SECRET.equals(clientSecret)) {
+            throw new ResponseStatusException(
+                HttpStatus.BAD_REQUEST,
+                "IDAM client secret must be supplied with X-IDAM-Client-Secret or configured as FINREM_IDAM_CLIENT_SECRET"
+            );
+        }
+
+        return clientSecret;
+    }
+
+    private IdamUserOrchestrationModels.UserResult createdUserResult(
+        Map<String, Object> createdUser,
+        IdamUserOrchestrationModels.User requestedUser,
+        String deletedEmail) {
+
+        return new IdamUserOrchestrationModels.UserResult(
+            stringValue(createdUser, "id"),
+            StringUtils.defaultIfBlank(stringValue(createdUser, "email"), requestedUser.email()),
+            deletedEmail,
+            requestedUser.roleNames()
+        );
+    }
+
+    private String stringValue(Map<String, Object> response, String key) {
+        if (response == null || response.get(key) == null) {
+            return null;
+        }
+        return response.get(key).toString();
+    }
+
+    private IdamUserOrchestrationModels.Step step(String name, String target, ResponseEntity<?> response) {
+        return new IdamUserOrchestrationModels.Step(name, target, response.getStatusCode().value());
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/wrapper/Bin.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/wrapper/Bin.java
@@ -7,6 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.TemporaryField;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CaseDocument;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.DynamicList;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.DynamicListElement;
@@ -26,6 +27,7 @@ import java.util.stream.Stream;
 public class Bin {
 
     @JsonProperty("bin_fileUrls")
+    @TemporaryField
     private DynamicList fileUrlsToBeDeleted;
 
     /**

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/wrapper/SendOrderWrapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/wrapper/SendOrderWrapper.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.TemporaryField;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CaseDocument;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.DocumentCollectionItem;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.DynamicMultiSelectList;
@@ -24,6 +25,7 @@ public class SendOrderWrapper {
     @Deprecated
     private CaseDocument additionalDocument;
 
+    @TemporaryField
     private List<DocumentCollectionItem> additionalDocuments;
 
     private OrdersToSend ordersToSend;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -189,6 +189,8 @@ idam.client.redirect_uri=${IDAM_API_REDIRECT_URL:https://finrem-frontend-aat.ser
 idam.client.id=finrem
 idam.client.secret=${FINREM_IDAM_CLIENT_SECRET:DUMMY_SECRET}
 idam.client.scope=${FINREM_IDAM_CLIENT_SCOPE:openid profile roles manage-user }
+idam.test-support.default-env=${IDAM_TEST_SUPPORT_ENV:aat}
+idam.test-support.client-credentials-scope=${IDAM_TEST_SUPPORT_SCOPE:profile roles}
 # PRD / Organisation Details
 prd.organisations.url=${PRD_API_URL:http://localhost:8090}
 prd.organisations.organisationsUrl=${prd.organisations.url}/refdata/external/v1/organisations

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/idam/IdamUserOrchestrationControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/idam/IdamUserOrchestrationControllerTest.java
@@ -1,0 +1,172 @@
+package uk.gov.hmcts.reform.finrem.caseorchestration.idam;
+
+import org.junit.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import uk.gov.hmcts.reform.finrem.caseorchestration.controllers.BaseControllerTest;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.reform.finrem.caseorchestration.idam.IdamUserOrchestrationController.IDAM_CLIENT_SECRET_HEADER;
+
+@WebMvcTest(IdamUserOrchestrationController.class)
+public class IdamUserOrchestrationControllerTest extends BaseControllerTest {
+
+    private static final String IDAM_USERS_URL = "/case-orchestration/idam/users";
+
+    @MockitoBean
+    private IdamUserOrchestrationService idamUserOrchestrationService;
+
+    @Test
+    public void shouldCreateUser() throws Exception {
+        when(idamUserOrchestrationService.createUser(
+            any(IdamUserOrchestrationModels.CreateUserRequest.class), eq("secret"))
+        ).thenReturn(response("CREATE"));
+
+        mvc.perform(post(IDAM_USERS_URL)
+                .header(IDAM_CLIENT_SECRET_HEADER, "secret")
+                .content(createJson())
+                .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.operation", is("CREATE")))
+            .andExpect(jsonPath("$.users[0].email", is("staff.admin@example.com")));
+
+        verify(idamUserOrchestrationService).createUser(
+            any(IdamUserOrchestrationModels.CreateUserRequest.class), eq("secret")
+        );
+    }
+
+    @Test
+    public void shouldDeleteUser() throws Exception {
+        when(idamUserOrchestrationService.deleteUser(any(IdamUserOrchestrationModels.DeleteUserRequest.class)))
+            .thenReturn(new IdamUserOrchestrationModels.OrchestrationResponse(
+                "DELETE",
+                "aat",
+                List.of(new IdamUserOrchestrationModels.UserResult(
+                    null,
+                    "staff.admin@example.com",
+                    "staff.admin@example.com",
+                    null
+                )),
+                List.of(step("DELETE_USER"))
+            ));
+
+        mvc.perform(delete(IDAM_USERS_URL)
+                .content("""
+                    {
+                      "environment": "aat",
+                      "users": [
+                        {
+                          "email": "staff.admin@example.com"
+                        }
+                      ]
+                    }
+                    """)
+                .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.operation", is("DELETE")))
+            .andExpect(jsonPath("$.users[0].deletedEmail", is("staff.admin@example.com")));
+
+        verify(idamUserOrchestrationService).deleteUser(
+            any(IdamUserOrchestrationModels.DeleteUserRequest.class)
+        );
+    }
+
+    @Test
+    public void shouldUpdateUser() throws Exception {
+        when(idamUserOrchestrationService.updateUser(
+            any(IdamUserOrchestrationModels.UpdateUserRequest.class), eq("secret"))
+        ).thenReturn(response("UPDATE"));
+
+        mvc.perform(put(IDAM_USERS_URL)
+                .header(IDAM_CLIENT_SECRET_HEADER, "secret")
+                .content("""
+                    {
+                      "environment": "aat",
+                      "password": "updated-password",
+                      "users": [
+                        {
+                          "existingEmail": "staff.admin@example.com",
+                          "email": "staff.admin@example.com",
+                          "forename": "Staff",
+                          "surname": "Admin",
+                          "roleNames": [
+                            "staff-admin",
+                            "caseworker"
+                          ]
+                        }
+                      ]
+                    }
+                    """)
+                .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.operation", is("UPDATE")))
+            .andExpect(jsonPath("$.users[0].email", is("staff.admin@example.com")));
+
+        verify(idamUserOrchestrationService).updateUser(
+            any(IdamUserOrchestrationModels.UpdateUserRequest.class), eq("secret")
+        );
+    }
+
+    @Test
+    public void shouldRejectCreateWithoutUser() throws Exception {
+        mvc.perform(post(IDAM_USERS_URL)
+                .content("""
+                    {
+                      "environment": "aat",
+                      "password": "test-password"
+                    }
+                    """)
+                .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isBadRequest());
+    }
+
+    private String createJson() {
+        return """
+            {
+              "environment": "aat",
+              "password": "test-password",
+              "users": [
+                {
+                  "email": "staff.admin@example.com",
+                  "forename": "Staff",
+                  "surname": "Admin",
+                  "roleNames": [
+                    "staff-admin",
+                    "caseworker"
+                  ]
+                }
+              ]
+            }
+            """;
+    }
+
+    private IdamUserOrchestrationModels.OrchestrationResponse response(String operation) {
+        return new IdamUserOrchestrationModels.OrchestrationResponse(
+            operation,
+            "aat",
+            List.of(new IdamUserOrchestrationModels.UserResult(
+                "user-id",
+                "staff.admin@example.com",
+                null,
+                List.of("staff-admin", "caseworker")
+            )),
+            List.of(step("GET_CLIENT_CREDENTIALS_TOKEN"), step("CREATE_USER"))
+        );
+    }
+
+    private IdamUserOrchestrationModels.Step step(String name) {
+        return new IdamUserOrchestrationModels.Step(name, "idam", 200);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/idam/IdamUserOrchestrationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/idam/IdamUserOrchestrationServiceTest.java
@@ -1,0 +1,231 @@
+package uk.gov.hmcts.reform.finrem.caseorchestration.idam;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.server.ResponseStatusException;
+import uk.gov.hmcts.reform.idam.client.OAuth2Configuration;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class IdamUserOrchestrationServiceTest {
+
+    private static final String CLIENT_ID = "finrem";
+    private static final String CLIENT_SECRET = "configured-secret";
+    private static final String TOKEN = "access-token";
+    private static final String USER_EMAIL = "staff.admin@example.com";
+    private static final String USER_ID = "user-id";
+
+    @Mock
+    private RestTemplate restTemplate;
+    @Mock
+    private OAuth2Configuration oauth2Configuration;
+
+    private IdamUserOrchestrationService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new IdamUserOrchestrationService(restTemplate, oauth2Configuration, "aat", "profile roles");
+    }
+
+    @Test
+    void shouldCreateUserUsingClientCredentialsToken() {
+        when(oauth2Configuration.getClientId()).thenReturn(CLIENT_ID);
+        when(oauth2Configuration.getClientSecret()).thenReturn(CLIENT_SECRET);
+        whenIdamCreateFlowSucceeds();
+
+        IdamUserOrchestrationModels.OrchestrationResponse response = service.createUser(createRequest("demo"), null);
+
+        assertThat(response.operation()).isEqualTo("CREATE");
+        assertThat(response.environment()).isEqualTo("demo");
+        assertThat(response.users()).hasSize(1);
+        assertThat(response.users().get(0).id()).isEqualTo(USER_ID);
+        assertThat(response.users().get(0).email()).isEqualTo(USER_EMAIL);
+        assertThat(response.users().get(0).roleNames()).containsExactly("staff-admin", "caseworker");
+        assertThat(response.steps()).extracting(IdamUserOrchestrationModels.Step::name)
+            .containsExactly("GET_CLIENT_CREDENTIALS_TOKEN", "CREATE_USER");
+
+        assertTokenRequest("https://idam-web-public.demo.platform.hmcts.net/o/token", CLIENT_SECRET);
+        assertCreateUserRequest("https://idam-testing-support-api.demo.platform.hmcts.net/test/idam/users");
+    }
+
+    @Test
+    void shouldUseClientSecretHeaderOverrideWhenProvided() {
+        when(oauth2Configuration.getClientId()).thenReturn(CLIENT_ID);
+        whenIdamCreateFlowSucceeds();
+
+        service.createUser(createRequest(null), "override-secret");
+
+        assertTokenRequest("https://idam-web-public.aat.platform.hmcts.net/o/token", "override-secret");
+    }
+
+    @Test
+    void shouldDeleteUser() {
+        when(restTemplate.exchange(any(URI.class), eq(HttpMethod.DELETE), any(HttpEntity.class), eq(Void.class)))
+            .thenReturn(ResponseEntity.noContent().build());
+
+        IdamUserOrchestrationModels.OrchestrationResponse response = service.deleteUser(
+            new IdamUserOrchestrationModels.DeleteUserRequest(
+                "aat",
+                List.of(new IdamUserOrchestrationModels.UserToDelete(USER_EMAIL))
+            )
+        );
+
+        assertThat(response.operation()).isEqualTo("DELETE");
+        assertThat(response.users()).hasSize(1);
+        assertThat(response.users().get(0).email()).isEqualTo(USER_EMAIL);
+        assertThat(response.users().get(0).deletedEmail()).isEqualTo(USER_EMAIL);
+        assertThat(response.steps()).extracting(IdamUserOrchestrationModels.Step::name)
+            .containsExactly("DELETE_USER");
+
+        ArgumentCaptor<URI> uriCaptor = ArgumentCaptor.forClass(URI.class);
+        verify(restTemplate).exchange(uriCaptor.capture(), eq(HttpMethod.DELETE), any(HttpEntity.class), eq(Void.class));
+        assertThat(uriCaptor.getValue()).hasToString(
+            "https://idam-api.aat.platform.hmcts.net/testing-support/accounts/staff.admin@example.com"
+        );
+    }
+
+    @Test
+    void shouldUpdateUserByDeletingAndCreating() {
+        when(oauth2Configuration.getClientId()).thenReturn(CLIENT_ID);
+        when(oauth2Configuration.getClientSecret()).thenReturn(CLIENT_SECRET);
+        when(restTemplate.exchange(any(URI.class), eq(HttpMethod.DELETE), any(HttpEntity.class), eq(Void.class)))
+            .thenReturn(ResponseEntity.noContent().build());
+        whenIdamCreateFlowSucceeds();
+
+        IdamUserOrchestrationModels.OrchestrationResponse response = service.updateUser(
+            new IdamUserOrchestrationModels.UpdateUserRequest(
+                "aat",
+                "updated-password",
+                List.of(new IdamUserOrchestrationModels.UserToUpdate(
+                    "old.staff.admin@example.com",
+                    USER_EMAIL,
+                    "Staff",
+                    "Admin",
+                    List.of("staff-admin", "caseworker")
+                ))
+            ),
+            null
+        );
+
+        assertThat(response.operation()).isEqualTo("UPDATE");
+        assertThat(response.users()).hasSize(1);
+        assertThat(response.users().get(0).deletedEmail()).isEqualTo("old.staff.admin@example.com");
+        assertThat(response.users().get(0).id()).isEqualTo(USER_ID);
+        assertThat(response.users().get(0).email()).isEqualTo(USER_EMAIL);
+        assertThat(response.steps()).extracting(IdamUserOrchestrationModels.Step::name)
+            .containsExactly("DELETE_USER", "GET_CLIENT_CREDENTIALS_TOKEN", "CREATE_USER");
+    }
+
+    @Test
+    void shouldRejectCreateWhenClientSecretIsNotConfiguredOrProvided() {
+        when(oauth2Configuration.getClientSecret()).thenReturn("DUMMY_SECRET");
+
+        assertThatThrownBy(() -> service.createUser(createRequest("aat"), null))
+            .isInstanceOf(ResponseStatusException.class)
+            .extracting("statusCode")
+            .isEqualTo(HttpStatus.BAD_REQUEST);
+
+        verify(restTemplate, never()).exchange(
+            any(URI.class), any(HttpMethod.class), any(HttpEntity.class), anyMapResponse()
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    private void assertTokenRequest(String expectedUri, String expectedSecret) {
+        ArgumentCaptor<URI> uriCaptor = ArgumentCaptor.forClass(URI.class);
+        ArgumentCaptor<HttpEntity> entityCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+
+        verify(restTemplate, times(2)).exchange(
+            uriCaptor.capture(),
+            eq(HttpMethod.POST),
+            entityCaptor.capture(),
+            anyMapResponse()
+        );
+
+        assertThat(uriCaptor.getAllValues().get(0)).hasToString(expectedUri);
+        assertThat(entityCaptor.getAllValues().get(0).getHeaders().getContentType())
+            .isEqualTo(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> body =
+            (MultiValueMap<String, String>) entityCaptor.getAllValues().get(0).getBody();
+        assertThat(body.getFirst("grant_type")).isEqualTo("client_credentials");
+        assertThat(body.getFirst("client_id")).isEqualTo(CLIENT_ID);
+        assertThat(body.getFirst("client_secret")).isEqualTo(expectedSecret);
+        assertThat(body.getFirst("scope")).isEqualTo("profile roles");
+    }
+
+    @SuppressWarnings("unchecked")
+    private void assertCreateUserRequest(String expectedUri) {
+        ArgumentCaptor<URI> uriCaptor = ArgumentCaptor.forClass(URI.class);
+        ArgumentCaptor<HttpEntity> entityCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+
+        verify(restTemplate, times(2)).exchange(
+            uriCaptor.capture(),
+            eq(HttpMethod.POST),
+            entityCaptor.capture(),
+            anyMapResponse()
+        );
+
+        assertThat(uriCaptor.getAllValues().get(1)).hasToString(expectedUri);
+        assertThat(entityCaptor.getAllValues().get(1).getHeaders().getFirst(HttpHeaders.AUTHORIZATION))
+            .isEqualTo("Bearer " + TOKEN);
+        assertThat(entityCaptor.getAllValues().get(1).getHeaders().getContentType())
+            .isEqualTo(MediaType.APPLICATION_JSON);
+
+        Map<String, Object> body = (Map<String, Object>) entityCaptor.getAllValues().get(1).getBody();
+        assertThat(body.get("password")).isEqualTo("test-password");
+        assertThat(body.get("user")).isEqualTo(user());
+    }
+
+    private void whenIdamCreateFlowSucceeds() {
+        ResponseEntity<Map<String, Object>> tokenResponse = ResponseEntity.ok(Map.of("access_token", TOKEN));
+        ResponseEntity<Map<String, Object>> createResponse = ResponseEntity.status(HttpStatus.CREATED)
+            .body(Map.of("id", USER_ID, "email", USER_EMAIL));
+
+        when(restTemplate.exchange(any(URI.class), eq(HttpMethod.POST), any(HttpEntity.class), anyMapResponse()))
+            .thenReturn(tokenResponse, createResponse);
+    }
+
+    private IdamUserOrchestrationModels.CreateUserRequest createRequest(String environment) {
+        return new IdamUserOrchestrationModels.CreateUserRequest(environment, "test-password", List.of(user()));
+    }
+
+    private IdamUserOrchestrationModels.User user() {
+        return new IdamUserOrchestrationModels.User(
+            USER_EMAIL,
+            "Staff",
+            "Admin",
+            List.of("staff-admin", "caseworker")
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    private ParameterizedTypeReference<Map<String, Object>> anyMapResponse() {
+        return (ParameterizedTypeReference<Map<String, Object>>) any(ParameterizedTypeReference.class);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/spreadsheet/CCDConfigValidator.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/spreadsheet/CCDConfigValidator.java
@@ -10,6 +10,7 @@ import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.TemporaryField;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.State;
 
 import java.io.File;
@@ -192,10 +193,12 @@ public class CCDConfigValidator {
                 log.info("Looking for FinremCaseData Field Id: {} and Field Type: {}", field.getName(), field.getType());
                 boolean found = false;
                 for (CcdFieldAttributes ccdFieldAttributes : caseFields) {
-                    if (field.getAnnotation(JsonUnwrapped.class) != null || field.getAnnotation(JsonIgnore.class) != null) {
+                    if (field.getAnnotation(JsonUnwrapped.class) != null
+                        || field.getAnnotation(JsonIgnore.class) != null
+                        || field.getAnnotation(TemporaryField.class) != null) {
                         found = true;
-                        log.info("FinremCaseData Field Id: {} and Field Type: {} are annotated with JsonUnwrapped or JsonIgnore", field.getName(),
-                            field.getType());
+                        log.info("FinremCaseData Field Id: {} and Field Type: {} are annotated with JsonUnwrapped, JsonIgnore or TemporaryField",
+                            field.getName(), field.getType());
                         break;
                     }
                     if (ccdFieldAttributes.getFieldId().equals(field.getName())) {

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -125,6 +125,8 @@ idam.s2s-auth.url=http://localhost:4502
 idam.client.redirect_uri=${IDAM_API_REDIRECT_URL:https://finrem-frontend-aat.service.core-compute-aat.internal/oauth2/callback}
 idam.client.id=finrem
 idam.client.secret=${FINREM_IDAM_CLIENT_SECRET:DUMMY_SECRET}
+idam.test-support.default-env=${IDAM_TEST_SUPPORT_ENV:aat}
+idam.test-support.client-credentials-scope=${IDAM_TEST_SUPPORT_SCOPE:profile roles}
 # PRD / Organisation Details
 prd.organisations.url=${PRD_API_URL:http://localhost:8090}
 prd.organisations.organisationsUrl=${prd.organisations.url}/refdata/external/v1/organisations
@@ -335,4 +337,3 @@ uk.gov.notify.email.contestedContactEmails={bedfordshire:{name: 'Bedfordshire, C
   thamesvalley:{name: 'Thames Valley FRC', email: 'FRCThamesValley@justice.gov.uk'},\
   highcourt:{name: 'High Court Family Division FRC', email: 'rcj.familyhighcourt@justice.gov.uk'},\
   testCourt:{name: 'TEST SELECTED COURT', email: 'selected@justice.gov.uk'}}
-


### PR DESCRIPTION
###[ https://tools.hmcts.net/jira/browse/DFR-5168]

or WA we will want to have test users specifically in use for WA scenarios so that they can be manipulated without affecting existing BAU tests/processes.  

Check with the Onboarding team what the process is first before creation as any Idam users may have to match what will be put into Reference Data.

Check the Consented WA Config page: https://tools.hmcts.net/confluence/spaces/FR/pages/1958285910/Consented+FR+Work+Allocation+Configuration

And establish which users are required - both Judicial and Staff

Refer to users created in other projects like PRL and Probate and Idam guidance.

Probate WA Users: https://tools.hmcts.net/confluence/spaces/PRO/pages/1586828668/DTS+Probate+Master+Confluence+page#DTSProbateMasterConfluencepage-AAT

Idam Guidance: https://tools.hmcts.net/confluence/spaces/SISM/pages/1646233703/Creating+Test+Users+in+IDAM#CreatingTestUsersinIDAM-Howtocleardowntestusersaftertesting
**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [X] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [X] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
