### PR TITLE
CVE-2026-66299 CVE suppressed.  Tomcat version bumped to closer to fixed version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ project.ext {
     springCloudBomVersion = "2025.0.0"
     restAssuredBomVersion = "5.5.7"
     // Tomcat bump to address CVEs.  Remove when upgrading SpringBoot to version 4.
-    set('tomcat.version', '10.1.56')
+    set('tomcat.version', '10.1.57')
 }
 
 group = 'uk.gov.hmcts.reform.finrem'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -117,7 +117,7 @@ for kotlin-stdlib, kotlin-stdlib-jdk7, kotlin-stdlib-jdk8).
           Apache states that deployments without the examples application
           are not affected. Remove after upgrading to Tomcat 10.1.58 or later.
       ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat-embed-websocket@.*$</packageUrl>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat-embed-.*@10\.1\.57$</packageUrl>
         <cve>CVE-2026-66299</cve>
     </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -119,4 +119,17 @@ for kotlin-stdlib, kotlin-stdlib-jdk7, kotlin-stdlib-jdk8).
         <cve>CVE-2026-59083</cve>
         <cve>CVE-2026-59084</cve>
     </suppress>
+    <suppress until="2026-09-01Z">
+        <notes><![CDATA[
+          CVE-2026-66299 applies to the Tomcat WebSocket chat example.
+          This Spring Boot application uses embedded Tomcat and does not
+          package or deploy the Tomcat examples web application.
+          Apache states that deployments without the examples application
+          are not affected. Remove after upgrading to Tomcat 10.1.58 or later.
+      ]]></notes>
+        <packageUrl regex="true">
+            ^pkg:maven/org\.apache\.tomcat\.embed/tomcat-embed-websocket@.*$
+        </packageUrl>
+        <cve>CVE-2026-66299</cve>
+    </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -109,16 +109,6 @@ for kotlin-stdlib, kotlin-stdlib-jdk7, kotlin-stdlib-jdk8).
         <packageUrl regex="true">^pkg:maven/org\.apache\.logging\.log4j/log4j-.*@.*$</packageUrl>
         <cve>CVE-2026-49844</cve>
     </suppress>
-
-    <suppress until="2026-12-31Z">
-        <notes><![CDATA[
-    Suppress Tomcat 10.1.56 false positives / accepted risk pending fix.
-    Version managed by Spring Boot 3 BOM.
-    ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat-embed-.*@.*$</packageUrl>
-        <cve>CVE-2026-59083</cve>
-        <cve>CVE-2026-59084</cve>
-    </suppress>
     <suppress until="2026-09-01Z">
         <notes><![CDATA[
           CVE-2026-66299 applies to the Tomcat WebSocket chat example.
@@ -127,9 +117,7 @@ for kotlin-stdlib, kotlin-stdlib-jdk7, kotlin-stdlib-jdk8).
           Apache states that deployments without the examples application
           are not affected. Remove after upgrading to Tomcat 10.1.58 or later.
       ]]></notes>
-        <packageUrl regex="true">
-            ^pkg:maven/org\.apache\.tomcat\.embed/tomcat-embed-websocket@.*$
-        </packageUrl>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat-embed-websocket@.*$</packageUrl>
         <cve>CVE-2026-66299</cve>
     </suppress>
 </suppressions>


### PR DESCRIPTION
### Jira link

N/A

### Change description

- suppressed CVE-2026-66299 until 1/09/2026. Check then for fix.
- bumped tomcat version to be closer to fixed version.

### Testing done

- unit
- smoke

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
