### PR TITLE
Revert "DFR-5052-Move-Final-Question"

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/DirectionOrder.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/DirectionOrder.java
@@ -31,8 +31,6 @@ public class DirectionOrder implements HasCaseDocument, WithAttachments, HasUplo
     CaseDocument originalDocument;
     @JsonProperty("additionalDocuments")
     private List<DocumentCollectionItem> additionalDocuments;
-    @JsonProperty("isFinalOrder")
-    YesOrNo isFinalOrder;
 
     @Override
     @JsonIgnore

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/DraftDirectionDetailsHolder.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/DraftDirectionDetailsHolder.java
@@ -14,7 +14,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class DraftDirectionDetailsHolder {
-    @Deprecated
     private YesOrNo isThisFinalYN;
     private YesOrNo isAnotherHearingYN;
     private HearingTypeDirection typeOfHearing;

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/DraftDirectionOrder.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/DraftDirectionOrder.java
@@ -28,9 +28,6 @@ public class DraftDirectionOrder implements HasCaseDocument, HasUploadingDocumen
     @JsonProperty("additionalDocuments")
     private List<DocumentCollectionItem> additionalDocuments;
 
-    @JsonProperty("isFinalOrder")
-    YesOrNo isFinalOrder;
-
     @Override
     @JsonIgnore
     public List<CaseDocument> getUploadingDocuments() {

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/UploadedApprovedOrder.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/model/ccd/UploadedApprovedOrder.java
@@ -7,6 +7,4 @@ public interface UploadedApprovedOrder {
     CaseDocument getApprovedOrder();
 
     List<DocumentCollectionItem> getAdditionalDocuments();
-
-    YesOrNo getIsFinalOrder();
 }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/HearingOrderService.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/HearingOrderService.java
@@ -142,11 +142,6 @@ public class HearingOrderService {
 
     private void appendDocumentToUploadHearingOrder(FinremCaseData finremCaseData, CaseDocument order,
                                                     List<DocumentCollectionItem> additionalDocs, YesOrNo isOrderStamped) {
-        appendDocumentToUploadHearingOrder(finremCaseData, order, additionalDocs, isOrderStamped, null);
-    }
-
-    private void appendDocumentToUploadHearingOrder(FinremCaseData finremCaseData, CaseDocument order,
-                                                    List<DocumentCollectionItem> additionalDocs, YesOrNo isOrderStamped, YesOrNo isFinalOrder) {
         List<DirectionOrderCollection> directionOrders = ofNullable(finremCaseData.getUploadHearingOrder()).orElse(new ArrayList<>());
         directionOrders.add(
             DirectionOrderCollection.builder()
@@ -154,7 +149,6 @@ public class HearingOrderService {
                     .uploadDraftDocument(order)
                     .additionalDocuments(additionalDocs)
                     .isOrderStamped(isOrderStamped)
-                    .isFinalOrder(isFinalOrder)
                     .build())
                 .build()
         );
@@ -246,7 +240,7 @@ public class HearingOrderService {
         } else {
             isOrderStamped = YesOrNo.NO;
             // make the uploaded approved orders available for judge uploaded orders in Process Order event
-            appendDocumentToUploadHearingOrder(caseData, order.getApprovedOrder(), additionalDocs, isOrderStamped, order.getIsFinalOrder());
+            appendDocumentToUploadHearingOrder(caseData, order.getApprovedOrder(), additionalDocs, isOrderStamped);
         }
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/HearingOrderServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/caseorchestration/service/HearingOrderServiceTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InOrder;
 import org.mockito.Mock;
@@ -436,24 +435,6 @@ class HearingOrderServiceTest {
             }
         }
 
-        @ParameterizedTest
-        @EnumSource(value = YesOrNo.class, names = {"NO", "YES"})
-        void givenJudgeApprovedOrderWithIsFinalYN_whenStampAndStore_thenUploadHearingOrderContainsIsFinalYN(YesOrNo isFinalYN) {
-            FinremCaseData finremCaseData = setupFinremCaseData(
-                DraftDirectionWrapper.builder()
-                    .judgeApprovedOrderCollection(List.of(createJudgeApprovedOrder(uao1Docx, null, isFinalYN)))
-                    .build()
-            );
-
-            when(orderDateService.syncCreatedDateAndMarkDocumentStamped(originalFinalOrderCollection, AUTH_TOKEN))
-                .thenReturn(new ArrayList<>());
-
-            doTest(finremCaseData, JUDGE_UAO_EVENT);
-
-            assertUploadHearingOrder(finremCaseData,
-                createUploadHearingEntry(uao1Docx, null, YesOrNo.NO, isFinalYN));
-        }
-
         private void stubDocsConversionToPdf(List<Pair<CaseDocument, CaseDocument>> pairs) {
             for (Pair<CaseDocument, CaseDocument> pair : pairs) {
                 lenient().when(genericDocumentService.convertDocumentIfNotPdfAlready(pair.getLeft(), AUTH_TOKEN, CONTESTED))
@@ -510,20 +491,6 @@ class HearingOrderServiceTest {
                 .build();
         }
 
-        private DirectionOrderCollection createUploadHearingEntry(CaseDocument uploadDraftDocument,
-                                                                  List<DocumentCollectionItem> additionalDocs,
-                                                                  YesOrNo isOrderStamped,
-                                                                  YesOrNo isFinalOrder) {
-            return DirectionOrderCollection.builder()
-                .value(DirectionOrder.builder()
-                    .uploadDraftDocument(uploadDraftDocument)
-                    .additionalDocuments(additionalDocs)
-                    .isOrderStamped(isOrderStamped)
-                    .isFinalOrder(isFinalOrder)
-                    .build())
-                .build();
-        }
-
         private DirectionOrderCollection createStampedDirectionOrderCollection(CaseDocument uploadDraftDocument,
                                                                                LocalDateTime orderDateTime) {
             return createStampedDirectionOrderCollection(uploadDraftDocument, orderDateTime, null);
@@ -566,18 +533,6 @@ class HearingOrderServiceTest {
                 .value(DraftDirectionOrder.builder()
                     .uploadDraftDocument(uploadDraftDocument)
                     .additionalDocuments(additionalDocs)
-                    .build())
-                .build();
-        }
-
-        private static DraftDirectionOrderCollection createJudgeApprovedOrder(CaseDocument uploadDraftDocument,
-                                                                              List<DocumentCollectionItem> additionalDocs,
-                                                                              YesOrNo isFinalOrder) {
-            return DraftDirectionOrderCollection.builder()
-                .value(DraftDirectionOrder.builder()
-                    .uploadDraftDocument(uploadDraftDocument)
-                    .additionalDocuments(additionalDocs)
-                    .isFinalOrder(isFinalOrder)
                     .build())
                 .build();
         }


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DFR-5052

Reverts hmcts/finrem-case-orchestration-service#2969

This was deployed without the required definitions.  Users are blocked from events with an about-to-start handler.

Definitions PR pipeline not working in good time.  Best option for Users is to rollback.

