### PR TITLE
DFR-5087: Handler changes to support V3 Asset List when amended a drafted case.

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/amendapplicationdetails/contested/AmendApplicationContestedAboutToStartHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/amendapplicationdetails/contested/AmendApplicationContestedAboutToStartHandler.java
@@ -8,12 +8,14 @@ import uk.gov.hmcts.reform.finrem.caseorchestration.handler.CallbackHandlerLogge
 import uk.gov.hmcts.reform.finrem.caseorchestration.handler.FinremCallbackHandler;
 import uk.gov.hmcts.reform.finrem.caseorchestration.handler.FinremCallbackRequest;
 import uk.gov.hmcts.reform.finrem.caseorchestration.mapper.FinremCaseDetailsMapper;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.EstimatedAssetsChecklistVersion;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.EventType;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CaseType;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.FinremCaseData;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.FinremCaseDetails;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.wrapper.MiamWrapper;
 import uk.gov.hmcts.reform.finrem.caseorchestration.service.AssignCaseAccessService;
+import uk.gov.hmcts.reform.finrem.caseorchestration.service.FeatureToggleService;
 import uk.gov.hmcts.reform.finrem.caseorchestration.service.OnStartDefaultValueService;
 import uk.gov.hmcts.reform.finrem.caseorchestration.service.miam.MiamLegacyExemptionsService;
 import uk.gov.hmcts.reform.finrem.caseorchestration.utils.refuge.RefugeWrapperUtils;
@@ -32,15 +34,18 @@ public class AmendApplicationContestedAboutToStartHandler extends FinremCallback
     private final MiamLegacyExemptionsService miamLegacyExemptionsService;
 
     private final AssignCaseAccessService assignCaseAccessService;
+    private final FeatureToggleService featureToggleService;
 
     public AmendApplicationContestedAboutToStartHandler(FinremCaseDetailsMapper finremCaseDetailsMapper,
                                                         OnStartDefaultValueService onStartDefaultValueService,
                                                         MiamLegacyExemptionsService miamLegacyExemptionsService,
-                                                        AssignCaseAccessService assignCaseAccessService) {
+                                                        AssignCaseAccessService assignCaseAccessService,
+                                                        FeatureToggleService featureToggleService) {
         super(finremCaseDetailsMapper);
         this.onStartDefaultValueService = onStartDefaultValueService;
         this.miamLegacyExemptionsService = miamLegacyExemptionsService;
         this.assignCaseAccessService = assignCaseAccessService;
+        this.featureToggleService = featureToggleService;
     }
 
     @Override
@@ -76,6 +81,8 @@ public class AmendApplicationContestedAboutToStartHandler extends FinremCallback
             userAuthorisation);
         caseData.setCurrentUserCaseRoleType(loggedInUserCaseRole);
 
+        setEstimatedAssetsChecklistVersion(caseData);
+
         return response(callbackRequest.getCaseDetails().getData(), warnings, null);
     }
 
@@ -87,5 +94,22 @@ public class AmendApplicationContestedAboutToStartHandler extends FinremCallback
         warnings.addAll(invalidLegacyExemptions);
 
         return warnings;
+    }
+
+    /**
+     * This method sets the version of the Estimated Assets Checklist to be used in the case data based on a feature toggle.
+     * Since these are drafted cases, we want to use the new version of the checklist once the feature toggle is enabled.
+     * So, if the feature toggle is enabled, any drafted case will use the V3 list; otherwise the new case will use the V2 list.
+     * Cleaning up the V2 list done in the about-to-submit handler.
+     *
+     * @param caseData The case data.
+     */
+    private void setEstimatedAssetsChecklistVersion(FinremCaseData caseData) {
+        boolean useV3EstimatedAssetsChecklist = featureToggleService.isEstimatedAssetsChecklistV3Enabled();
+        if (useV3EstimatedAssetsChecklist) {
+            caseData.getEstimatedAssetsChecklistWrapper().setEstimatedAssetsChecklistVersion(EstimatedAssetsChecklistVersion.V3);
+        } else {
+            caseData.getEstimatedAssetsChecklistWrapper().setEstimatedAssetsChecklistVersion(EstimatedAssetsChecklistVersion.V2);
+        }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/amendapplicationdetails/contested/AmendApplicationDetailsAboutToSubmitHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/amendapplicationdetails/contested/AmendApplicationDetailsAboutToSubmitHandler.java
@@ -120,19 +120,8 @@ public class AmendApplicationDetailsAboutToSubmitHandler extends FinremAboutToSu
     private void clearUnusedEstimatedAssetsChecklist(FinremCaseData caseData) {
         EstimatedAssetV3 latestAssetValue = caseData.getEstimatedAssetsChecklistV3();
         if (latestAssetValue != null) {
-            clearOutdatedEstimatedAssetsChecklists(caseData);
+            expressCaseService.clearUnusedEstimatedAssetsChecklist(caseData);
         }
-    }
-
-    /*
-     * This method is used to clear the outdated estimated assets checklist when a new version is introduced.
-     * Summer 2026: The Estimated Assets Checklist V3 is introduced.
-     * V2 checklist is removed from drafted case data.
-     *
-     * @param caseData The case data.
-     */
-    private void clearOutdatedEstimatedAssetsChecklists(FinremCaseData caseData) {
-        caseData.setEstimatedAssetsChecklistV2(null);
     }
 
     private void generateMiniFormA(FinremCaseDetails finremCaseDetails, String userAuthorisation) {

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/amendapplicationdetails/contested/AmendApplicationDetailsAboutToSubmitHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/amendapplicationdetails/contested/AmendApplicationDetailsAboutToSubmitHandler.java
@@ -12,7 +12,6 @@ import uk.gov.hmcts.reform.finrem.caseorchestration.helper.ContactDetailsValidat
 import uk.gov.hmcts.reform.finrem.caseorchestration.mapper.FinremCaseDetailsMapper;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.EventType;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CaseType;
-import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.EstimatedAssetV3;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.FinremCaseData;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.FinremCaseDetails;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.NatureApplication;
@@ -90,7 +89,7 @@ public class AmendApplicationDetailsAboutToSubmitHandler extends FinremAboutToSu
         clearUnusedMiamDetailsFields(caseData);
         clearUnusedUploadAdditionalDocuments(caseData);
 
-        clearUnusedEstimatedAssetsChecklist(caseData);
+        expressCaseService.clearUnusedEstimatedAssetsChecklist(caseData);
 
         generateMiniFormA(caseDetails, userAuthorisation);
 
@@ -107,21 +106,6 @@ public class AmendApplicationDetailsAboutToSubmitHandler extends FinremAboutToSu
         }
 
         return response(caseData, null, ContactDetailsValidator.validateOrganisationPolicy(caseData));
-    }
-
-    /*
-     * This method checks to see if the case is using the most up-to-date asset check list.
-     * If it is, then it calls clearOutdatedEstimatedAssetsChecklists, to remove older checklists.
-     *
-     * At the time of writing, the most up-to-date checklist is V3.
-     *
-     * @param caseData The case data.
-     */
-    private void clearUnusedEstimatedAssetsChecklist(FinremCaseData caseData) {
-        EstimatedAssetV3 latestAssetValue = caseData.getEstimatedAssetsChecklistV3();
-        if (latestAssetValue != null) {
-            expressCaseService.clearUnusedEstimatedAssetsChecklist(caseData);
-        }
     }
 
     private void generateMiniFormA(FinremCaseDetails finremCaseDetails, String userAuthorisation) {

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/amendapplicationdetails/contested/AmendApplicationDetailsAboutToSubmitHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/amendapplicationdetails/contested/AmendApplicationDetailsAboutToSubmitHandler.java
@@ -118,10 +118,8 @@ public class AmendApplicationDetailsAboutToSubmitHandler extends FinremAboutToSu
      * @param caseData The case data.
      */
     private void clearUnusedEstimatedAssetsChecklist(FinremCaseData caseData) {
-
-        EstimatedAssetV3 v3assetValue = caseData.getEstimatedAssetsChecklistV3();
-
-        if (v3assetValue != null) {
+        EstimatedAssetV3 latestAssetValue = caseData.getEstimatedAssetsChecklistV3();
+        if (latestAssetValue != null) {
             clearOutdatedEstimatedAssetsChecklists(caseData);
         }
     }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/amendapplicationdetails/contested/AmendApplicationDetailsAboutToSubmitHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/amendapplicationdetails/contested/AmendApplicationDetailsAboutToSubmitHandler.java
@@ -5,13 +5,14 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.finrem.caseorchestration.ccd.callback.CallbackType;
 import uk.gov.hmcts.reform.finrem.caseorchestration.controllers.GenericAboutToStartOrSubmitCallbackResponse;
 import uk.gov.hmcts.reform.finrem.caseorchestration.handler.CallbackHandlerLogger;
-import uk.gov.hmcts.reform.finrem.caseorchestration.handler.FinremCallbackHandler;
+import uk.gov.hmcts.reform.finrem.caseorchestration.handler.FinremAboutToSubmitCallbackHandler;
 import uk.gov.hmcts.reform.finrem.caseorchestration.handler.FinremCallbackRequest;
 import uk.gov.hmcts.reform.finrem.caseorchestration.handler.solicitorcreatecase.mandatorydatavalidation.CreateCaseMandatoryDataValidator;
 import uk.gov.hmcts.reform.finrem.caseorchestration.helper.ContactDetailsValidator;
 import uk.gov.hmcts.reform.finrem.caseorchestration.mapper.FinremCaseDetailsMapper;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.EventType;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CaseType;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.EstimatedAssetV3;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.FinremCaseData;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.FinremCaseDetails;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.NatureApplication;
@@ -38,7 +39,7 @@ import static uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.Schedule1Or
 
 @Slf4j
 @Service
-public class AmendApplicationDetailsAboutToSubmitHandler extends FinremCallbackHandler {
+public class AmendApplicationDetailsAboutToSubmitHandler extends FinremAboutToSubmitCallbackHandler {
 
     private final OnlineFormDocumentService onlineFormDocumentService;
     private final CaseFlagsService caseFlagsService;
@@ -89,6 +90,8 @@ public class AmendApplicationDetailsAboutToSubmitHandler extends FinremCallbackH
         clearUnusedMiamDetailsFields(caseData);
         clearUnusedUploadAdditionalDocuments(caseData);
 
+        clearUnusedEstimatedAssetsChecklist(caseData);
+
         generateMiniFormA(caseDetails, userAuthorisation);
 
         RefugeWrapperUtils.updateApplicantInRefugeTab(caseDetails);
@@ -104,6 +107,34 @@ public class AmendApplicationDetailsAboutToSubmitHandler extends FinremCallbackH
         }
 
         return response(caseData, null, ContactDetailsValidator.validateOrganisationPolicy(caseData));
+    }
+
+    /*
+     * This method checks to see if the case is using the most up-to-date asset check list.
+     * If it is, then it calls clearOutdatedEstimatedAssetsChecklists, to remove older checklists.
+     *
+     * At the time of writing, the most up-to-date checklist is V3.
+     *
+     * @param caseData The case data.
+     */
+    private void clearUnusedEstimatedAssetsChecklist(FinremCaseData caseData) {
+
+        EstimatedAssetV3 v3assetValue = caseData.getEstimatedAssetsChecklistV3();
+
+        if (v3assetValue != null) {
+            clearOutdatedEstimatedAssetsChecklists(caseData);
+        }
+    }
+
+    /*
+     * This method is used to clear the outdated estimated assets checklist when a new version is introduced.
+     * Summer 2026: The Estimated Assets Checklist V3 is introduced.
+     * V2 checklist is removed from drafted case data.
+     *
+     * @param caseData The case data.
+     */
+    private void clearOutdatedEstimatedAssetsChecklists(FinremCaseData caseData) {
+        caseData.setEstimatedAssetsChecklistV2(null);
     }
 
     private void generateMiniFormA(FinremCaseDetails finremCaseDetails, String userAuthorisation) {

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/express/ExpressCaseService.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/express/ExpressCaseService.java
@@ -145,19 +145,23 @@ public class ExpressCaseService {
     }
 
     /**
-     * Returns true if either Estimated Asset Value field is under £250k.
+     * Returns true if the latest populated Estimated Asset Value field is under £250k.
      *
-     * <p>Handlers ensure that only one of the two Estimated Asset Value fields is set,
-     * so both fields can be checked safely. This method is null-safe and returns false
-     * if both values are null.</p>
+     * <p>V3 is newer than V2, so when a V3 value is present it takes precedence.
+     * The isEstimatedAssetsChecklistV3Enabled feature toggle is not considered, this is so existing V3 cases can
+     * still be processed after submission if Service decide to toggle off V3 case creation.
+     * This method is null-safe and returns false if both values are null.</p>
      *
      * @param v2assetValue the value from the older EstimatedAssetV2 enum
      * @param v3assetValue the value from the newer EstimatedAssetV3 enum
-     * @return true if the asset value qualifies for express case participation, false otherwise
+     * @return true if the latest populated asset value qualifies for express case participation, false otherwise
      */
     private boolean isExpressPilotAssetValue(EstimatedAssetV2 v2assetValue, EstimatedAssetV3 v3assetValue) {
-        return EstimatedAssetV2.UNDER_TWO_HUNDRED_AND_FIFTY_THOUSAND_POUNDS.equals(v2assetValue)
-            || EstimatedAssetV3.UNDER_TWO_HUNDRED_AND_FIFTY_THOUSAND_POUNDS.equals(v3assetValue);
+        if (v3assetValue != null) {
+            return EstimatedAssetV3.UNDER_TWO_HUNDRED_AND_FIFTY_THOUSAND_POUNDS.equals(v3assetValue);
+        }
+
+        return EstimatedAssetV2.UNDER_TWO_HUNDRED_AND_FIFTY_THOUSAND_POUNDS.equals(v2assetValue);
     }
 
     /* Checks that a region has been selected before calling getSelectedAllocatedCourt, as an indication

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/amendapplicationdetails/contested/AmendApplicationContestedAboutToStartHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/amendapplicationdetails/contested/AmendApplicationContestedAboutToStartHandlerTest.java
@@ -2,6 +2,8 @@ package uk.gov.hmcts.reform.finrem.caseorchestration.handler.amendapplicationdet
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
@@ -9,12 +11,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.finrem.caseorchestration.FinremCallbackRequestFactory;
 import uk.gov.hmcts.reform.finrem.caseorchestration.ccd.callback.CallbackType;
 import uk.gov.hmcts.reform.finrem.caseorchestration.handler.FinremCallbackRequest;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.EstimatedAssetsChecklistVersion;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.EventType;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CaseType;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.FinremCaseData;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.FinremCaseDetails;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.wrapper.MiamWrapper;
 import uk.gov.hmcts.reform.finrem.caseorchestration.service.AssignCaseAccessService;
+import uk.gov.hmcts.reform.finrem.caseorchestration.service.FeatureToggleService;
 import uk.gov.hmcts.reform.finrem.caseorchestration.service.OnStartDefaultValueService;
 import uk.gov.hmcts.reform.finrem.caseorchestration.service.miam.MiamLegacyExemptionsService;
 import uk.gov.hmcts.reform.finrem.caseorchestration.utils.refuge.RefugeWrapperUtils;
@@ -50,6 +54,9 @@ class AmendApplicationContestedAboutToStartHandlerTest {
 
     @Mock
     private MiamLegacyExemptionsService miamLegacyExemptionsService;
+
+    @Mock
+    private FeatureToggleService featureToggleService;
 
     @Test
     void testHandlerCanHandle() {
@@ -131,5 +138,20 @@ class AmendApplicationContestedAboutToStartHandlerTest {
             () -> verify(assignCaseAccessService).getActiveUser(CASE_ID, AUTH_TOKEN),
             () -> verifyNoMoreInteractions(assignCaseAccessService)
         );
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void givenCaseWithValidLegacyMiamExemptions_whenHandledasqwwqs_thenPrepopulateFieldsAndNoWarnings(Boolean isV3) {
+        FinremCaseData caseData = FinremCaseData.builder().build();
+        FinremCallbackRequest callbackRequest = FinremCallbackRequestFactory.from(caseData);
+
+        when(featureToggleService.isEstimatedAssetsChecklistV3Enabled()).thenReturn(isV3);
+        EstimatedAssetsChecklistVersion expectedVersion = isV3
+            ? EstimatedAssetsChecklistVersion.V3 : EstimatedAssetsChecklistVersion.V2;
+
+        handler.handle(callbackRequest, AUTH_TOKEN);
+
+        assertEquals(caseData.getEstimatedAssetsChecklistWrapper().getEstimatedAssetsChecklistVersion(), expectedVersion);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/amendapplicationdetails/contested/AmendApplicationContestedAboutToStartHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/amendapplicationdetails/contested/AmendApplicationContestedAboutToStartHandlerTest.java
@@ -142,7 +142,7 @@ class AmendApplicationContestedAboutToStartHandlerTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    void givenCaseWithAnyAssetListVersion_whenHandled_thenCaseDataPopulatedWithßCorrectVersion(Boolean isV3) {
+    void givenCaseWithAnyAssetListVersion_whenHandled_thenCaseDataPopulatedWithCorrectVersion(Boolean isV3) {
         FinremCaseData caseData = FinremCaseData.builder().build();
         FinremCallbackRequest callbackRequest = FinremCallbackRequestFactory.from(caseData);
 

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/amendapplicationdetails/contested/AmendApplicationContestedAboutToStartHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/amendapplicationdetails/contested/AmendApplicationContestedAboutToStartHandlerTest.java
@@ -142,7 +142,7 @@ class AmendApplicationContestedAboutToStartHandlerTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    void givenCaseWithValidLegacyMiamExemptions_whenHandledasqwwqs_thenPrepopulateFieldsAndNoWarnings(Boolean isV3) {
+    void givenCaseWithAnyAssetListVersion_whenHandled_thenCaseDataPopulatedWithßCorrectVersion(Boolean isV3) {
         FinremCaseData caseData = FinremCaseData.builder().build();
         FinremCallbackRequest callbackRequest = FinremCallbackRequestFactory.from(caseData);
 

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/amendapplicationdetails/contested/AmendApplicationDetailsAboutToSubmitHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/amendapplicationdetails/contested/AmendApplicationDetailsAboutToSubmitHandlerTest.java
@@ -55,6 +55,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -973,6 +974,7 @@ class AmendApplicationDetailsAboutToSubmitHandlerTest {
 
         GenericAboutToStartOrSubmitCallbackResponse<FinremCaseData> response = handler.handle(callbackRequest, AUTH_TOKEN);
 
+        verify(expressCaseService, never()).clearUnusedEstimatedAssetsChecklist(finremCaseData);
         assertThat(response.getData())
             .extracting(FinremCaseData::getEstimatedAssetsChecklistV2)
             .isEqualTo(EstimatedAssetV2.OVER_FIFTEEN_MILLION_POUNDS);

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/amendapplicationdetails/contested/AmendApplicationDetailsAboutToSubmitHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/amendapplicationdetails/contested/AmendApplicationDetailsAboutToSubmitHandlerTest.java
@@ -55,7 +55,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -963,6 +962,11 @@ class AmendApplicationDetailsAboutToSubmitHandlerTest {
         assertThat(response.getData()).extracting(FinremCaseData::getEstimatedAssetsChecklistV2).isNull();
     }
 
+    /*
+     * The Express Case must be Mocked for other tests (Spy not appropriate)
+     * Use the genuine ExpressCaseService.clearUnusedEstimatedAssetsChecklist method, for data amendment
+     * then verify that the mocked version of clearUnusedEstimatedAssetsChecklist is called.
+     */
     @Test
     void whenHandled_ifV2Asset_thenNothingCleared() {
         FinremCaseData finremCaseData = FinremCaseData.builder()
@@ -971,10 +975,12 @@ class AmendApplicationDetailsAboutToSubmitHandlerTest {
             .build();
 
         FinremCallbackRequest callbackRequest = FinremCallbackRequestFactory.from(finremCaseData);
+        ExpressCaseService realExpressCaseService = new ExpressCaseService(featureToggleService);
+        realExpressCaseService.clearUnusedEstimatedAssetsChecklist(finremCaseData);
 
         GenericAboutToStartOrSubmitCallbackResponse<FinremCaseData> response = handler.handle(callbackRequest, AUTH_TOKEN);
 
-        verify(expressCaseService, never()).clearUnusedEstimatedAssetsChecklist(finremCaseData);
+        verify(expressCaseService).clearUnusedEstimatedAssetsChecklist(finremCaseData);
         assertThat(response.getData())
             .extracting(FinremCaseData::getEstimatedAssetsChecklistV2)
             .isEqualTo(EstimatedAssetV2.OVER_FIFTEEN_MILLION_POUNDS);

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/amendapplicationdetails/contested/AmendApplicationDetailsAboutToSubmitHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/amendapplicationdetails/contested/AmendApplicationDetailsAboutToSubmitHandlerTest.java
@@ -13,6 +13,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.finrem.caseorchestration.FinremCallbackRequestFactory;
 import uk.gov.hmcts.reform.finrem.caseorchestration.controllers.GenericAboutToStartOrSubmitCallbackResponse;
 import uk.gov.hmcts.reform.finrem.caseorchestration.handler.FinremCallbackRequest;
 import uk.gov.hmcts.reform.finrem.caseorchestration.handler.solicitorcreatecase.mandatorydatavalidation.CreateCaseMandatoryDataValidator;
@@ -21,6 +22,8 @@ import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.Address;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.BenefitPayment;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.BenefitPaymentChecklist;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.CaseDocument;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.EstimatedAssetV2;
+import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.EstimatedAssetV3;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.FastTrackReason;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.FinremCaseData;
 import uk.gov.hmcts.reform.finrem.caseorchestration.model.ccd.FinremCaseDetails;
@@ -935,6 +938,35 @@ class AmendApplicationDetailsAboutToSubmitHandlerTest {
         assertThat(response.getErrors()).hasSize(1);
         assertThat(response.getErrors().getFirst()).isEqualTo("Validation failed");
         assertThat(response.getData()).isNotNull();
+    }
+
+    @Test
+    void whenHandled_ifV3Asset_thenAnyV2AssetCleared() {
+        FinremCaseData finremCaseData = FinremCaseData.builder()
+            .estimatedAssetsChecklistV2(EstimatedAssetV2.OVER_FIFTEEN_MILLION_POUNDS)
+            .estimatedAssetsChecklistV3(EstimatedAssetV3.OVER_TWENTY_MILLION_POUNDS)
+            .build();
+        FinremCallbackRequest callbackRequest = FinremCallbackRequestFactory.from(finremCaseData);
+
+        GenericAboutToStartOrSubmitCallbackResponse<FinremCaseData> response = handler.handle(callbackRequest, AUTH_TOKEN);
+
+        assertThat(response.getData()).extracting(FinremCaseData::getEstimatedAssetsChecklistV2).isNull();
+    }
+
+    @Test
+    void whenHandled_ifV2Asset_thenNothingCleared() {
+        FinremCaseData finremCaseData = FinremCaseData.builder()
+            .estimatedAssetsChecklistV2(EstimatedAssetV2.OVER_FIFTEEN_MILLION_POUNDS)
+            .estimatedAssetsChecklistV3(null)
+            .build();
+
+        FinremCallbackRequest callbackRequest = FinremCallbackRequestFactory.from(finremCaseData);
+
+        GenericAboutToStartOrSubmitCallbackResponse<FinremCaseData> response = handler.handle(callbackRequest, AUTH_TOKEN);
+
+        assertThat(response.getData())
+            .extracting(FinremCaseData::getEstimatedAssetsChecklistV2)
+            .isEqualTo(EstimatedAssetV2.OVER_FIFTEEN_MILLION_POUNDS);
     }
 
     private <T> void assertContainsOnlyNulls(T target, List<?> functions) {

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/amendapplicationdetails/contested/AmendApplicationDetailsAboutToSubmitHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/handler/amendapplicationdetails/contested/AmendApplicationDetailsAboutToSubmitHandlerTest.java
@@ -940,6 +940,11 @@ class AmendApplicationDetailsAboutToSubmitHandlerTest {
         assertThat(response.getData()).isNotNull();
     }
 
+    /*
+     * The Express Case must be Mocked for other tests (Spy not appropriate)
+     * Use the genuine ExpressCaseService.clearUnusedEstimatedAssetsChecklist method, for data amendment
+     * then verify that the mocked version of clearUnusedEstimatedAssetsChecklist is called.
+     */
     @Test
     void whenHandled_ifV3Asset_thenAnyV2AssetCleared() {
         FinremCaseData finremCaseData = FinremCaseData.builder()
@@ -948,8 +953,12 @@ class AmendApplicationDetailsAboutToSubmitHandlerTest {
             .build();
         FinremCallbackRequest callbackRequest = FinremCallbackRequestFactory.from(finremCaseData);
 
+        ExpressCaseService realExpressCaseService = new ExpressCaseService(featureToggleService);
+        realExpressCaseService.clearUnusedEstimatedAssetsChecklist(finremCaseData);
+
         GenericAboutToStartOrSubmitCallbackResponse<FinremCaseData> response = handler.handle(callbackRequest, AUTH_TOKEN);
 
+        verify(expressCaseService).clearUnusedEstimatedAssetsChecklist(finremCaseData);
         assertThat(response.getData()).extracting(FinremCaseData::getEstimatedAssetsChecklistV2).isNull();
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/express/ExpressCaseServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/express/ExpressCaseServiceTest.java
@@ -196,6 +196,26 @@ class ExpressCaseServiceTest {
         assertEquals(DOES_NOT_QUALIFY, caseData.getExpressCaseWrapper().getExpressCaseParticipation());
     }
 
+    /*
+     * Do not maintain this test after V3 Asset values are known to work.
+     * This is covers an edge-case.  This is a scenario where both EstimatedAssetV2 and EstimatedAssetV3 are set.
+     * This can happen if the case was drafted with a V2 asset value, and amended the case with a V3 asset value.
+     * When available V3 asset values are given preference. This will best support post-submission events, related to Express.
+     */
+    @Test
+    void whenExpressCaseEnrollmentStatus_ifTwoAssetVersions_thenLatestAssetUsed() {
+
+        FinremCaseData caseData = createCaseData();
+
+        // The V3 asset should be the one chosen, so the case should qualify for Express; so show as ENROLLED
+        caseData.setEstimatedAssetsChecklistV2(EstimatedAssetV2.OVER_FIFTEEN_MILLION_POUNDS);
+        caseData.setEstimatedAssetsChecklistV3(EstimatedAssetV3.UNDER_TWO_HUNDRED_AND_FIFTY_THOUSAND_POUNDS);
+
+        when(featureToggleService.isExpressPilotEnabled()).thenReturn(true);
+        expressCaseService.setExpressCaseEnrollmentStatus(caseData);
+        assertEquals(ENROLLED, caseData.getExpressCaseWrapper().getExpressCaseParticipation());
+    }
+
     private static Stream<Arguments> provideIsExpressCase() {
         return Stream.of(
             Arguments.of(false, createCaseDetailsWithParticipation(ENROLLED), false),


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DFR-5087

### Change description

Targets Form A Amend Application Details event.

* About to start handler sets the CCD field to determine asset list version
* About to submit handler clears temporary field by inheriting FinremAboutToSubmitCallbackHandler.
* About to submit handler clears V2 asset values if they were used when drafting.
* Private method isExpressPilotAssetValue needed a tweak to ignore V3 Assets if null.
* Tests updated.

### Testing done

* Manual Testing
* Unit Testing
* Playwright testing

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [X] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
